### PR TITLE
Revamp usage instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,10 +198,10 @@ add_subdirectory(Descent3)
 
 add_subdirectory(tools)
 add_subdirectory(netcon)
+add_subdirectory(netgames)
 
 # For now we don't need to build the scripts under windows, so we'll only include
 # the directory when building for linux/osx. In the future we may want to to fix bugs, etc.
 if(UNIX)
-  add_subdirectory(netgames)
   add_subdirectory(scripts)
 endif()

--- a/Descent3/CMakeLists.txt
+++ b/Descent3/CMakeLists.txt
@@ -302,7 +302,7 @@ target_link_libraries(Descent3
   music networking physics renderer rtperformance sndlib ui unzip vecmat md5
   ${PLATFORM_LIBS})
 target_include_directories(Descent3 PRIVATE ${PROJECT_BINARY_DIR}/lib)
-add_dependencies(Descent3 get_git_hash Direct_TCP_IP_Hog)
+add_dependencies(Descent3 get_git_hash Direct_TCP_IP_Hog NetgamesDir)
 
 if(UNIX)
 	add_dependencies(Descent3 HogFull)

--- a/README.md
+++ b/README.md
@@ -9,17 +9,86 @@ There is no "release" yet. The current milestone is "1.5 Stable", which is meant
 The milestone needs testing on all platforms. Please report issues when found.
 
 ## Usage
