### PR TITLE
Ensure STDCALL/STDCALLPTR is only invoked on x86

### DIFF
--- a/lib/module.h
+++ b/lib/module.h
@@ -76,17 +76,24 @@
 #define CPPEXTERN extern
 #endif
 
+#ifdef _MSC_VER // MSVC Build
+# define STDCALL __stdcall
+# define STDCALLPTR *STDCALL
+#else // Non-MS compilers
+# if defined(__i386__) || defined(_X86_) || defined(__THW_INTEL__)
+#  define STDCALL __attribute__((stdcall))
+# else
+#  define STDCALL
+# endif
+# define STDCALLPTR STDCALL *
+#endif
+
+# define DLLFUNCCALL STDCALL
+# define DLLFUNCCALLPTR STDCALLPTR
+
 #ifdef WIN32
 //=========================Windows Definition============================
 #include "windows.h"
-
-#ifdef _MSC_VER // Visual C++ Build
-#define DLLFUNCCALL __stdcall
-#define DLLFUNCCALLPTR *DLLFUNCCALL
-#else // Non-Visual C++ Build
-#define DLLFUNCCALL __attribute__((stdcall))
-#define DLLFUNCCALLPTR DLLFUNCCALL *
-#endif
 
 #define MODPROCADDRESS FARPROC
 #define DLLFUNCEXPORT __declspec(dllexport)
@@ -101,8 +108,6 @@ typedef struct {
 #include <dlfcn.h>
 
 #define MODPROCADDRESS void *
-#define DLLFUNCCALL __attribute__((stdcall))
-#define DLLFUNCCALLPTR DLLFUNCCALL *
 #define DLLFUNCEXPORT
 #define DLLFUNCIMPORT
 #define DLLEXPORT CPPEXTERN
@@ -114,8 +119,6 @@ typedef struct {
 #elif defined(MACINTOSH)
 //==========================Mac Definitions============================
 #define MODPROCADDRESS void *
-#define DLLFUNCCALL
-#define DLLFUNCCALLPTR DLLFUNCCALL *
 #define DLLFUNCEXPORT
 #define DLLFUNCIMPORT
 #define DLLEXPORT

--- a/scripts/AIGame.cpp
+++ b/scripts/AIGame.cpp
@@ -26,13 +26,7 @@
 #include "osiris_vector.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/AIGame3.cpp
+++ b/scripts/AIGame3.cpp
@@ -28,13 +28,7 @@
 
 #include "AIGame3_External.h"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/BatteriesIncluded.cpp
+++ b/scripts/BatteriesIncluded.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/BossCamera.cpp
+++ b/scripts/BossCamera.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/CanyonsCTF.cpp
+++ b/scripts/CanyonsCTF.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/CellTestLevel.cpp
+++ b/scripts/CellTestLevel.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/ChrisTest.cpp
+++ b/scripts/ChrisTest.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/GameGauge.cpp
+++ b/scripts/GameGauge.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Geodomes.cpp
+++ b/scripts/Geodomes.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/HalfPipe.cpp
+++ b/scripts/HalfPipe.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/InfernalBolt.cpp
+++ b/scripts/InfernalBolt.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Inversion.cpp
+++ b/scripts/Inversion.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/LEVEL0.cpp
+++ b/scripts/LEVEL0.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/LEVEL15.cpp
+++ b/scripts/LEVEL15.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Level12.cpp
+++ b/scripts/Level12.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Level16.cpp
+++ b/scripts/Level16.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Level6.cpp
+++ b/scripts/Level6.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Level9.cpp
+++ b/scripts/Level9.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/LevelS1.cpp
+++ b/scripts/LevelS1.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Merc02.cpp
+++ b/scripts/Merc02.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Merc1.cpp
+++ b/scripts/Merc1.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Merc3.cpp
+++ b/scripts/Merc3.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Merc4.cpp
+++ b/scripts/Merc4.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Merc6.cpp
+++ b/scripts/Merc6.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Merc7.cpp
+++ b/scripts/Merc7.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Mysterious_Isle.cpp
+++ b/scripts/Mysterious_Isle.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/PINBALL.CPP
+++ b/scripts/PINBALL.CPP
@@ -12,13 +12,7 @@
 #include "osiris_common.h"
 #include "dallasfuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include <utils/lib_helper.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Paranoia.cpp
+++ b/scripts/Paranoia.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/PiccuStation.cpp
+++ b/scripts/PiccuStation.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Polaris.cpp
+++ b/scripts/Polaris.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Quadsomniac.cpp
+++ b/scripts/Quadsomniac.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/RudeAwakening.cpp
+++ b/scripts/RudeAwakening.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/SewerRat.cpp
+++ b/scripts/SewerRat.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/TrainingMission.cpp
+++ b/scripts/TrainingMission.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/Y2K.cpp
+++ b/scripts/Y2K.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/aigame2.cpp
+++ b/scripts/aigame2.cpp
@@ -26,13 +26,7 @@
 #include "osiris_vector.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/aigame4.cpp
+++ b/scripts/aigame4.cpp
@@ -26,13 +26,7 @@
 #include "osiris_vector.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/barney.cpp
+++ b/scripts/barney.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/clutter.cpp
+++ b/scripts/clutter.cpp
@@ -25,13 +25,7 @@
 #include "osiris_common.h"
 #include "osiris_vector.h"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/generic.cpp
+++ b/scripts/generic.cpp
@@ -25,13 +25,7 @@
 #include "osiris_import.h"
 #include "osiris_common.h"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/kbLEVEL15.cpp
+++ b/scripts/kbLEVEL15.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/kbtest.cpp
+++ b/scripts/kbtest.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level1.cpp
+++ b/scripts/level1.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level10.cpp
+++ b/scripts/level10.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level11.cpp
+++ b/scripts/level11.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level13.cpp
+++ b/scripts/level13.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level14.cpp
+++ b/scripts/level14.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level17.cpp
+++ b/scripts/level17.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level2.cpp
+++ b/scripts/level2.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level3.cpp
+++ b/scripts/level3.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level4.cpp
+++ b/scripts/level4.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level5.cpp
+++ b/scripts/level5.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level7.cpp
+++ b/scripts/level7.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/level8.cpp
+++ b/scripts/level8.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/levelS2.cpp
+++ b/scripts/levelS2.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/merc5.cpp
+++ b/scripts/merc5.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/myPowerHouse.cpp
+++ b/scripts/myPowerHouse.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/orbital.cpp
+++ b/scripts/orbital.cpp
@@ -30,13 +30,7 @@
 #include "osiris_common.h"
 #include "DallasFuncs.cpp"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/scripttest1.cpp
+++ b/scripts/scripttest1.cpp
@@ -24,13 +24,7 @@
 #include "osiris_import.h"
 #include "osiris_common.h"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/testscript.cpp
+++ b/scripts/testscript.cpp
@@ -24,13 +24,7 @@
 #include "osiris_import.h"
 #include "osiris_common.h"
 
-#ifdef _MSC_VER // Visual C++ Build
-#define STDCALL __stdcall
-#define STDCALLPTR *STDCALL
-#else // Non-Visual C++ Build
-#define STDCALL __attribute__((stdcall))
-#define STDCALLPTR STDCALL *
-#endif
+#include "module.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Prevent the code from trying to use stdcall for anything except (32-bit) x86 builds because it's the only platform it's applicable for.

This clears up a lot of annoying warning messages.

Alteration to CMakeList.txt is only whitespace clean up.