### PR TITLE
x86-64 supports the `int $3` opcode to trigger a breakpoint.

### DIFF
--- a/lnxmvelib/asmstub.c
+++ b/lnxmvelib/asmstub.c
@@ -145,7 +145,7 @@ void MVE_gfxSetSplit(unsigned line);
 
 // rcg07272000
 // need this on non-Intel platforms. Intel uses int $3.
-#if (defined __i386__)
+#if (defined __i386__) || defined(__x86_64__)
 #define int3 __asm__ __volatile__("int $3");
 #else
 #define int3 raise(SIGTRAP);

--- a/lnxmvelib/mveasm.cpp
+++ b/lnxmvelib/mveasm.cpp
@@ -1575,7 +1575,8 @@ void MVE_gfxSetSplit(unsigned line);
 
 // rcg07272000
 // need this on non-Intel platforms. Intel uses int $3.
-#if (defined __i386__)
+#if (defined __i386__) || defined(__x86_64__)
+#error
 #define int3() __asm__ __volatile__("int $3")
 #else
 #define int3() raise(SIGTRAP)

--- a/netgames/includes/DMFC.h
+++ b/netgames/includes/DMFC.h
@@ -346,7 +346,7 @@
 #ifdef DEBUG_BREAK
 #undef DEBUG_BREAK
 #endif
-#if (defined __i386__)
+#if (defined __i386__) || defined(__x86_64__)
 #define DEBUG_BREAK()                                                                                                  \
   do {                                                                                                                 \
     if (DLLDebugBreak_callback_stop)                                                                                   \


### PR DESCRIPTION
This architecture obviously didn't exist in 1999.  :)
