### PR TITLE
Fixed Windows debug build when ENABLE_LOGGER is active.

### DIFF
--- a/ddebug/winmono.cpp
+++ b/ddebug/winmono.cpp
@@ -410,7 +410,7 @@ void Debug_ConsolePrintf(int n, const char *format, ...) {
   }
 }
 
-void Debug_ConsolePrintf(int n, int row, int col, const char *format, ...) {
+void Debug_ConsolePrintfAt(int n, int row, int col, const char *format, ...) {
   char *ptr = Mono_buffer;
   int r, c;
   std::va_list args;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Builds on Windows with ENABLE_LOGGER in Debug configuration currently fail with an unresolved external symbol Debug_ConsolePrintfAt linker error. Looks like this function was renamed in the passed and was just missed in the windows sources.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
