### PR TITLE
Fix mercenary features

### DIFF
--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1051,6 +1051,8 @@ int CD_inserted = 0;
 float Mouselook_sensitivity = kAnglesPerDegree * kDefaultMouselookSensitivity;
 float Mouse_sensitivity = 1.0f;
 
+int merc_hid = -1;
+
 int IsLocalOk(void) {
 #ifdef WIN32
 #ifdef ALLOW_ALL_LANG
@@ -1548,40 +1550,6 @@ tTempFileInfo temp_file_wildcards[] = {{"d3s*.tmp"}, {"d3m*.tmp"}, {"d3o*.tmp"},
                                        {"d3c*.tmp"}, {"d3t*.tmp"}, {"d3i*.tmp"}};
 int num_temp_file_wildcards = sizeof(temp_file_wildcards) / sizeof(tTempFileInfo);
 
-// Returns true if Mercenary is installed
-bool MercInstalled() {
-#if defined(LINUX)
-  return false; // TODO: check for mercenary
-#else
-  HKEY key;
-  DWORD lType;
-  LONG error;
-
-#define BUFLEN 2000
-  char dir[BUFLEN];
-  DWORD dir_len = BUFLEN;
-
-  error =
-      RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Descent3 Mercenary", 0,
-                   KEY_ALL_ACCESS, &key);
-
-  if ((error == ERROR_SUCCESS)) {
-    lType = REG_EXPAND_SZ;
-
-    unsigned long len = BUFLEN;
-    error = RegQueryValueEx(key, "UninstallString", NULL, &lType, (unsigned char *)dir, &len);
-
-    if (error == ERROR_SUCCESS) {
-      // Mercenary is installed
-      return true;
-    }
-  }
-
-  // Mercenary not installed
-  return false;
-#endif
-}
-
 /*
         I/O systems initialization
 */
@@ -1668,7 +1636,7 @@ void InitIOSystems(bool editor) {
   }
 
   // Init hogfiles
-  int d3_hid = -1, extra_hid = -1, merc_hid = -1, sys_hid = -1, extra13_hid = -1;
+  int d3_hid = -1, extra_hid = -1, sys_hid = -1, extra13_hid = -1;
   char fullname[_MAX_PATH];
 
 #ifdef DEMO
