### PR TITLE
Correctly load mercenary assets (extra.hog)

### DIFF
--- a/Descent3/Player.cpp
+++ b/Descent3/Player.cpp
@@ -2754,10 +2754,8 @@ void PlayerSpewGuidebot(object *parent, int type, int id) {
   int model_num = Object_info[ROBOT_GUIDEBOT].render_handle;
   float size;
 
+  // Spews the red guidebot if using the Black Pyro ship
   if (stricmp(Ships[Players[parent->id].ship_index].name, "Black Pyro") == 0) {
-    // Only spew red GB if merc is installed
-    extern bool MercInstalled();
-    if (MercInstalled())
       model_num = Object_info[ROBOT_GUIDEBOTRED].render_handle;
   }
 

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1693,21 +1693,10 @@ void InitIOSystems(bool editor) {
   ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
   extra_hid = cf_OpenLibrary(fullname);
 
-  // Opens the mercenary hog if it exists and the registry entery is present
-  // Win32 only.  Mac and Linux users are SOL for now
-#ifdef WIN32
-  HKEY key;
-  DWORD lType;
-  LONG error;
-
-#define BUFLEN 2000
-  char dir[BUFLEN];
-  DWORD dir_len = BUFLEN;
-
   // Always look for merc.hog first
   merc_hid = cf_OpenLibrary("merc.hog");
   // Check if merc_hid is valid, if not, open extra.hog
-  if (merc_hid == INVALID_HANDLE_VALUE) {
+  if (merc_hid == nullptr) {
     merc_hid = cf_OpenLibrary("extra.hog");
   }
   // Open this for extra 1.3 code (Black Pyro, etc)

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1696,7 +1696,7 @@ void InitIOSystems(bool editor) {
   // Always look for merc.hog first
   merc_hid = cf_OpenLibrary("merc.hog");
   // Check if merc_hid is valid, if not, open extra.hog
-  if (merc_hid == nullptr) {
+  if (merc_hid == -1) {
     merc_hid = cf_OpenLibrary("extra.hog");
   }
   // Open this for extra 1.3 code (Black Pyro, etc)

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1548,12 +1548,6 @@ tTempFileInfo temp_file_wildcards[] = {{"d3s*.tmp"}, {"d3m*.tmp"}, {"d3o*.tmp"},
                                        {"d3c*.tmp"}, {"d3t*.tmp"}, {"d3i*.tmp"}};
 int num_temp_file_wildcards = sizeof(temp_file_wildcards) / sizeof(tTempFileInfo);
 
-// JC: Assume merc is installed by default. Fix later if needed.
-// Returns true if Mercenary is installed
-bool MercInstalled() {
-	return true;
-}
-
 /*
         I/O systems initialization
 */

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1704,24 +1704,12 @@ void InitIOSystems(bool editor) {
   char dir[BUFLEN];
   DWORD dir_len = BUFLEN;
 
-  error =
-      RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Descent3 Mercenary", 0,
-                   KEY_ALL_ACCESS, &key);
-
-  if ((error == ERROR_SUCCESS)) {
-    lType = REG_EXPAND_SZ;
-
-    unsigned long len = BUFLEN;
-    error = RegQueryValueEx(key, "UninstallString", NULL, &lType, (unsigned char *)dir, &len);
-
-    if (error == ERROR_SUCCESS) {
-      merc_hid = cf_OpenLibrary("merc.hog");
-    }
-  }
-#else
-  // non-windows platforms always get merc!
+  // Always look for merc.hog first
   merc_hid = cf_OpenLibrary("merc.hog");
-#endif
+  // Check if merc_hid is valid, if not, open extra.hog
+  if (merc_hid == INVALID_HANDLE_VALUE) {
+    merc_hid = cf_OpenLibrary("extra.hog");
+  }
   // Open this for extra 1.3 code (Black Pyro, etc)
   ddio_MakePath(fullname, LocalD3Dir, "extra13.hog", NULL);
   extra13_hid = cf_OpenLibrary(fullname);

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1548,38 +1548,10 @@ tTempFileInfo temp_file_wildcards[] = {{"d3s*.tmp"}, {"d3m*.tmp"}, {"d3o*.tmp"},
                                        {"d3c*.tmp"}, {"d3t*.tmp"}, {"d3i*.tmp"}};
 int num_temp_file_wildcards = sizeof(temp_file_wildcards) / sizeof(tTempFileInfo);
 
+// JC: Assume merc is installed by default. Fix later if needed.
 // Returns true if Mercenary is installed
 bool MercInstalled() {
-#if defined(LINUX)
-  return false; // TODO: check for mercenary
-#else
-  HKEY key;
-  DWORD lType;
-  LONG error;
-
-#define BUFLEN 2000
-  char dir[BUFLEN];
-  DWORD dir_len = BUFLEN;
-
-  error =
-      RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Descent3 Mercenary", 0,
-                   KEY_ALL_ACCESS, &key);
-
-  if ((error == ERROR_SUCCESS)) {
-    lType = REG_EXPAND_SZ;
-
-    unsigned long len = BUFLEN;
-    error = RegQueryValueEx(key, "UninstallString", NULL, &lType, (unsigned char *)dir, &len);
-
-    if (error == ERROR_SUCCESS) {
-      // Mercenary is installed
-      return true;
-    }
-  }
-
-  // Mercenary not installed
-  return false;
-#endif
+	return true;
 }
 
 /*
@@ -1690,20 +1662,21 @@ void InitIOSystems(bool editor) {
 #endif
 
   // Open this file if it's present for stuff we might add later
-  // JC: Digital releases call this 'extra1'hog', on CD releases it's 'extra.hog'. Check for extra1.hog first.
   ddio_MakePath(fullname, LocalD3Dir, "extra1.hog", NULL);
   extra_hid = cf_OpenLibrary(fullname);
-  if (extra_hid == -1) {
-	ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
- 	extra_hid = cf_OpenLibrary(fullname);
+  if (extra_hid == 0) {
+  	ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
+  	extra_hid = cf_OpenLibrary(fullname);
   }
 
-  // Always look for extra.hog first
-  merc_hid = cf_OpenLibrary("extra.hog");
-  // Check if merc_hid is valid, if not, open merc.hog
-  if (merc_hid == -1) {
-    merc_hid = cf_OpenLibrary("merc.hog");
-  }
+  // Open mercenary hog if it exists
+  ddio_MakePath(fullname, LocalD3Dir, "merc.hog", NULL);
+  merc_hid = cf_OpenLibrary(fullname);
+  if (merc_hid == 0) {
+  	ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
+  	merc_hid = cf_OpenLibrary(fullname);
+  }  
+	
   // Open this for extra 1.3 code (Black Pyro, etc)
   ddio_MakePath(fullname, LocalD3Dir, "extra13.hog", NULL);
   extra13_hid = cf_OpenLibrary(fullname);

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1690,14 +1690,19 @@ void InitIOSystems(bool editor) {
 #endif
 
   // Open this file if it's present for stuff we might add later
-  ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
+  // JC: Digital releases call this 'extra1'hog', on CD releases it's 'extra.hog'. Check for extra1.hog first.
+  ddio_MakePath(fullname, LocalD3Dir, "extra1.hog", NULL);
   extra_hid = cf_OpenLibrary(fullname);
+  if (extra_hid == -1) {
+	ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
+ 	extra_hid = cf_OpenLibrary(fullname);
+  }
 
-  // Always look for merc.hog first
-  merc_hid = cf_OpenLibrary("merc.hog");
-  // Check if merc_hid is valid, if not, open extra.hog
+  // Always look for extra.hog first
+  merc_hid = cf_OpenLibrary("extra.hog");
+  // Check if merc_hid is valid, if not, open merc.hog
   if (merc_hid == -1) {
-    merc_hid = cf_OpenLibrary("extra.hog");
+    merc_hid = cf_OpenLibrary("merc.hog");
   }
   // Open this for extra 1.3 code (Black Pyro, etc)
   ddio_MakePath(fullname, LocalD3Dir, "extra13.hog", NULL);

--- a/Descent3/multi.cpp
+++ b/Descent3/multi.cpp
@@ -9439,14 +9439,6 @@ void MultiDoBashPlayerShip(ubyte *data) {
   if (ship_index < 0)
     ship_index = 0;
 
-  // If told to switch to the Black Pyro, make sure it's allowed
-  if (!stricmp(Ships[ship_index].name, "Black Pyro")) {
-    extern bool MercInstalled();
-    if (!MercInstalled()) {
-      BailOnMultiplayer("Exiting: Game requires Black Pyro");
-    }
-  }
-
   AddHUDMessage("%s not allowed", Ships[Players[Player_num].ship_index].name);
   AddHUDMessage("Switching to %s", Ships[ship_index].name);
 

--- a/Descent3/object_external.h
+++ b/Descent3/object_external.h
@@ -352,10 +352,6 @@
 
 // Static Robot ids
 #define ROBOT_GUIDEBOT 0 // NOTE: this must match GENOBJ_GUIDEBOT
-#ifdef _WIN32
 #define ROBOT_GUIDEBOTRED 2 // NOTE: this must match GENOBJ_GUIDEBOTRED
-#else
-#define ROBOT_GUIDEBOTRED 0 // NOTE: this must match GENOBJ_GUIDEBOTRED
-#endif
 
 #endif

--- a/Descent3/objinfo.cpp
+++ b/Descent3/objinfo.cpp
@@ -54,7 +54,7 @@ int Num_object_ids[MAX_OBJECT_TYPES];
 // #ifdef _WIN32
 // char *Static_object_names[]={TBL_GENERIC("GuideBot"),TBL_GENERIC("ChaffChunk"),TBL_GENERIC("GuideBotRed")};
 // #else
-const char *Static_object_names[] = {TBL_GENERIC("GuideBot"), TBL_GENERIC("ChaffChunk")};
+const char *Static_object_names[] = {TBL_GENERIC("GuideBot"), TBL_GENERIC("ChaffChunk"),TBL_GENERIC("GuideBotRed")};
 // #endif
 
 #define NUM_STATIC_OBJECTS (sizeof(Static_object_names) / sizeof(*Static_object_names))

--- a/Descent3/objinfo.h
+++ b/Descent3/objinfo.h
@@ -358,11 +358,7 @@ extern char *Anim_state_names[];
 // These defines must correspond to the Static_object_names array
 #define GENOBJ_GUIDEBOT 0 // NOTE: This must match ROBOT_GUIDEBOT
 #define GENOBJ_CHAFFCHUNK 1
-#ifdef _WIN32
 #define GENOBJ_GUIDEBOTRED 2 // NOTE: This must match ROBOT_GUIDEBOTRED
-#else
-#define GENOBJ_GUIDEBOTRED 0 // NOTE: This must match ROBOT_GUIDEBOTRED
-#endif
 
 #define IS_GUIDEBOT(x)                                                                                                 \
   (((object *)x)->type == OBJ_ROBOT &&                                                                                 \

--- a/Descent3/pilot.cpp
+++ b/Descent3/pilot.cpp
@@ -2897,7 +2897,6 @@ bool PltSelectShip(pilot *Pilot) {
     goto ship_id_err;
 
   bool found_ship;
-  bool shipoktoadd;
 
   found_ship = false;
   count = 0;
@@ -2909,49 +2908,8 @@ bool PltSelectShip(pilot *Pilot) {
       ship_info.idlist[count] = i;
 #ifdef DEMO
       if (strcmpi(Ships[i].name, DEFAULT_SHIP) == 0) {
-#endif
-#ifdef WIN32
-        HKEY key;
-        DWORD lType;
-        LONG error;
-
-#define BUFLEN 2000
-        char dir[BUFLEN];
-        DWORD dir_len = BUFLEN;
-
-        if (!stricmp(Ships[i].name, "Black Pyro")) {
-          // make sure they have mercenary in order to play with Black Pyro
-          shipoktoadd = false;
-
-          error = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
-                               "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Descent3 Mercenary", 0,
-                               KEY_ALL_ACCESS, &key);
-
-          if ((error == ERROR_SUCCESS)) {
-            lType = REG_EXPAND_SZ;
-
-            unsigned long len = BUFLEN;
-            error = RegQueryValueEx(key, "UninstallString", NULL, &lType, (unsigned char *)dir, &len);
-
-            if (error == ERROR_SUCCESS) {
-              // they have mercenary, and this is a black pyro...add it
-              shipoktoadd = true;
-            }
-          }
-        } else {
-          // this isn't a black pyro
-          shipoktoadd = true;
-        }
-#else
-      // Non-Windows versions don't have to check
-      if (!stricmp(Ships[i].name, "Black Pyro")) {
-        shipoktoadd = false;
-      } else {
-        shipoktoadd = true;
-      }
-#endif
-        if (shipoktoadd)
-          ship_list->AddItem(Ships[i].name);
+#endif      
+    ship_list->AddItem(Ships[i].name);
 #ifdef DEMO
       }
 #endif


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Some mercenary assets are not loaded properly since merc.hog is named extra.hog in digital releases. Adjust the check here. Resolves #255 and enables mercenary stuff for other platforms.
