### PR TITLE
Update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There is no "release" yet. The current milestone is "1.5 Stable", which is meant
 The milestone needs testing on all platforms. Please report issues when found.
 
 ## Usage
-Purchase Descent 3 from a reputable source and install it, then replace the main binary with the newly build Descent3 binary under `${CMAKE_BINARY_DIR}/Descent3/*/Descent3[.exe]`.
+Purchase Descent 3 from a reputable source and install it, then replace the main binary with the newly built `Descent3` binary under `${CMAKE_BINARY_DIR}/Descent3/*/Descent3[.exe]`.
 See your platform below:
 
 #### Windows


### PR DESCRIPTION
I noticed what looks like a small grammatical/formatting mistake in the README.md file. 

This change matches the usage in the rest of the readme for “built `Descent3` binary”.