### PR TITLE
Support case-insensitive loading of content files

### DIFF
--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -118,7 +118,7 @@ int cf_OpenLibrary(const char *libname) {
   char t_file[_MAX_PATH];
   char t_ext[256];
   ddio_SplitPath(libname, t_dir, t_file, t_ext);
-  char *resolve_dir = nullptr;
+  const char *resolve_dir = nullptr;
   const char *resolve_name = libname;
   if (strlen(t_dir) > 0) {
     strcat(t_file, t_ext);
@@ -613,9 +613,14 @@ bool cf_FindRealFileNameCaseInsenstive(const char *directory, const char *fname,
 
 FILE *open_file_in_directory_case_sensitive(const char *directory, const char *filename, const char *mode,
                                             char *new_filename) {
+  char t_dir[_MAX_PATH];
+  ddio_SplitPath(filename, t_dir, nullptr, nullptr);
   if (cf_FindRealFileNameCaseInsenstive(directory, filename, new_filename)) {
     // we have a file, open it open and use it
     char full_path[_MAX_PATH * 2];
+    // if we had a directory as part of the file name, put it back in
+    if (strlen(t_dir) > 0)
+      directory = t_dir;
     if (directory != nullptr) {
       ddio_MakePath(full_path, directory, new_filename, NULL);
     } else {

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -108,12 +108,42 @@ int cf_OpenLibrary(const char *libname) {
   tHogHeader header;
   tHogFileEntry entry;
 
-  fp = fopen(libname, "rb");
-  if (fp == nullptr)
+  // allocation library stucture
+  lib = (library *)mem_malloc(sizeof(*lib));
+  if (!lib) { // malloc error
+    return 0;
+  }
+  // resolve library name
+  char t_dir[_MAX_PATH];
+  char t_file[_MAX_PATH];
+  char t_ext[256];
+  ddio_SplitPath(libname, t_dir, t_file, t_ext);
+  char *resolve_dir = nullptr;
+  const char *resolve_name = libname;
+  if (strlen(t_dir) > 0) {
+    strcat(t_file, t_ext);
+    resolve_dir = t_dir;
+    resolve_name = t_file;
+  }
+  char t_out[_MAX_PATH];
+  if (!cf_FindRealFileNameCaseInsenstive(resolve_dir, resolve_name, t_out)) {
+    mem_free(lib);
+    return 0; // CF_NO_FILE
+  }
+  // re-assemble
+  if (resolve_dir != nullptr)
+    ddio_MakePath(lib->name, resolve_dir, t_out, nullptr);
+  else
+    strcpy(lib->name, t_out);
+  fp = fopen(lib->name, "rb");
+  if (fp == nullptr) {
+    mem_free(lib);
     return 0; // CF_NO_FILE;
+  }
   fread(id, strlen(HOG_TAG_STR), 1, fp);
   if (strncmp(id, HOG_TAG_STR, strlen(HOG_TAG_STR))) {
     fclose(fp);
+    mem_free(lib);
     return 0; // CF_BAD_FILE;
   }
   // check if this if first library opened
@@ -121,13 +151,6 @@ int cf_OpenLibrary(const char *libname) {
     atexit(cf_Close);
     first_time = 0;
   }
-  // allocation library stucture
-  lib = (library *)mem_malloc(sizeof(*lib));
-  if (!lib) { // malloc error
-    fclose(fp);
-    return 0;
-  }
-  strcpy(lib->name, libname);
   //	read HOG header
   if (!ReadHogHeader(fp, &header)) {
     fclose(fp);
@@ -601,7 +624,6 @@ FILE *open_file_in_directory_case_sensitive(const char *directory, const char *f
 
     return fopen(full_path, mode);
   }
-
   return nullptr;
 }
 #endif

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -113,6 +113,7 @@ int cf_OpenLibrary(const char *libname) {
   if (!lib) { // malloc error
     return 0;
   }
+#ifdef __LINUX__
   // resolve library name
   char t_dir[_MAX_PATH];
   char t_file[_MAX_PATH];
@@ -135,6 +136,9 @@ int cf_OpenLibrary(const char *libname) {
     ddio_MakePath(lib->name, resolve_dir, t_out, nullptr);
   else
     strcpy(lib->name, t_out);
+#else
+  strcpy(lib->name, libname);
+#endif
   fp = fopen(lib->name, "rb");
   if (fp == nullptr) {
     mem_free(lib);

--- a/cfile/cfile.h
+++ b/cfile/cfile.h
@@ -135,6 +135,13 @@ int cf_OpenLibrary(const char *libname);
 // Parameters:  handle: the handle returned by cf_OpenLibrary()
 void cf_CloseLibrary(int handle);
 
+// Maps fixed case file name to actual case on disk
+// Parameters:  directory: optional directory to search within (can be NULL)
+//              filename: the fixed case name to map to reality
+//              new_filename: buffer to store mapped name, must be at least _MAX_PATH bytes
+// Returns: false if error, true if translated
+bool cf_FindRealFileNameCaseInsenstive(const char *directory, const char *filename, char *new_filename);
+
 // Specify a directory to look in for files
 // Variable arguments is a NULL-terminated list of extensions
 // If no extensions are specified, look in this directory for all files.

--- a/cfile/cfile.h
+++ b/cfile/cfile.h
@@ -135,12 +135,14 @@ int cf_OpenLibrary(const char *libname);
 // Parameters:  handle: the handle returned by cf_OpenLibrary()
 void cf_CloseLibrary(int handle);
 
+#ifdef __LINUX__
 // Maps fixed case file name to actual case on disk
 // Parameters:  directory: optional directory to search within (can be NULL)
 //              filename: the fixed case name to map to reality
 //              new_filename: buffer to store mapped name, must be at least _MAX_PATH bytes
 // Returns: false if error, true if translated
 bool cf_FindRealFileNameCaseInsenstive(const char *directory, const char *filename, char *new_filename);
+#endif
 
 // Specify a directory to look in for files
 // Variable arguments is a NULL-terminated list of extensions

--- a/movie/d3movie.cpp
+++ b/movie/d3movie.cpp
@@ -467,6 +467,7 @@ void mve_SetCallback(MovieFrameCallback_fp callBack) {
 // used to tell movie library how to render movies.
 void mve_SetRenderProperties(short x, short y, short w, short h, renderer_type type, bool hicolor) {}
 
+#ifdef __LINUX__
 // locates the case-sensitive movie file name
 bool mve_FindMovieFileRealName(const char *movie, char *real_name) {
   // split into directory and file...
@@ -493,16 +494,21 @@ bool mve_FindMovieFileRealName(const char *movie, char *real_name) {
   }
   return true;
 }
+#endif
 
 // plays a movie using the current screen.
 int mve_PlayMovie(const char *pMovieName, oeApplication *pApp) {
 #ifndef NO_MOVIES
   // first, find that movie..
   char real_name[_MAX_PATH];
+#ifdef __LINUX__
   if (!mve_FindMovieFileRealName(pMovieName, real_name)) {
     mprintf((0, "MOVIE: No such file %s\n", pMovieName));
     return MVELIB_FILE_ERROR;
   }
+#else
+  strcpy(real_name, pMovieName);
+#endif
   // open movie file.
   int hFile = open(real_name, O_RDONLY | O_BINARY);
   if (hFile == -1) {
@@ -719,11 +725,15 @@ intptr_t mve_SequenceStart(const char *mvename, int *fhandle, oeApplication *app
 
   // first, find that movie..
   char real_name[_MAX_PATH];
+#ifdef __LINUX__
   if (!mve_FindMovieFileRealName(mvename, real_name)) {
     mprintf((0, "MOVIE: No such file %s\n", mvename));
     *fhandle = -1;
     return 0;
   }
+#else
+  strcpy(real_name, mvename);
+#endif
   int hfile = open(real_name, O_RDONLY | O_BINARY);
 
   if (hfile == -1) {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [x] Runtime changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Supports loading content files in a case-insensitive manner, in particular `HOG` files and movies.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #262 

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->

Works for me with RandOmlY capitalisED `HOG` or movie files.