### PR TITLE
Fix crash in hlsSystem::ComputePlayInfo(), #141

### DIFF
--- a/Descent3/terrain.h
+++ b/Descent3/terrain.h
@@ -213,7 +213,18 @@ extern terrain_tex_segment Terrain_tex_seg[TERRAIN_TEX_WIDTH * TERRAIN_TEX_DEPTH
 // first object to render after cell has been rendered (only used for SW renderer)
 extern short Terrain_seg_render_objs[];
 
+#ifdef RELEASE
 #define TERRAIN_REGION(x) ((Terrain_seg[0x7FFFFFFF & x].flags & TFM_REGION_MASK) >> 5)
+#else // debug(-ish) builds - check if x is valid
+inline int TERRAIN_REGION(int x) {
+	ASSERT(x != -1 && "invalid/unset room number (-1)!");
+	// Note: due to the 0x7FFFFFFF mask, terrSegIdx will be >= 0
+	int terrSegIdx = 0x7FFFFFFF & x;
+	// catch other invalid cell/segment numbers than -1 as well
+	ASSERT((terrSegIdx < TERRAIN_WIDTH * TERRAIN_DEPTH) && "invalid cellnum!");
+	return (Terrain_seg[terrSegIdx].flags & TFM_REGION_MASK) >> 5;
+}
+#endif
 
 extern terrain_sky Terrain_sky;
 

--- a/sndlib/hlsoundlib.cpp
+++ b/sndlib/hlsoundlib.cpp
@@ -922,6 +922,16 @@ bool hlsSystem::ComputePlayInfo(int sound_obj_index, vector *virtual_pos, vector
     sound_seg = m_sound_objects[sound_obj_index].m_link_info.pos_info.segnum;
   }
 
+  // sound_seg == -1 causes crashes when BOA_INDEX() calls TERRAIN_REGION()
+  // with that value (though by pure luck on 32bit platforms the overflow
+  // and truncation will likely use an address that doesn't crash,
+  // but is still invalid). At least one case that could cause this was fixed,
+  // if there are others, the ASSERT should tell us about it
+  // (and if assertions are disabled, return false to handle this gracefully)
+  ASSERT(sound_seg != -1);
+  if (sound_seg == -1)
+    return false;
+
   sound_seg = BOA_INDEX(sound_seg);
   ear_seg = BOA_INDEX(Viewer_object->roomnum);
   if (!BOA_IsSoundAudible(sound_seg, ear_seg))
@@ -1078,6 +1088,11 @@ int hlsSystem::Play3dSound(int sound_index, pos_state *cur_pos, object *cur_obj,
   if (sound_index < 0)
     return -1;
   if (sound_index >= MAX_SOUNDS || Sounds[sound_index].used == 0)
+    return -1;
+  // if the position doesn't belong to any valid room or cell,
+  // all this would fail anyway (in Emulate3dSound() -> ComputePlayInfo()),
+  // so might as well give up now
+  if (cur_pos->roomnum == -1)
     return -1;
   // initialize sound.
   Sound_system.CheckAndForceSoundDataAlloc(sound_index);


### PR DESCRIPTION
sound_seg was -1, which crashes in BOA_INDEX(sound_seg) on 64bit platforms (by pure luck it doesn't seem to crash on 32bit platforms)

See https://github.com/DescentDevelopers/Descent3/issues/141#issuecomment-2071219212 for more details.

I still am not 100% sure if this is the proper fix or just hides another bug.
@kevinbentley is it expected that `objp->roomnum` can be `-1` in that function, or does this indicate a bug elsewhere, of that object wasn't initialized properly?