### PR TITLE
Add virtual default destructors on a few abstract classes.

### DIFF
--- a/lib/ssl_lib.h
+++ b/lib/ssl_lib.h
@@ -446,6 +446,7 @@ protected:
   // Public functions
 public:
   llsSystem();
+  virtual ~llsSystem() = default;
 
   // may be called before init (must be to be valid, the card passed here will be initialized in InitSoundLib)
   virtual void SetSoundCard(const char *name) = 0;

--- a/netgames/includes/idmfc.h
+++ b/netgames/includes/idmfc.h
@@ -177,6 +177,7 @@ IObject
 */
 class IObject {
 public:
+  virtual ~IObject() = default;
   virtual void Delete(void) = 0;
   virtual void *Dynamic_Cast(const char *pszType) = 0;
   virtual void DuplicatePointer(void) = 0;
@@ -1650,6 +1651,7 @@ public:
   // in the range of 0 to MAX_OBJECT_IDS, this returns a pointer to it's information (see objinfo.h)
   //	It returns NULL if an invalid id is given (or it's not used)
   virtual object_info *GetObjectInfo(int objinfo_id) = 0;
+  virtual ~IDMFC() = default;
 };
 
 //===========================================================================================
@@ -1684,6 +1686,7 @@ public:
   virtual void SetState(int state) = 0;
   virtual bool SetStateItemList(int count, ...) = 0;
   virtual bool SetStateItemListArray(int count, char **array) = 0;
+  virtual ~IMenuItem() = default;
 };
 
 //===========================================================================================
@@ -1711,6 +1714,7 @@ public:
   virtual bool CanScrollDown() = 0;
   // returns true if the player list can scroll up any more
   virtual bool CanScrollUp() = 0;
+  virtual ~IDmfcStats() = default;
 };
 
 #endif // #ifdef USECLASSES


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [X] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
This pull request quiets the Clang warning `-Wdelete-abstract-non-virtual-dtor`. There's only three places this warning comes up: once in hlsoundlib.cpp, and twice in dmfcmenu.cpp

### Related Issues
None that I'm aware of.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [X] I have documented any new or modified functionality.
- [X] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [X] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
Not sure what this actually fixes, or if it does fix it (maybe the destructor of the non-abstract subclass doesn't get called?).