@@ -1688,40 +1656,25 @@ void InitIOSystems(bool editor) {
   ddio_MakePath(fullname, LocalD3Dir, "d3-osx.hog", NULL);
   sys_hid = cf_OpenLibrary(fullname);
 #endif
-
+  
+  // JC: Steam release uses extra1.hog instead of extra.hog, so try loading it first
   // Open this file if it's present for stuff we might add later
-  ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
+  ddio_MakePath(fullname, LocalD3Dir, "extra1.hog", NULL);
   extra_hid = cf_OpenLibrary(fullname);
-
-  // Opens the mercenary hog if it exists and the registry entery is present
-  // Win32 only.  Mac and Linux users are SOL for now
-#ifdef WIN32
-  HKEY key;
-  DWORD lType;
-  LONG error;
-
-#define BUFLEN 2000
-  char dir[BUFLEN];
-  DWORD dir_len = BUFLEN;
-
-  error =
-      RegOpenKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Descent3 Mercenary", 0,
-                   KEY_ALL_ACCESS, &key);
-
-  if ((error == ERROR_SUCCESS)) {
-    lType = REG_EXPAND_SZ;
-
-    unsigned long len = BUFLEN;
-    error = RegQueryValueEx(key, "UninstallString", NULL, &lType, (unsigned char *)dir, &len);
-
-    if (error == ERROR_SUCCESS) {
-      merc_hid = cf_OpenLibrary("merc.hog");
-    }
+  if (extra_hid == 0) {
+  	ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
+  	extra_hid = cf_OpenLibrary(fullname);
   }
-#else
-  // non-windows platforms always get merc!
-  merc_hid = cf_OpenLibrary("merc.hog");
-#endif
+
+  // JC: Steam release uses extra.hog instead of merc.hog, so try loading it last (so we don't conflict with the above)
+  // Open mercenary hog if it exists
+  ddio_MakePath(fullname, LocalD3Dir, "merc.hog", NULL);
+  merc_hid = cf_OpenLibrary(fullname);
+  if (merc_hid == 0) {
+  	ddio_MakePath(fullname, LocalD3Dir, "extra.hog", NULL);
+  	merc_hid = cf_OpenLibrary(fullname);
+  }
+
   // Open this for extra 1.3 code (Black Pyro, etc)
   ddio_MakePath(fullname, LocalD3Dir, "extra13.hog", NULL);
   extra13_hid = cf_OpenLibrary(fullname);
@@ -1763,6 +1716,11 @@ void InitIOSystems(bool editor) {
   if (sys_hid != -1)
     Osiris_ExtractScriptsFromHog(sys_hid, false);
   Osiris_ExtractScriptsFromHog(d3_hid, false);
+}
+
+// Returns true if Mercenary is installed (inits the Black Pyro and Red GB)
+bool MercInstalled() {
+	return merc_hid > 0;
 }
 
 extern int Num_languages;

--- a/Descent3/object_external.h
+++ b/Descent3/object_external.h
@@ -352,10 +352,6 @@
 
 // Static Robot ids
 #define ROBOT_GUIDEBOT 0 // NOTE: this must match GENOBJ_GUIDEBOT
-#ifdef _WIN32
 #define ROBOT_GUIDEBOTRED 2 // NOTE: this must match GENOBJ_GUIDEBOTRED
-#else
-#define ROBOT_GUIDEBOTRED 0 // NOTE: this must match GENOBJ_GUIDEBOTRED
-#endif
 
 #endif

--- a/Descent3/objinfo.cpp
+++ b/Descent3/objinfo.cpp
@@ -54,7 +54,7 @@ int Num_object_ids[MAX_OBJECT_TYPES];
 // #ifdef _WIN32
 // char *Static_object_names[]={TBL_GENERIC("GuideBot"),TBL_GENERIC("ChaffChunk"),TBL_GENERIC("GuideBotRed")};
 // #else
-const char *Static_object_names[] = {TBL_GENERIC("GuideBot"), TBL_GENERIC("ChaffChunk")};
+const char *Static_object_names[] = {TBL_GENERIC("GuideBot"), TBL_GENERIC("ChaffChunk"),TBL_GENERIC("GuideBotRed")};
 // #endif
 
 #define NUM_STATIC_OBJECTS (sizeof(Static_object_names) / sizeof(*Static_object_names))

--- a/Descent3/objinfo.h
+++ b/Descent3/objinfo.h
@@ -358,11 +358,7 @@ extern char *Anim_state_names[];
 // These defines must correspond to the Static_object_names array
 #define GENOBJ_GUIDEBOT 0 // NOTE: This must match ROBOT_GUIDEBOT
 #define GENOBJ_CHAFFCHUNK 1
-#ifdef _WIN32
 #define GENOBJ_GUIDEBOTRED 2 // NOTE: This must match ROBOT_GUIDEBOTRED
-#else
-#define GENOBJ_GUIDEBOTRED 0 // NOTE: This must match ROBOT_GUIDEBOTRED
-#endif
 
 #define IS_GUIDEBOT(x)                                                                                                 \
   (((object *)x)->type == OBJ_ROBOT &&                                                                                 \

--- a/Descent3/pilot.cpp
+++ b/Descent3/pilot.cpp
@@ -2910,46 +2910,16 @@ bool PltSelectShip(pilot *Pilot) {
 #ifdef DEMO
       if (strcmpi(Ships[i].name, DEFAULT_SHIP) == 0) {
 #endif
-#ifdef WIN32
-        HKEY key;
-        DWORD lType;
-        LONG error;
-
-#define BUFLEN 2000
-        char dir[BUFLEN];
-        DWORD dir_len = BUFLEN;
-
-        if (!stricmp(Ships[i].name, "Black Pyro")) {
-          // make sure they have mercenary in order to play with Black Pyro
-          shipoktoadd = false;
-
-          error = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
-                               "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Descent3 Mercenary", 0,
-                               KEY_ALL_ACCESS, &key);
-
-          if ((error == ERROR_SUCCESS)) {
-            lType = REG_EXPAND_SZ;
-
-            unsigned long len = BUFLEN;
-            error = RegQueryValueEx(key, "UninstallString", NULL, &lType, (unsigned char *)dir, &len);
-
-            if (error == ERROR_SUCCESS) {
-              // they have mercenary, and this is a black pyro...add it
-              shipoktoadd = true;
-            }
-          }
-        } else {
-          // this isn't a black pyro
-          shipoktoadd = true;
-        }
-#else
-      // Non-Windows versions don't have to check
-      if (!stricmp(Ships[i].name, "Black Pyro")) {
-        shipoktoadd = false;
-      } else {
-        shipoktoadd = true;
-      }
-#endif
+	  // make sure they have mercenary in order to play with Black Pyro
+	  if (!stricmp(Ships[i].name, "Black Pyro")) {
+		shipoktoadd = false;
+		extern bool MercInstalled();
+		if (MercInstalled()) {
+		  shipoktoadd = true;
+		}
+	  }
+	  else
+		  shipoktoadd = true;
         if (shipoktoadd)
           ship_list->AddItem(Ships[i].name);
 #ifdef DEMO


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
This pull modifies how the game detects mercenary installation. Only Win32 had been properly implemented, and in many cases the registry values the game checked for do not exist. Mercenary must still be present to use the Black Pyro ship in multiplayer.

The source previously only attempted to load hogfiles `extra.hog` and `merc.hog`. On CD installations, this file combination is present. However, in digital installations, the file combination is `extra1.hog` and  `extra.hog`. This pull also correctly detects both combinations.

Fixes #255 

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
Tested in windows only. Needs multiplatform testing. If the Mercenary hogfile is loaded, the player should be able to select the Black Pyro at the pilot config screen, provided they have cleared Mercenary Level 2. Also, when using the Black Pyro, the guidebot should be red.
