### PR TITLE
Don't run the workflow on specific file changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,16 @@ name: Descent 3 Build
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/README.md'
+      - '**/LICENSE'
+      - '**/.github/**'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/README.md'
+      - '**/LICENSE'
+      - '**/.github/**'
 
 jobs:
   build:


### PR DESCRIPTION
Ignore changes to `README.md`, `LICENSE`, and anything inside the .github folder. This will conserve our workflow runner quota.