### PR TITLE
Fix window drag

### DIFF
--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1671,6 +1671,14 @@ void InitIOSystems(bool editor) {
 
   Descent->set_defer_handler(D3DeferHandler);
 
+  if (!editor && !FindArg("-windowed")) {
+    if (Dedicated_server) {
+      ddio_MouseMode(MOUSE_STANDARD_MODE);
+    } else {
+      ddio_MouseMode(MOUSE_EXCLUSIVE_MODE);
+    }
+  }
+
   //	do io init stuff
   io_info.obj = Descent;
   io_info.use_lo_res_time = (bool)(FindArg("-lorestimer") != 0);
@@ -1678,14 +1686,6 @@ void InitIOSystems(bool editor) {
   io_info.key_emulation = true; //(bool)(FindArg("-slowkey")!=0); WIN95: DirectInput is flaky for some keys.
   if (!ddio_Init(&io_info)) {
     Error("I/O initialization failed.");
-  }
-
-  if (!editor && !FindArg("-windowed")) {
-    if (Dedicated_server) {
-      ddio_MouseMode(MOUSE_STANDARD_MODE);
-    } else {
-      ddio_MouseMode(MOUSE_EXCLUSIVE_MODE);
-    }
   }
 
   int rocknride_arg = FindArg("-rocknride");
@@ -2544,6 +2544,14 @@ void RestartD3() {
 
   mprintf((0, "Restarting D3...\n"));
 
+  if (!FindArg("-windowed")) {
+    if (Dedicated_server) {
+      ddio_MouseMode(MOUSE_STANDARD_MODE);
+    } else {
+      ddio_MouseMode(MOUSE_EXCLUSIVE_MODE);
+    }
+  }
+
   // startup io
   io_info.obj = Descent;
   io_info.use_lo_res_time = (bool)(FindArg("-lorestimer") != 0);
@@ -2551,14 +2559,6 @@ void RestartD3() {
   io_info.joy_emulation = (bool)((FindArg("-alternatejoy") == 0) && (FindArg("-directinput") == 0));
   if (!ddio_Init(&io_info)) {
     Error("I/O initialization failed.");
-  }
-
-  if (!FindArg("-windowed")) {
-    if (Dedicated_server) {
-      ddio_MouseMode(MOUSE_STANDARD_MODE);
-    } else {
-      ddio_MouseMode(MOUSE_EXCLUSIVE_MODE);
-    }
   }
 
   //	startup screen.

--- a/ddio_win/winmouse.cpp
+++ b/ddio_win/winmouse.cpp
@@ -392,10 +392,10 @@ bool InitNewMouse() {
     //TODO: This code should be renabled when some solution for mouse capturing is decided on.
     // The game should free the capture when the cursor is visible, and recapture it when it isn't visible.
     // Account for the original mode.
-    //if (DDIO_mouse_state.mode == MOUSE_EXCLUSIVE_MODE)
+    if (DDIO_mouse_state.mode == MOUSE_EXCLUSIVE_MODE)
       rawInputDevice.dwFlags = RIDEV_CAPTUREMOUSE | RIDEV_NOLEGACY;
-    //else
-    //  rawInputDevice.dwFlags = 0;
+    else
+      rawInputDevice.dwFlags = 0;
 
     rawInputDevice.hwndTarget = DInputData.hwnd;
 

--- a/ddio_win/winmouse.cpp
+++ b/ddio_win/winmouse.cpp
@@ -110,15 +110,6 @@ void DDIOShowCursor(BOOL show) {
 }
 
 void ddio_MouseMode(int mode) {
-  if (mode == MOUSE_EXCLUSIVE_MODE) {
-    DDIOShowCursor(FALSE);
-  } else if (mode == MOUSE_STANDARD_MODE) {
-    DDIOShowCursor(TRUE);
-  } else {
-    Int3();
-    return;
-  }
-
   DDIO_mouse_state.mode = mode;
 }
 
@@ -446,7 +437,7 @@ bool ddio_MouseInit() {
     DDIO_mouse_state.cursor_count = ShowCursor(FALSE);
   }
 
-  ddio_MouseMode(MOUSE_STANDARD_MODE);
+  DDIOShowCursor(DDIO_mouse_state.mode == MOUSE_EXCLUSIVE_MODE ? FALSE : TRUE);
 
   DDIO_mouse_state.suspended = false;
   ddio_MouseReset();


### PR DESCRIPTION
This change allows the mouse from being captured exclusively only in fullscreen mode. So in window mode, the window can actually be dragged around again.