### PR TITLE
Update script CHECKSUM for 64 bit platforms

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_definitions(-DCHECKSUM=2273873307UL)
+# 64 bit machines have a different game checksum than 32 bit machines
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+  add_definitions(-DCHECKSUM=2273889867UL)
+else ()
+  add_definitions(-DCHECKSUM=2273873307UL)
+endif()
+
 set(HEADERS)
 set(CPPS)
 if (UNIX)


### PR DESCRIPTION
Osiris_CreateGameChecksum computes a different checksum on 64 bit architectures due to the game structures being larger, mostly from pointers being 8 bytes instead of 4.

Fixes #160