### PR TITLE
Fix a couple of out-of-bounds warnings found by Clang.

### DIFF
--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -1013,7 +1013,7 @@ bool LoadMission(const char *mssn) {
           for (int a = 0; a < MAX_MISSION_URL_COUNT; a++) {
             if (Net_msn_URLs.URL[a][0] == '\0') {
               strncpy(Net_msn_URLs.URL[a], operand, MAX_MISSION_URL_LEN - 1);
-              Net_msn_URLs.URL[a][MAX_MISSION_URL_LEN] = '\0';
+              Net_msn_URLs.URL[a][MAX_MISSION_URL_LEN - 1] = '\0';
               mprintf((0, "Found a Mission URL: %s\n", operand));
               break;
             }

--- a/netcon/includes/con_dll.h
+++ b/netcon/includes/con_dll.h
@@ -1167,9 +1167,9 @@ int StartMultiplayerGameMenu() {
       if (!mi)
         break;
       strncpy(DLLNetgame->mission, mi->msn_file, MSN_NAMELEN);
-      DLLNetgame->mission[MSN_NAMELEN] = '\0';
+      DLLNetgame->mission[MSN_NAMELEN - 1] = '\0';
       strncpy(DLLNetgame->mission_name, mi->msn_name, MISSION_NAME_LEN);
-      DLLNetgame->mission_name[MISSION_NAME_LEN] = '\0';
+      DLLNetgame->mission_name[MISSION_NAME_LEN - 1] = '\0';
 #else
       // strcpy(DLLNetgame->mission,DLLListGetSelectedIndex(list_1)?"thecore.d3l":"polaris.d3l");
 

--- a/scripts/AIGame.cpp
+++ b/scripts/AIGame.cpp
@@ -5730,7 +5730,6 @@ bool GuideBot::DoInit(int me, bool f_reinit) {
     memory->powerups[2] = 0;
     memory->powerups[3] = 0;
     memory->powerups[4] = 0;
-    memory->powerups[5] = 0;
 
     for (i = 0; i < NUM_GB_SOUNDS; i++) {
       memory->sounds[i] = -1;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
This fixes a few out-of-bounds warnings for c arrays found during compilation on Clang 15.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
Three of these are C strings that were adding a null character one byte longer than the string. The fourth is clearing an array one passed the end of the array.