### PR TITLE
Fix sound stuttering in MVE on Linux 64bit platforms

### DIFF
--- a/libmve/lnxdsound.cpp
+++ b/libmve/lnxdsound.cpp
@@ -236,7 +236,7 @@ int LnxSoundBuffer_Release(LnxSoundBuffer *buff) {
 //        0 : no error
 //       -1 : Cannot set volume
 //       -2 : Invalid parameters
-int LnxSoundBuffer_SetVolume(LnxSoundBuffer *buff, signed long vol) {
+int LnxSoundBuffer_SetVolume(LnxSoundBuffer *buff, int32_t vol) {
   if (!buff)
     return -1;
 
@@ -278,7 +278,7 @@ int LnxSoundBuffer_SetVolume(LnxSoundBuffer *buff, signed long vol) {
 //        0 : no error
 //       -1 : Cannot set pan
 //       -2 : Invalid parameters
-int LnxSoundBuffer_SetPan(LnxSoundBuffer *buff, signed long pan) {
+int LnxSoundBuffer_SetPan(LnxSoundBuffer *buff, int32_t pan) {
   if (!buff)
     return -1;
 

--- a/libmve/lnxdsound.h
+++ b/libmve/lnxdsound.h
@@ -19,6 +19,8 @@
 #ifndef __LNX_DSOUND_H_
 #define __LNX_DSOUND_H_
 
+#include <cstdint>
+
 #include "SystemInterfaces.h"
 typedef struct {
   int sound_device;       // file device handle for sound
@@ -43,12 +45,12 @@ typedef struct {
   unsigned int play_cursor;
   unsigned int write_cursor;
   unsigned int flags;
-  unsigned long left_vol, right_vol;
+  uint32_t left_vol, right_vol;
 
   unsigned char *buffer;
 
-  signed long volume;
-  signed long pan;
+  int32_t volume;
+  int32_t pan;
 
   WAVEFORMATEX wfx;
 
@@ -90,7 +92,7 @@ int LnxSoundBuffer_Release(LnxSoundBuffer *buff);
 //        0 : no error
 //       -1 : Cannot set volume
 //       -2 : Invalid parameters
-int LnxSoundBuffer_SetVolume(LnxSoundBuffer *buff, signed long vol);
+int LnxSoundBuffer_SetVolume(LnxSoundBuffer *buff, int32_t vol);
 
 ///////////////////////////
 // LnxSoundBuffer_SetPan
@@ -101,7 +103,7 @@ int LnxSoundBuffer_SetVolume(LnxSoundBuffer *buff, signed long vol);
 //        0 : no error
 //       -1 : Cannot set pan
 //       -2 : Invalid parameters
-int LnxSoundBuffer_SetPan(LnxSoundBuffer *buff, signed long pan);
+int LnxSoundBuffer_SetPan(LnxSoundBuffer *buff, int32_t pan);
 
 /////////////////////////
 // LnxSoundBuffer_Stop

--- a/libmve/mvelibi.h
+++ b/libmve/mvelibi.h
@@ -31,6 +31,8 @@
 #error No platform defined
 #endif
 
+#include <cstdint>
+
 #include "byteswap.h"
 //--------------------------------
 // Compressed Video Constants
@@ -53,16 +55,7 @@
 // some inlines to prevent macro craziness when using incrementers and dereferencing, and so I can use operator
 // overloading
 inline unsigned short IntelSwapper(unsigned short a) { return INTEL_SHORT(a); }
-
-inline short IntelSwapper(short a) { return INTEL_SHORT(a); }
-
 inline unsigned int IntelSwapper(unsigned int a) { return INTEL_INT(a); }
-
-inline int IntelSwapper(int a) { return INTEL_INT(a); }
-
-inline unsigned long IntelSwapper(unsigned long a) { return INTEL_INT(a); }
-
-inline long IntelSwapper(long a) { return INTEL_INT(a); }
 
 typedef struct _mve_hdr {
   char FileType[20];      // MVE_FILE_TYPE
@@ -121,7 +114,7 @@ typedef struct _mcmd_hdr {
 
 #define mcmd_syncInit 2
 typedef struct _syncInit {
-  unsigned long period;       // period of quanta
+  uint32_t period;       // period of quanta
   unsigned short wait_quanta; // # of quanta per frame
   void SwapBytes() {
     period = IntelSwapper(period);
@@ -149,7 +142,7 @@ typedef struct _sndConfigure {
 #endif
   unsigned short frequency;
   // Minor opcode 1 extends buflen to be a long
-  unsigned long buflen;
+  uint32_t buflen;
   void SwapBytes() {
     rate = IntelSwapper(rate);
     frequency = IntelSwapper(frequency);

--- a/libmve/mvelibl.cpp
+++ b/libmve/mvelibl.cpp
@@ -494,8 +494,8 @@ static unsigned sndAddHelper(unsigned char *dst, unsigned char **pSrc, unsigned 
         src += len >> 1;
       } else {
         if (init) {
-          state = IntelSwapper(*(unsigned long *)src);
-          *(unsigned long *)dst = state;
+          state = IntelSwapper(*(uint32_t *)src);
+          *(uint32_t *)dst = state;
           src += 4;
           dst += 4;
           len -= 4;
@@ -1214,7 +1214,7 @@ int MVE_rmStepMovie(void) {
         marg_sndConfigure *arg = (marg_sndConfigure *)p;
         arg->SwapBytes();
         unsigned comp16 = hdr.minor >= 1 ? arg->comp16 : 0;
-        unsigned buflen = arg->buflen;
+        uint32_t buflen = arg->buflen;
         if (hdr.minor == 0)
           buflen &= 0xFFFF;
         if (!sndConfigure(arg->rate, buflen, arg->stereo, arg->frequency, arg->bits16, comp16)) {


### PR DESCRIPTION
In MVE decoder on sound decoding occurs unnecessary long to int and int to long conversions with byteswap, which causes sound cuts.