### PR TITLE
Enable building 32-bit binaries on 64-bit Linux via toolchain file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,17 @@ jobs:
             preset: linux
             cc: clang
             cxx: clang++
-            name: Linux-x64-clang
+            name: no_upload
+          - runner: ubuntu-latest
+            preset: linux-32
+            cc: gcc
+            cxx: g++
+            name: Linux-i386
+          - runner: ubuntu-latest
+            preset: linux-32
+            cc: clang
+            cxx: clang++
+            name: no_upload
         build_type:
           - Debug
           - Release
@@ -69,6 +79,14 @@ jobs:
           sudo apt install -y --no-install-recommends \
             ninja-build cmake g++ libgtest-dev libsdl1.2-dev libsdl-image1.2-dev libncurses-dev zlib1g-dev
 
+      - name: Install Linux dependencies for 32-bit build
+        if: ${{ matrix.os.preset == 'linux-32' }}
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt update
+          sudo apt install -y --no-install-recommends \
+            ninja-build cmake g++ g++-multilib libgtest-dev:i386 libsdl1.2-dev:i386 libsdl-image1.2-dev:i386 libncurses-dev:i386 zlib1g-dev:i386
+
       - name: Configure CMake
         env:
           CC: ${{ matrix.os.cc }}
@@ -83,6 +101,7 @@ jobs:
         run: ctest --preset ${{ matrix.os.preset }} -C ${{ matrix.build_type }}
 
       - name: Upload Artifacts
+        if: ${{ matrix.os.name != 'no_upload' }}
         uses: actions/upload-artifact@v4
         with:
           name: Descent3_${{ matrix.build_type }}_${{ matrix.os.name }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,6 +37,13 @@
 				"lhs": "${hostSystemName}",
 				"rhs": "Linux"
 			}
+		},
+		{
+			"name": "linux-32",
+			"inherits": "linux",
+                        "cacheVariables": {
+                                "CMAKE_TOOLCHAIN_FILE": "tools/toolchain-32-bit.cmake"
+                        }
 		}
 	],
 	"buildPresets": [
@@ -51,6 +58,10 @@
 		{
 			"name": "linux",
 			"configurePreset": "linux"
+		},
+		{
+			"name": "linux-32",
+			"configurePreset": "linux-32"
 		}
 	],
 	"testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -89,6 +89,12 @@
 			"inherits": "defaults",
 			"description": "Testing under Linux",
 			"configurePreset": "linux"
+		},
+		{
+			"name": "linux-32",
+			"inherits": "defaults",
+			"description": "Testing under Linux (32-bit)",
+			"configurePreset": "linux-32"
 		}
 	]
 }

--- a/tools/toolchain-32-bit.cmake
+++ b/tools/toolchain-32-bit.cmake
@@ -1,0 +1,19 @@
+# CMake toolchain file to build 32-bit binaries on a 64-bit multiarch system.
+# Call with -DCMAKE_TOOLCHAIN_FILE=...
+
+function(add_m32_flag VAR_NAME)
+  if(DEFINED ${VAR_NAME})
+    if(NOT ${VAR_NAME} MATCHES "-m32")
+      set(${VAR_NAME} "${${VAR_NAME}} -m32" PARENT_SCOPE)
+    endif()
+  else()
+    set(${VAR_NAME} "-m32" PARENT_SCOPE)
+  endif()
+endfunction()
+
+
+add_m32_flag(CMAKE_C_FLAGS)
+add_m32_flag(CMAKE_CXX_FLAGS)
+add_m32_flag(CMAKE_EXE_LINKER_FLAGS)
+add_m32_flag(CMAKE_MODULE_LINKER_FLAGS)
+add_m32_flag(CMAKE_SHARED_LINKER_FLAGS)


### PR DESCRIPTION
Works with variables passed on the commandline via `-D CMAKE_..`, flags     from https://wiki.debian.org/Multiarch/Compiling

---

~~Avoids adding a toolchain file.~~ - It does not avoid this at all!