### PR TITLE
Remove unnecessary build dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install -y --no-install-recommends \
-            ninja-build make cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev \
+            ninja-build cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev \
             libxext6:i386  # for ./scripts/hogutils/hogUtils-i686 binary
           mkdir ~/Descent3
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cmake --build --preset mac --config [Debug/Release]
 ```
 sudo dpkg --add-architecture i386
 sudo apt update
-sudo apt install -y --no-install-recommends ninja-build make cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev libxext6:i386
+sudo apt install -y --no-install-recommends ninja-build cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev libxext6:i386
 cmake --preset linux
 cmake --build --preset linux --config [Debug/Release]
 ```


### PR DESCRIPTION
2d4d82d (Accurately find the linux artifacts (#80), 2024-04-19) made it so that make no longer gets used as a part of the build process, but it didn’t remove make from the list of build dependencies.
