### PR TITLE
New windowed and fullscreen mode

### DIFF
--- a/Descent3/config.cpp
+++ b/Descent3/config.cpp
@@ -748,6 +748,7 @@ struct video_menu {
     // video resolution
     window_width = Game_window_res_width;
     window_height = Game_window_res_height;
+    sheet->NewGroup(TXT_RESOLUTION, 0, 0);
     buffer = sheet->AddChangeableText(RESBUFFER_SIZE);
     snprintf(buffer, RESBUFFER_SIZE, "%d x %d", Game_window_res_width, Game_window_res_height);
     sheet->AddLongButton("Change...", IDV_CHANGEWINDOW);

--- a/Descent3/config.h
+++ b/Descent3/config.h
@@ -154,13 +154,9 @@ extern tGameToggles Game_toggles;
 #define RES_1600X1200 6
 #endif
 // stored resolution list and desired game resolution
-typedef struct tVideoResolution {
-  ushort width;
-  ushort height;
-} tVideoResolution;
-
-extern tVideoResolution Video_res_list[];
 extern int Game_video_resolution;
+extern int Game_window_res_width, Game_window_res_height;
+extern bool Game_fullscreen;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // KEEP THESE MEMBERS IN THE SAME ORDER, IF YOU ADD,REMOVE, OR CHANGE ANYTHING IN THIS STRUCT, MAKE SURE YOU

--- a/Descent3/game.cpp
+++ b/Descent3/game.cpp
@@ -958,8 +958,8 @@ void SetScreenMode(int sm, bool force_res_change) {
     int scr_width, scr_height, scr_bitdepth;
 
     if (sm == SM_GAME) {
-      scr_width = Video_res_list[Game_video_resolution].width;
-      scr_height = Video_res_list[Game_video_resolution].height;
+      scr_width = Game_window_res_width;
+      scr_height = Game_window_res_height;
       scr_bitdepth = Render_preferred_bitdepth;
 #ifdef MACINTOSH
       SwitchDSpContex(Game_video_resolution);
@@ -978,6 +978,9 @@ void SetScreenMode(int sm, bool force_res_change) {
       Render_preferred_state.width = scr_width;
       Render_preferred_state.height = scr_height;
       Render_preferred_state.bit_depth = scr_bitdepth;
+      Render_preferred_state.window_width = Game_window_res_width;
+      Render_preferred_state.window_height = Game_window_res_height;
+      Render_preferred_state.fullscreen = Game_fullscreen;
 
       rend_initted = rend_Init(PreferredRenderer, Descent, &Render_preferred_state);
       rend_width = rend_height = 0;
@@ -1008,10 +1011,16 @@ void SetScreenMode(int sm, bool force_res_change) {
         scr_height = 480;
       }
 
-      if (rend_width != scr_width || rend_height != scr_height) {
+	  if (rend_width != scr_width || rend_height != scr_height ||
+          Game_window_res_width != Render_preferred_state.window_width ||
+          Game_window_res_height != Render_preferred_state.window_height ||
+          Game_fullscreen != Render_preferred_state.fullscreen) {
         Render_preferred_state.width = scr_width;
         Render_preferred_state.height = scr_height;
         Render_preferred_state.bit_depth = scr_bitdepth;
+        Render_preferred_state.window_width = Game_window_res_width;
+        Render_preferred_state.window_height = Game_window_res_height;
+        Render_preferred_state.fullscreen = Game_fullscreen;
 
         mprintf((0, "Setting rend_width=%d height=%d\n", scr_width, scr_height));
         int retval = rend_SetPreferredState(&Render_preferred_state);
@@ -1353,4 +1362,12 @@ void DoScreenshot() {
   bm_FreeBitmap(bm_handle);
 
   StartTime();
+}
+
+bool ShouldCaptureMouse() {
+  // If the UI cursor is visible, then the mouse shouldn't be captured.
+  if (ui_IsCursorVisible())
+    return false;
+
+  return true;
 }

--- a/Descent3/game.h
+++ b/Descent3/game.h
@@ -352,4 +352,7 @@ void SetGamemodeScript(const char *scrfilename, int num_requested_teams = -1);
 // Does a screenshot and tells the bitmap lib to save out the picture as a tga
 void DoScreenshot();
 
+// [ISB] Returns true if the mouse should be captured upon returning to the game.
+bool ShouldCaptureMouse();
+
 #endif

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1288,6 +1288,9 @@ void SaveGameSettings() {
   Database->write("DetailPowerupHalos", Detail_settings.Powerup_halos);
 
   Database->write("RS_resolution", Game_video_resolution);
+  Database->write("RS_windowwidth", Game_window_res_width);
+  Database->write("RS_windowheight", Game_window_res_height);
+  Database->write("RS_fullscreen", Game_fullscreen);
 
   Database->write("RS_bitdepth", Render_preferred_bitdepth);
   Database->write("RS_bilear", Render_preferred_state.filtering);
@@ -1457,6 +1460,8 @@ void LoadGameSettings() {
   Database->read("RS_bitdepth", &Render_preferred_bitdepth, sizeof(Render_preferred_bitdepth));
   Database->read_int("RS_resolution", &Game_video_resolution);
   Database->read_int("RS_bilear", &Render_preferred_state.filtering);
+  Database->read_int("RS_windowwidth", &Game_window_res_width);
+  Database->read_int("RS_windowheight", &Game_window_res_height);
   Database->read_int("RS_mipping", &Render_preferred_state.mipping);
   Database->read_int("RS_color_model", &Render_state.cur_color_model);
   Database->read_int("RS_light", &Render_state.cur_light_state);
@@ -1551,16 +1556,6 @@ void LoadGameSettings() {
 
   Database->read_int("PredefDetailSetting", &level);
   ConfigSetDetailLevel(level);
-  int widtharg = FindArg("-Width");
-  int heightarg = FindArg("-Height");
-  if (widtharg) {
-    Video_res_list[N_SUPPORTED_VIDRES - 1].width = atoi(GameArgs[widtharg + 1]);
-    Game_video_resolution = N_SUPPORTED_VIDRES - 1;
-  }
-  if (heightarg) {
-    Video_res_list[N_SUPPORTED_VIDRES - 1].height = atoi(GameArgs[heightarg + 1]);
-    Game_video_resolution = N_SUPPORTED_VIDRES - 1;
-  }
 
   // Motion blur
   Use_motion_blur = 0;
@@ -1680,7 +1675,7 @@ void InitIOSystems(bool editor) {
     Error("I/O initialization failed.");
   }
 
-  if (!editor && !FindArg("-windowed")) {
+  if (!editor) {
     if (Dedicated_server) {
       ddio_MouseMode(MOUSE_STANDARD_MODE);
     } else {
@@ -2553,7 +2548,7 @@ void RestartD3() {
     Error("I/O initialization failed.");
   }
 
-  if (!FindArg("-windowed")) {
+  if (ShouldCaptureMouse()) {
     if (Dedicated_server) {
       ddio_MouseMode(MOUSE_STANDARD_MODE);
     } else {

--- a/Descent3/pilot_class.cpp
+++ b/Descent3/pilot_class.cpp
@@ -210,8 +210,8 @@ void pilot::initialize(void) {
 #endif
   hud_stat = 0;
   hud_graphical_stat = STAT_STANDARD;
-  game_window_w = Video_res_list[Game_video_resolution].width;
-  game_window_h = Video_res_list[Game_video_resolution].height;
+  game_window_w = Game_window_res_width;
+  game_window_h = Game_window_res_height;
   num_missions_flown = 0;
   mission_data = NULL;
   mouselook_control = false;

--- a/lib/application.h
+++ b/lib/application.h
@@ -98,6 +98,10 @@ public:
   virtual void delay(float secs) = 0;
   //	set a function to run when deferring to OS.
   virtual void set_defer_handler(void (*func)(bool)) = 0;
+  //  [ISB] changes the flags and applies changes to the window.
+  virtual void set_flags(int newflags) = 0;
+  //  [ISB] moves the window. 
+  virtual void set_sizepos(int x, int y, int w, int h) = 0;
 
 public:
   //	checks if the application is active

--- a/lib/renderer.h
+++ b/lib/renderer.h
@@ -451,6 +451,8 @@ typedef struct {
 
   int clip_x1, clip_x2, clip_y1, clip_y2;
   int screen_width, screen_height;
+  // [ISB] Size of the true view. These names should maybe be flipped?
+  int view_width, view_height;
 
 } rendering_state;
 
@@ -461,6 +463,9 @@ typedef struct {
   ubyte bit_depth;
   int width, height;
   ubyte vsync_on;
+  // [ISB]
+  bool fullscreen;                 // Informs the window system that fullscreen should be used.
+  int window_width, window_height; // Size of the game window, may != width/height.
 } renderer_preferred_state;
 
 typedef struct {

--- a/lib/win/win32app.h
+++ b/lib/win/win32app.h
@@ -157,6 +157,7 @@ private:
 
 private:
   int defer_block(); // real defer code.
+  void change_window(); // Adjusts the window based on style
 
 public:
   //	Creates the window handle
@@ -187,6 +188,8 @@ public:
 
   //	Sizes the displayable region of the app (the window)
   void set_sizepos(int x, int y, int w, int h);
+
+  void set_flags(int newflags);
 
   //	returns -1 if we pass to default window handler.
   virtual int WndProc(HWnd hwnd, unsigned msg, unsigned wParam, long lParam);

--- a/ui/UISystem.cpp
+++ b/ui/UISystem.cpp
@@ -558,6 +558,7 @@ bool ui_ShowCursor() {
   ::HideCursor();
 #endif
   if (!UI_cursor_show) {
+    ddio_MouseMode(MOUSE_STANDARD_MODE);
     UI_cursor_show = 1;
     return false;
   }
@@ -565,6 +566,7 @@ bool ui_ShowCursor() {
 }
 bool ui_HideCursor() {
   if (UI_cursor_show) {
+    ddio_MouseMode(MOUSE_EXCLUSIVE_MODE);
     UI_cursor_show = 0;
     return false;
   }

--- a/win32/winapp.cpp
+++ b/win32/winapp.cpp
@@ -362,8 +362,43 @@ void oeWin32Application::init() {
     return;
   }
 
-  ShowWindow((HWND)m_hWnd, SW_SHOWNORMAL);
+  if (m_Flags & OEAPP_FULLSCREEN)
+    ShowWindow((HWND)m_hWnd, SW_SHOWMAXIMIZED);
+  else
+    ShowWindow((HWND)m_hWnd, SW_SHOWNORMAL);
   UpdateWindow((HWND)m_hWnd);
+}
+
+void oeWin32Application::change_window() {
+  if (m_Flags & OEAPP_FULLSCREEN) {
+    SetWindowLongPtr((HWND)m_hWnd, GWL_STYLE, kWindowStyle_FullScreen);
+    SetWindowLongPtr((HWND)m_hWnd, GWL_EXSTYLE, WS_EX_TOPMOST);
+
+    RECT r{};
+    GetWindowRect((HWND)m_hWnd, &r);
+
+    m_X = r.left;
+    m_Y = r.top;
+    m_W = r.right - r.left;
+    m_H = r.bottom - r.top;
+
+    SetWindowPos((HWND)m_hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+    ShowWindow((HWND)m_hWnd, SW_SHOWMAXIMIZED);
+  } else {
+    SetWindowLongPtr((HWND)m_hWnd, GWL_STYLE, kWindowStyle_Windowed);
+    SetWindowLongPtr((HWND)m_hWnd, GWL_EXSTYLE, 0);
+
+    ShowWindow((HWND)m_hWnd, SW_NORMAL);
+    SetWindowPos((HWND)m_hWnd, HWND_TOP, m_X, m_Y, m_W, m_H, SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
+  }
+}
+
+void oeWin32Application::set_flags(int newflags) {
+  int oldflags = m_Flags;
+  m_Flags = newflags;
+
+  if (m_Flags != oldflags)
+    change_window();
 }
 
 //	Function to retrieve information from object through a platform defined structure.


### PR DESCRIPTION
This adds a new fullscreen and windowed mode, with some benefits and caveats, and adds simple logic for mouse capture and release. This also removes the legacy resolution system, and uses a much larger selection of resolutions

Benefits of the new system are that it is possible to leave the window while a UI is up, but it is constrained when in game, and the size of the window is decoupled from the actual rendering resolution (for the 640x480 menus). In windowed mode, the window can be dragged around as usual due to this. This disables the code that makes the window vanish when alt tabbing, though the game will still defer and not execute during this time. 

Caveats right now are that the scaling system uses a virtual screen resolution enforced by setting the viewport and ortho matrices correctly, but this virtual screen resolution isn't used in game so the game's render resolution will always be that of the window. Framebuffer objects could be brought in to fix that if desired.

At the moment, this code only works on Windows. To restore compatibility with other platforms, in the oeApplication implementation for that platform, the virtual functions set_sizepos and set_flags will need to be implemented, and an implementation of opengl_UpdateWindow will need to be implemented in HardwareOpenGL.cpp. For the mouse capture system to work correctly, equivalents of the WM_SETFOCUS and WM_KILLFOCUS messages implemented in winmain.cpp will need to be implemented. 