### PR TITLE
Fix variable name in Linux build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cmake --build --preset mac --config [Debug|Release]
 ```sh
 sudo apt update
 sudo apt install -y --no-install-recommends ninja-build cmake g++ libsdl1.2-dev libsdl-image1.2-dev libncurses-dev zlib1g-dev libspdlog-dev
-cmake --preset linux -D LOGGER=[ON|OFF]
+cmake --preset linux -D ENABLE_LOGGER=[ON|OFF]
 cmake --build --preset linux --config [Debug|Release]
 ```
 
@@ -60,7 +60,7 @@ cmake --build --preset linux --config [Debug|Release]
 ```sh
 sudo dnf update --refresh
 sudo dnf install -y ninja-build cmake gcc-c++ SDL-devel SDL_image-devel ncurses-devel zlib-devel spdlog-devel
-cmake --preset linux -D LOGGER=[ON|OFF]
+cmake --preset linux -D ENABLE_LOGGER=[ON|OFF]
 cmake --build --preset linux --config [Debug|Release]
 ```
 


### PR DESCRIPTION

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [x] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
0b41a1b (CMake: expose BUILD_TESTNG option, rename LOGGER to ENABLE_LOGGER, 2024-04-29) had originally introduced this change. It looks like d132a1c (Merge pull request #251 from winterheart/pstring-unittests, 2024-05-01) unintentionally removed this change.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
