### PR TITLE
Only load one OS hog file.

### DIFF
--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1648,13 +1648,14 @@ void InitIOSystems(bool editor) {
   d3_hid = cf_OpenLibrary(fullname);
 
 #ifdef __LINUX__
+#ifndef MACOSX
   // DAJ	sys_hid = cf_OpenLibrary("d3-linux.hog");
   ddio_MakePath(fullname, LocalD3Dir, "d3-linux.hog", NULL);
   sys_hid = cf_OpenLibrary(fullname);
-#endif
-#ifdef MACOSX
+#else
   ddio_MakePath(fullname, LocalD3Dir, "d3-osx.hog", NULL);
   sys_hid = cf_OpenLibrary(fullname);
+#endif
 #endif
   
   // JC: Steam release uses extra1.hog instead of extra.hog, so try loading it first


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [X] Other changes

### Description
This prevents a dangling file pointer on macOS if a user has both _d3-linux.hog_ and _d3-osx.hog_.

### Related Issues
Related to #275 
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [X] I have documented any new or modified functionality.
- [X] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [X] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
