### PR TITLE
[CI] Use same job for both Debug and Release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
         run: cmake --preset ${{ matrix.os.preset }}
 
       - name: Debug Build
-        run: cmake --build --preset ${{ matrix.os.preset }} --config Debug
+        run: cmake --build --preset ${{ matrix.os.preset }} --config Debug --verbose
 
       - name: Release Build
-        run: cmake --build --preset ${{ matrix.os.preset }} --config Release
+        run: cmake --build --preset ${{ matrix.os.preset }} --config Release --verbose
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
           - {runner: macos-12, preset: mac}       # This is supposed to be Intel for now, and what macos-latest is defaulting to for some reason (as of 04/2024)
           - {runner: macos-14, preset: mac}       # This is supposed to be M1
           - {runner: ubuntu-latest, preset: linux}
-        build_type: [Debug, Release]
 
     runs-on: ${{ matrix.os.runner }}
 
@@ -42,11 +41,16 @@ jobs:
       - name: Configure CMake
         run: cmake --preset ${{ matrix.os.preset }}
 
-      - name: Build
-        run: cmake --build --preset ${{ matrix.os.preset }} --config ${{ matrix.build_type }}
+      - name: Debug Build
+        run: cmake --build --preset ${{ matrix.os.preset }} --config Debug
+
+      - name: Release Build
+        run: cmake --build --preset ${{ matrix.os.preset }} --config Release
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build_${{ matrix.os.runner }}_${{ matrix.build_type }}
-          path: "${{ github.workspace }}/builds/${{ matrix.os.preset }}/Descent3/${{ matrix.build_type }}"
+          name: build_${{ matrix.os.runner }}
+          path: |
+            ${{ github.workspace }}/builds/${{ matrix.os.preset }}/Descent3/Debug/
+            ${{ github.workspace }}/builds/${{ matrix.os.preset }}/Descent3/Release/


### PR DESCRIPTION
Making use of CMake's multi-config generators which we're using. 
Simpler and more efficient, halves number of jobs.