### PR TITLE
Enable unittests on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.os.runner }}, ${{ matrix.os.cxx }}, ${{ matrix.build_type }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,20 +63,25 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y --no-install-recommends \
-            ninja-build cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev zlib1g-dev
+            ninja-build cmake g++ libgtest-dev libsdl1.2-dev libsdl-image1.2-dev libncurses-dev zlib1g-dev
 
       - name: Configure CMake
         env:
           CC: ${{ matrix.os.cc }}
           CXX: ${{ matrix.os.cxx }}
           VCPKG_ROOT: C:/vcpkg
-        run: cmake --preset ${{ matrix.os.preset }}
+        run: cmake --preset ${{ matrix.os.preset }} -DBUILD_TESTING=ON
 
       - name: Debug Build
         run: cmake --build --preset ${{ matrix.os.preset }} --config Debug --verbose
 
       - name: Release Build
         run: cmake --build --preset ${{ matrix.os.preset }} --config Release --verbose
+
+      - name: Run Unittests
+        run: |
+          ctest --preset ${{ matrix.os.preset }} -C Debug
+          ctest --preset ${{ matrix.os.preset }} -C Release
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
             cc: clang
             cxx: clang++
             name: Linux-x64-clang
+        build_type:
+          - Debug
+          - Release
 
     runs-on: ${{ matrix.os.runner }}
 
@@ -72,21 +75,14 @@ jobs:
           VCPKG_ROOT: C:/vcpkg
         run: cmake --preset ${{ matrix.os.preset }} -DBUILD_TESTING=ON
 
-      - name: Debug Build
-        run: cmake --build --preset ${{ matrix.os.preset }} --config Debug --verbose
+      - name: Build ${{ matrix.build_type }}
+        run: cmake --build --preset ${{ matrix.os.preset }} --config ${{ matrix.build_type }} --verbose
 
-      - name: Release Build
-        run: cmake --build --preset ${{ matrix.os.preset }} --config Release --verbose
-
-      - name: Run Unittests
-        run: |
-          ctest --preset ${{ matrix.os.preset }} -C Debug
-          ctest --preset ${{ matrix.os.preset }} -C Release
+      - name: Run ${{ matrix.build_type }} Unittests
+        run: ctest --preset ${{ matrix.os.preset }} -C ${{ matrix.build_type }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Descent3_${{ matrix.os.name }}
-          path: |
-            ${{ github.workspace }}/builds/${{ matrix.os.preset }}/Descent3/Debug/
-            ${{ github.workspace }}/builds/${{ matrix.os.preset }}/Descent3/Release/
+          name: Descent3_${{ matrix.build_type }}_${{ matrix.os.name }}
+          path: ${{ github.workspace }}/builds/${{ matrix.os.preset }}/Descent3/${{ matrix.build_type }}/

--- a/Brewfile
+++ b/Brewfile
@@ -9,6 +9,7 @@ brew "sdl12-compat"
 brew "sdl2_image"
 
 brew "cmake"
+brew "googletest"
 brew "ninja"
 
 # zlib

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -52,5 +52,32 @@
 			"name": "linux",
 			"configurePreset": "linux"
 		}
+	],
+	"testPresets": [
+		{
+			"name": "defaults",
+			"hidden": true,
+			"output": {
+				"outputOnFailure": true
+			}
+		},
+		{
+			"name": "win",
+			"inherits": "defaults",
+			"description": "Testing under Windows",
+			"configurePreset": "win"
+		},
+		{
+			"name": "mac",
+			"inherits": "defaults",
+			"description": "Testing under macOS",
+			"configurePreset": "mac"
+		},
+		{
+			"name": "linux",
+			"inherits": "defaults",
+			"description": "Testing under Linux",
+			"configurePreset": "linux"
+		}
 	]
 }

--- a/tests/byteswap_tests.cpp
+++ b/tests/byteswap_tests.cpp
@@ -23,7 +23,7 @@
 // This code taken from original byteswap.h for testing float conversion
 // It cannot convert negative float numbers in 64-bit systems, so testing only non-negative numbers
 
-#define SWAPINT(x) (int)(((x) << 24) | (((ulong)(x)) >> 24) | (((x) & 0x0000ff00) << 8) | (((x) & 0x00ff0000) >> 8))
+#define SWAPINT(x) (int)(((x) << 24) | (((unsigned long)(x)) >> 24) | (((x) & 0x0000ff00) << 8) | (((x) & 0x00ff0000) >> 8))
 
 // Stupid function to trick the compiler into letting me byteswap a float
 inline float SWAPFLOAT(float x) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "builtin-baseline": "000d1bda1ffa95a73e0b40334fa4103d6f4d3d48",
   "dependencies": [
+    "gtest",
     "zlib"
   ]
 }


### PR DESCRIPTION
Unittests requires optional dependency, and most users don't have to install it. Therefore, GTest is not included to vcpkg and brew files, but CI does.