### PR TITLE
Windows/CMake: add /MP for multi process MSBuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_compile_options("/we4715")  # 'function' : not all control paths return a value
     add_compile_options("/we4834")  # discarding return value of function with [[nodiscard]] attribute
   endif()
+
+  add_compile_options("/MP")  # so msbuild builds with multiple processes
 endif()
 
 add_compile_definitions($<$<CONFIG:Release>:RELEASE>)


### PR DESCRIPTION
### Description

"The `/MP` option can reduce the total time to compile the source files on the command line. The `/MP` option causes the compiler to create one or more copies of itself, each in a separate process."

<https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=msvc-170>

---

Yes, a _compile_ option which modifies the build process...

## Pull Request Type


- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes


### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [ ] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
