### PR TITLE
HogMaker: don't modify data when printing it

### DIFF
--- a/tools/HogMaker/HogFormat.cpp
+++ b/tools/HogMaker/HogFormat.cpp
@@ -19,32 +19,33 @@
 #include "HogFormat.h"
 #include "IOOps.h"
 
+#include <algorithm>
 #include <fstream>
+#include <iterator>
 
 namespace D3 {
 
-std::ostream &operator<<(std::ostream &output, HogHeader &header) {
-  output.write((char *)&header.tag[0], 4);
+std::ostream &operator<<(std::ostream &output, const HogHeader &header) {
+  std::copy(header.tag.begin(), header.tag.end(), std::ostream_iterator<char>(output));
   bin_write(output, header.nfiles);
   bin_write(output, header.file_data_offset);
-  header.reserved.fill(-1);
-  output.write((char *)&header.reserved[0], 56);
+  std::copy(header.reserved.begin(), header.reserved.end(), std::ostream_iterator<char>(output));
 
   return output;
 }
 
-std::ostream &operator<<(std::ostream &output, HogFileEntry &entry) {
-  output.write((char *)&entry.name[0], 36);
+std::ostream &operator<<(std::ostream &output, const HogFileEntry &entry) {
+  std::copy(entry.name.begin(), entry.name.end(), std::ostream_iterator<char>(output));
   bin_write(output, entry.flags);
   bin_write(output, entry.len);
   bin_write(output, entry.timestamp);
   return output;
 }
 
-std::ostream &operator<<(std::ostream &output, HogFormat &format) {
+std::ostream &operator<<(std::ostream &output, const HogFormat &format) {
   output << format.m_header;
-  for (auto i : format.m_file_entries) {
-    output << i;
+  for (const HogFileEntry &entry : format.m_file_entries) {
+    output << entry;
   }
 
   return output;

--- a/tools/HogMaker/HogFormat.h
+++ b/tools/HogMaker/HogFormat.h
@@ -39,11 +39,17 @@ FILE 1			[filelen(FILE 1)]
 FILE NFILES-1		[filelen(NFILES -1)]
 */
 
+inline std::array<char, 56> array_with(char val) {
+  std::array<char, 56> arr;
+  arr.fill(val);
+  return arr;
+}
+
 struct HogHeader {
   std::array<char, 4> tag = {'H', 'O', 'G', '2'}; // "HOG2"
   uint32_t nfiles = 0;                            // number of files in header
   uint32_t file_data_offset = 68;                 // offset in file to filedata.
-  std::array<char, 56> reserved = {};             // filled with 0xff
+  std::array<char, 56> reserved = array_with(-1); // filled with 0xff
 };
 
 struct HogFileEntry {
@@ -65,7 +71,7 @@ public:
     m_header.file_data_offset += 48;
   };
 
-  friend std::ostream &operator<<(std::ostream &output, HogFormat &format);
+  friend std::ostream &operator<<(std::ostream &output, const HogFormat &format);
 };
 
 } // namespace D3

--- a/tools/HogMaker/HogMaker.cpp
+++ b/tools/HogMaker/HogMaker.cpp
@@ -36,12 +36,6 @@ std::string str_tolower(std::string s) {
   return s;
 }
 
-struct {
-  bool operator()(const std::filesystem::path &a, const std::filesystem::path &b) const {
-    return (str_tolower(a.u8string()) < str_tolower(b.u8string()));
-  }
-} customLess;
-
 int main(int argc, char *argv[]) {
   std::vector<std::filesystem::path> input_files;
 
@@ -78,6 +72,11 @@ int main(int argc, char *argv[]) {
     std::cout << "Exception: " << e.what() << std::endl;
     return 1;
   }
+
+  auto customLess = [](const std::filesystem::path &a, const std::filesystem::path &b) {
+    return (str_tolower(a.u8string()) < str_tolower(b.u8string()));
+  };
+
   std::sort(input_files.begin(), input_files.end(), customLess);
 
   D3::HogFormat hog_table;

--- a/tools/HogMaker/IOOps.h
+++ b/tools/HogMaker/IOOps.h
@@ -55,9 +55,9 @@ template <typename T> constexpr T convert_le(T val) {
 }
 
 template <class T>
-inline std::ostream &bin_write(std::ostream &output, T &value, bool is_little_endian = true, size_t n = sizeof(T)) {
+inline std::ostream &bin_write(std::ostream &output, T value, bool is_little_endian = true, size_t n = sizeof(T)) {
   value = is_little_endian ? convert_le(value) : convert_be(value);
-  output.write(reinterpret_cast<char *>(&value), n);
+  output.write(reinterpret_cast<const char *>(&value), n);
 
   return output;
 }


### PR DESCRIPTION
- Create reserved bytes when constructing HogHeader
- Only byteswap a copy of the data
- Other small cleanups

---

I was about to leave comments to this effect on #143, but then it got merged :)

Verified to produce the same result (if timestamp is set to 0).