### PR TITLE
Quiet/fix a couple of static analyzer warnings as reported by Xcode.

### DIFF
--- a/bitmap/bitmain.cpp
+++ b/bitmap/bitmain.cpp
@@ -661,7 +661,7 @@ void bm_ChangeEndName(const char *src, char *dest) {
   ddio_SplitPath(src, path, filename, ext);
   limit = BITMAP_NAME_LEN - 7;
   // Make sure we don't go over our name length limit
-  strncpy(filename, filename, limit);
+//  strncpy(filename, filename, limit);
   filename[limit] = 0;
 Start:
   if (curnum != -1)

--- a/bitmap/bitmain.cpp
+++ b/bitmap/bitmain.cpp
@@ -661,7 +661,6 @@ void bm_ChangeEndName(const char *src, char *dest) {
   ddio_SplitPath(src, path, filename, ext);
   limit = BITMAP_NAME_LEN - 7;
   // Make sure we don't go over our name length limit
-//  strncpy(filename, filename, limit);
   filename[limit] = 0;
 Start:
   if (curnum != -1)

--- a/ddio_lnx/lnxfile.cpp
+++ b/ddio_lnx/lnxfile.cpp
@@ -262,7 +262,7 @@ void ddio_MakePath(char *newPath, const char *absolutePathHeader, const char *su
 
   // Add the first sub directory
   pathLength = strlen(newPath);
-  if (newPath[pathLength - 1] != delimiter) {
+  if (pathLength > 0 && newPath[pathLength - 1] != delimiter) {
     newPath[pathLength] = delimiter; // add the delimiter
     newPath[pathLength + 1] = 0;     // terminate the string
   }

--- a/ui/UIRes.cpp
+++ b/ui/UIRes.cpp
@@ -154,7 +154,9 @@ const UITextItem &UITextItem::operator=(const UITextItem &item) {
     dummy_str[0] = 0;
   }
 
-  strcpy(m_Text, item.m_Text);
+  if (m_Text != item.m_Text) {
+    strcpy(m_Text, item.m_Text);
+  }
   m_Color = item.m_Color;
   m_Alpha = item.m_Alpha;
   m_Font = item.m_Font;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [X] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [X] Other changes

### Description
This fixes one static analyzer warning (the one in lnxfile) and quiets another. This lets D3 get to the pilot select screen before hitting another static analyzer warning ("strcpy-param-overlap" in UITextItem equal setter).

### Related Issues


### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [X] I have documented any new or modified functionality.
- [X] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [X] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

