### PR TITLE
Import extra mouse buttons from Piccu

### DIFF
--- a/ddio_win/winmouse.cpp
+++ b/ddio_win/winmouse.cpp
@@ -319,6 +319,47 @@ int RawInputHandler(HWND hWnd, unsigned int msg, unsigned int wParam, long lPara
           MB_queue.send(ev);
         }
 
+        // JC: Imported extra mouse buttons code from Piccu Engine 2924ad2
+        if (buttons & RI_MOUSE_BUTTON_4_DOWN && !DIM_buttons.is_down[3])
+        {
+          DIM_buttons.down_count[3]++;
+          DIM_buttons.time_down[3] = curtime;
+          DIM_buttons.is_down[3] = true;
+          DDIO_mouse_state.btn_mask |= MOUSE_B4;
+          ev.btn = 3;
+          ev.state = true;
+          MB_queue.send(ev);
+        }
+        else if (buttons & RI_MOUSE_BUTTON_4_UP && DIM_buttons.is_down[3])
+        {
+          DIM_buttons.up_count[3]++;
+          DIM_buttons.is_down[3] = false;
+          DIM_buttons.time_up[3] = curtime;
+          DDIO_mouse_state.btn_mask &= ~MOUSE_B4;
+          ev.btn = 3;
+          ev.state = false;
+          MB_queue.send(ev);
+        }
+        if (buttons & RI_MOUSE_BUTTON_5_DOWN && !DIM_buttons.is_down[6])
+        {
+          DIM_buttons.down_count[6]++;
+          DIM_buttons.time_down[6] = curtime;
+          DIM_buttons.is_down[6] = true;
+          DDIO_mouse_state.btn_mask |= MOUSE_B7;
+          ev.btn = 6;
+          ev.state = true;
+          MB_queue.send(ev);
+        } else if (buttons & RI_MOUSE_BUTTON_5_UP && DIM_buttons.is_down[6])
+        {
+          DIM_buttons.up_count[6]++;
+          DIM_buttons.is_down[6] = false;
+          DIM_buttons.time_up[6] = curtime;
+          DDIO_mouse_state.btn_mask &= ~MOUSE_B7;
+          ev.btn = 6;
+          ev.state = false;
+          MB_queue.send(ev);
+        }
+
         if (buttons & RI_MOUSE_WHEEL) {
           wheelAccum += (int)(short)rawinput->data.mouse.usButtonData;
           if (wheelAccum >= WHEEL_DELTA) {
@@ -407,7 +448,7 @@ bool InitNewMouse() {
 
     DDIO_mouse_state.timer = timer_GetTime();
     DDIO_mouse_state.naxis = 2;
-    DDIO_mouse_state.nbtns = N_DIMSEBTNS + 2; // always have a mousewheel
+    DDIO_mouse_state.nbtns = N_DIMSEBTNS + 3; // always have a mousewheel. [ISB] disgusting hack: Can't change mousewheel bindings for old pilots, so make button 5 after the two mouse wheel buttons.
     for (i = 0; i < DDIO_mouse_state.nbtns; i++) {
       DDIO_mouse_state.btn_flags |= (1 << i);
     }
@@ -564,7 +605,7 @@ char Ctltext_MseBtnBindings[N_MSEBTNS][32] = {"mse-l\0\0\0\0\0\0\0\0\0\0\0\0",
                                               "mse-b4\0\0\0\0\0\0\0\0\0\0\0",
                                               "msew-u\0\0\0\0\0\0\0\0\0\0\0",
                                               "msew-d\0\0\0\0\0\0\0\0\0\0\0",
-                                              "",
+                                              "mse-b5",
                                               ""};
 
 char Ctltext_MseAxisBindings[][32] = {"mse-X\0\0\0\0\0\0\0\0\0\0\0\0", "mse-Y\0\0\0\0\0\0\0\0\0\0\0\0",


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [x] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Import the extra mouse buttons for Windows from Piccu Engine commit [2924ad2](https://github.com/InsanityBringer/PiccuEngine/commit/2924ad2c2a5961d3543550ea19e88541050ca02b). Will help until SDL2 is brought to Windows platform.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

Partially closes #187 -- this change affects `winmouse.cpp`, other platforms use SDL2.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->

Thanks to ISB and his raw mouse input code which makes this possible. This code was imported from https://github.com/InsanityBringer/PiccuEngine/commit/2924ad2c2a5961d3543550ea19e88541050ca02b.
