### PR TITLE
Fixes for missing movies

### DIFF
--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -1671,20 +1671,9 @@ void DoMissionMovie(char *movie) {
   return;
 #endif
   if (movie && *movie) {
-    char *moviepath;
-
-    if (Current_mission.filename &&
-        !(!stricmp(Current_mission.filename, "d3.mn3") || !stricmp(Current_mission.filename, "d3_2.mn3"))) {
-      char mpath[_MAX_PATH];
-      ddio_MakePath(mpath, LocalD3Dir, "movies", movie, NULL);
-      PlayMovie(mpath);
-    } else {
-      moviepath = GetMultiCDPath(movie);
-      if (moviepath) {
-        strcpy(temppath, moviepath);
-        PlayMovie(temppath);
-      }
-    }
+    char mpath[_MAX_PATH];
+    ddio_MakePath(mpath, LocalD3Dir, "movies", movie, NULL);
+    PlayMovie(mpath);
   }
   // PlayMovie(movie);
 }

--- a/Descent3/mmItem.cpp
+++ b/Descent3/mmItem.cpp
@@ -337,6 +337,15 @@ void mmInterface::Create() {
     char filename[_MAX_PATH];
     ddio_MakePath(filename, Base_directory, "movies", "mainmenu", NULL);
     m_movie = StartMovie(filename, true);
+
+    if (!m_movie) //[ISB] Didn't find the menu movie?
+    {
+      if (!LoadLargeBitmap("mainmenu.ogf", &m_art)) {
+        Error("Unable to load main menu art mainmenu.ogf.");
+      } else {
+        static_menu_background = true;
+      }
+    }
   }
 #endif
 


### PR DESCRIPTION
If the mainmenu video file isn't present, revert to using a static background image in the main menu.
If one of the built in mission videos can't be found, don't prompt for the Descent 3 CD-ROM.
Fixes #149 