### PR TITLE
Build the plug-ins as CMake modules.

### DIFF
--- a/netcon/lanclient/CMakeLists.txt
+++ b/netcon/lanclient/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS lanclient.cpp)
 
 set(NETGAME_MODULE "TCP_IP")
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3c")
 target_link_libraries(${NETGAME_MODULE} inetfile)

--- a/netgames/anarchy/CMakeLists.txt
+++ b/netgames/anarchy/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS anarchy.cpp)
 
 set(NETGAME_MODULE anarchy)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/netgames/coop/CMakeLists.txt
+++ b/netgames/coop/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS coop.cpp)
 
 set(NETGAME_MODULE coop)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/netgames/ctf/CMakeLists.txt
+++ b/netgames/ctf/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS ctf.cpp)
 
 set(NETGAME_MODULE ctf)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/netgames/entropy/CMakeLists.txt
+++ b/netgames/entropy/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS EntropyBase.cpp EntropyPackets.cpp EntropyRoom.cpp)
 
 set(NETGAME_MODULE entropy)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/netgames/hoard/CMakeLists.txt
+++ b/netgames/hoard/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS hoard.cpp hoard_ui.cpp)
 
 set(NETGAME_MODULE hoard)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/netgames/hyperanarchy/CMakeLists.txt
+++ b/netgames/hyperanarchy/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS hyperanarchy.cpp)
 
 set(NETGAME_MODULE hyperanarchy)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/netgames/monsterball/CMakeLists.txt
+++ b/netgames/monsterball/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS monsterball.cpp)
 
 set(NETGAME_MODULE monsterball)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/netgames/roboanarchy/CMakeLists.txt
+++ b/netgames/roboanarchy/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS roboanarchy.cpp)
 
 set(NETGAME_MODULE roboanarchy)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/netgames/tanarchy/CMakeLists.txt
+++ b/netgames/tanarchy/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CPPS tanarchy.cpp)
 
 set(NETGAME_MODULE tanarchy)
 
-add_library(${NETGAME_MODULE} SHARED ${CPPS} ${HEADERS})
+add_library(${NETGAME_MODULE} MODULE ${CPPS} ${HEADERS})
 set_target_properties(${NETGAME_MODULE} PROPERTIES PREFIX "")
 set_target_properties(${NETGAME_MODULE} PROPERTIES SUFFIX ".d3m")
 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -73,10 +73,13 @@ add_custom_target(HogFull-copy
 #)
 
 foreach(SCRIPT ${SCRIPTS})
-  add_library(${SCRIPT} SHARED ${CPPS} "${SCRIPT}.cpp")
+  add_library(${SCRIPT} MODULE ${CPPS} "${SCRIPT}.cpp")
   target_link_libraries(${SCRIPT} fix)
   add_dependencies(${SCRIPT} HogFull-copy) #  HogDemo-copy
   set_target_properties(${SCRIPT} PROPERTIES PREFIX "")
+  if (APPLE)
+    set_target_properties(${SCRIPT} PROPERTIES SUFFIX ".dylib")
+  endif ()
   if (UNIX)
     add_custom_command(
       TARGET ${SCRIPT}


### PR DESCRIPTION
This causes the level scripts/plugins to be built, on macOS, as a mach bundle (doesn't have an install name) instead of a library.
This also includes a hack to make the created modules for macOS match the old (pre-patch) file extension, otherwise they would have the extension of ".so" by CMake.