### PR TITLE
Update build label for appropriate *NIX platform

### DIFF
--- a/Descent3/lnxmain.cpp
+++ b/Descent3/lnxmain.cpp
@@ -547,8 +547,15 @@ int main(int argc, char *argv[]) {
 
   snprintf(game_version_buffer, sizeof(game_version_buffer),
            "\n\n"
-           "Descent 3 Linux %s v%d.%d.%d%s\n"
+           "Descent 3 %s %s v%d.%d.%d%s\n"
            "Copyright (C) 1999 Outrage Entertainment, Inc.\n",
+
+#if defined(__APPLE__) && defined(__MACH__)
+           "macOS",
+#else
+           "Linux",
+#endif
+
 #ifdef DEDICATED
            "Dedicated Server",
 #elif DEMO


### PR DESCRIPTION
It was kind of bugging me that the macOS build reports as a Linux build at runtime, so this fixes that.