-Purchase Descent 3 from a reputable source, such as [GOG](https://www.gog.com/game/descent_3_expansion) or [Steam](https://store.steampowered.com/app/273590/Descent_3/), and install it, then replace the main binary with the newly built `Descent3` binary under `${CMAKE_BINARY_DIR}/Descent3/*/Descent3[.exe]`.
-See your platform below:
+1. Make sure that you have a copy of Descent 3. You can purchase a copy of Descent 3 from [GOG](https://www.gog.com/game/descent_3_expansion) or [Steam](https://store.steampowered.com/app/273590/Descent_3/).
+2. Install Descent 3.
 
-#### Windows
-If still using the Descent 3 launcher, copy your `Descent3.exe` binary to your install folder and rename it `main.exe` (back up your old one). Otherwise, drop in `Descent3.exe` and play!
+    - **Note for Steam users:** If you own Descent 3 on Steam, then it’s recommended that you install the Windows version of the game even if you’re running macOS or Linux, otherwise movies will not work due to [current lack of Ogv support](https://github.com/DescentDevelopers/Descent3/issues/240). You can use either [Steam Play](https://help.steampowered.com/en/faqs/view/08F7-5D56-9654-39AF) or [SteamCMD](https://developer.valvesoftware.com/wiki/SteamCMD#Cross-Platform_Installation) to install the Windows version of the game on macOS or Linux.
 
-#### MacOS
-Right-click Descent3.app, click Show Package Contents. Back up your `Descent3` binary and drop your built `Descent3` binary into the install (Contents/MacOS) folder.
+    - **Note for non-Windows users:** If you have the Windows version of the game on CDs but you don’t want to use Windows to install them, then you can follow these instructions:
 
-#### Linux
-Back up your `Descent3` binary and drop your built `Descent3` binary into the install folder.
+        <details>
+        <summary>How to install the Windows Dual-Jewel version of Descent 3 in Wine</summary>
+
+        <ol type="1">
+            <li>Make sure that you have <a href="https://www.winehq.org">Wine</a> installed.</li>
+            <li><i>(Recommended)</i> Run <code>winecfg</code> and make sure that “Emulate a virtual desktop” is enabled.</li>
+            <li>
+                <p><i>(Optional)</i> Determine if you’re going to be affected by a bug with Descent 3’s installer, and potentially apply a workaround:</p>
+                <ol type="a">
+                    <li>Download <a href="https://codeberg.org/JasonYundt/environment-size-checker">Environment Size Checker</a>.</li>
+                    <li>Run <code>wine environment-size-checker.exe</code>.</li>
+                    <li>If that program tells you that your environment is more than 32,724 bytes large, then you’ll need to unset or shorten environment variables before running Descent 3’s installer. If you don’t, then the installer will page fault.</li>
+                </ol>
+            </li>
+            <li>
+                <p>Install Descent 3:</p>
+                <ol type="a">
+                    <li>Insert disc 1.</li>
+                    <li>Make sure that disc 1 is mounted.</li>
+                    <li>Determine which drive letter Wine is using for your CD drive. (Hint: try running <code>wine explorer</code>).</li>
+                    <li>Run <code>wine '&lt;drive-letter&gt;:\Setup.exe'</code>.</li>
+                    <li>Follow the installation wizard’s instructions until it asks you to choose a “Setup Type”.</li>
+                    <li>Select the “Full” Setup Type, then click “Next”.
+                    <li>Continue following the installation wizard’s instructions until it asks you to insert disc 2.</li>
+                    <li>
+                        <p>Switch to disc 2:</p>
+                        <!-- This really should be an <ol>, but I couldn’t get the numbering/lettering to work right: <https://github.com/orgs/community/discussions/124850> -->
+                        <ul>
+                            <li>Run <code>wine eject &lt;drive-letter&gt;:</code>.</li>
+                            <li>Make sure that the disc was unmounted and ejected.</li>
+                            <li>Insert disc 2.</li>
+                            <li>Mount disc 2.</li>
+                        </ul>
+                    </li>
+                    <li>Continue following the installation wizard’s instructions until it asks you to insert disc 1 again.</li>
+                    <li>Switch back to disc 1. Follow a similar procedure to the one that you used to switch to disc 2.</li>
+                    <li>Finish the going through the installation wizard.</li>
+                    <li>When the installation wizard finishes, it will open an explorer window. Close out of that window.</li>
+                    <li>Unmount the disc.</li>
+                    <li>Eject the disc.</li>
+                </ol>
+            <li>
+                <p>Install Descent 3: Mercenary:</p>
+                <ol type="a">
+                    <li>Insert disc 3.</li>
+                    <li>Make sure that disc 3 is mounted.</li>
+                    <li>Run <code>wine start /d &lt;drive-letter&gt;: setup.exe -autorun</code>.</li>
+                    <li>Follow the instructions in the installation wizard.</li>
+                </ol>
+            </li>
+        </ol>
+
+        </details>
+
+3. If your version of Descent 3 is older than v1.4, then [update it to v1.4](http://descent3.com/downloads.php).
+4. Create a new folder named `D3-open-source`.
+5. Copy the following files from your installation of Descent 3 to `D3-open-source`:
+    - All `.hog` files, except for `d3-linux.hog`
+    - The `missions` folder
+    - _(Optional)_ All `.pld` files
+    - _(Optional)_ The `demo` folder
+    - _(Optional)_ The `movies` folder
+6. Create the following folders in `D3-open-source`:
+    - `cache/`
+    - `custom/`
+    - `custom/cache/`
+7. Obtain new Descent 3 engine files:
+    - If you want to use pre-built binaries, then download one of the artifacts from our latest CI run. You can find a list of CI runs [here](https://github.com/DescentDevelopers/Descent3/actions/workflows/build.yml?query=branch%3Amain).
+    - If you want to build the engine files yourself, the follow [these instructions](#building). Once you build the engine files, they’ll be put in `builds/<platform>/Descent3/<build-type>/`. For example, if you’re using Linux and you create a “Release” build, then the files will be located at `builds/linux/Descent3/Release`.
+8. Copy all of the new engine files into `D3-open-source`.
+9. Run the game:
+    - On Windows, run `D3-open-source\Descent3.exe`.
+    - On other platforms, run `D3-open-source/Descent3`.
 
 ## Building
 Build steps below assume you have already cloned the repository and entered it locally.

--- a/netgames/CMakeLists.txt
+++ b/netgames/CMakeLists.txt
@@ -9,3 +9,16 @@ add_subdirectory(hyperanarchy)
 add_subdirectory(monsterball)
 add_subdirectory(roboanarchy)
 add_subdirectory(tanarchy)
+
+add_custom_target(NetgamesDir
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:anarchy> "$<TARGET_FILE_DIR:Descent3>/netgames/Anarchy.d3m"
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:coop> "$<TARGET_FILE_DIR:Descent3>/netgames/Co-op.d3m"
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:ctf> "$<TARGET_FILE_DIR:Descent3>/netgames/CTF.d3m"
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:entropy> "$<TARGET_FILE_DIR:Descent3>/netgames/Entropy.d3m"
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:hoard> "$<TARGET_FILE_DIR:Descent3>/netgames/Hoard.d3m"
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:hyperanarchy> "$<TARGET_FILE_DIR:Descent3>/netgames/Hyper-Anarchy.d3m"
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:monsterball> "$<TARGET_FILE_DIR:Descent3>/netgames/Monsterball.d3m"
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:roboanarchy> "$<TARGET_FILE_DIR:Descent3>/netgames/Robo-Anarchy.d3m"
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:tanarchy> "$<TARGET_FILE_DIR:Descent3>/netgames/Team Anarchy.d3m"
+  COMMENT "Create netgames/ directory"
+)


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [x] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
This commit revamps the usage instructions in order to accomplish two goals:

1. Make the instructions easier to follow by turning them into a numbered list.
2. Make sure that macOS and Linux users install all of the built libraries for their platforms.

In order to accomplish goal number 2, this PR makes it so that the `online/` and `netgames/` directories are automatically generated for macOS and Linux users.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Resolves #120. Fixes #369.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
Here are some things that I wasn’t sure about:
- One of the commits creates a new CMake target named `NetgamesDir`. I wasn’t sure if I should call it `NetgamesDir` or `NetGamesDir`. I went with `NetgamesDir` because the folder itself doesn’t do anything to separate the two words.
- One of the commits adds text that tells users to copy “All `.hog` files, except for `d3-linux.hog`”. This is done to make sure that an old version of `d3-linux.hog` doesn’t get used. Is there a macOS equivalent of that file? [The Steam version of Descent 3 for macOS uses `d3-linux.hog`.](https://steamdb.info/depot/273593/) Does the GraphSim version of Descent 3 have something similar to `d3-linux.hog`?
