### PR TITLE
Add a copy of the GPL to CI artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Run ${{ matrix.build_type }} Unittests
         run: ctest --preset ${{ matrix.os.preset }} -C ${{ matrix.build_type }}
 
+      - name: Ensure artifacts contain LICENSE
+        run: cp LICENSE ${{ github.workspace }}/builds/${{ matrix.os.preset }}/Descent3/${{ matrix.build_type }}/
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [x] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
[The GPL requires that you include a copy of the GPL with every copy of programs that are released under the GPL][1]. Before this change, CI artifacts didn’t include a copy of the GPL.

[1]: https://www.gnu.org/licenses/gpl-faq.en.html#WhyMustIInclude

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #276

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes ~~locally~~ _in CI_ and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
This is the new version of #281. [That PR was closed and can’t be reopened.](https://github.com/DescentDevelopers/Descent3/pull/242#issuecomment-2094366360)