### PR TITLE
Minor improvements to `cf_OpenLibrary()`’s HOG2 id detection code

### DIFF
--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -147,8 +147,7 @@ int cf_OpenLibrary(const char *libname) {
     mem_free(lib);
     return 0; // CF_NO_FILE;
   }
-  fread(id, HOG_TAG_LEN, 1, fp);
-  if (strncmp(id, HOG_TAG_STR, HOG_TAG_LEN)) {
+  if (!fread(id, HOG_TAG_LEN, 1, fp) || strncmp(id, HOG_TAG_STR, HOG_TAG_LEN)) {
     fclose(fp);
     mem_free(lib);
     return 0; // CF_BAD_FILE;

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -104,7 +104,7 @@ static CFILE *open_file_in_lib(const char *filename);
 // Returns: 0 if error, else library handle that can be used to close the library
 int cf_OpenLibrary(const char *libname) {
   FILE *fp;
-  char id[4];
+  char id[HOG_TAG_LEN];
   int i, offset;
   library *lib;
   static int first_time = 1;
@@ -147,8 +147,8 @@ int cf_OpenLibrary(const char *libname) {
     mem_free(lib);
     return 0; // CF_NO_FILE;
   }
-  fread(id, strlen(HOG_TAG_STR), 1, fp);
-  if (strncmp(id, HOG_TAG_STR, strlen(HOG_TAG_STR))) {
+  fread(id, HOG_TAG_LEN, 1, fp);
+  if (strncmp(id, HOG_TAG_STR, HOG_TAG_LEN)) {
     fclose(fp);
     mem_free(lib);
     return 0; // CF_BAD_FILE;
@@ -179,7 +179,7 @@ int cf_OpenLibrary(const char *libname) {
   // DAJ	offset = INTEL_INT(header.file_data_offset);
   offset = header.file_data_offset;
   // Go to index start
-  fseek(fp, strlen(HOG_TAG_STR) + HOG_HDR_SIZE, SEEK_SET);
+  fseek(fp, HOG_TAG_LEN + HOG_HDR_SIZE, SEEK_SET);
 
   // read in index table
   for (i = 0; i < lib->nfiles; i++) {

--- a/cfile/hogfile.h
+++ b/cfile/hogfile.h
@@ -65,6 +65,7 @@
 
 #define HOG_HDR_SIZE (64)
 #define HOG_TAG_STR "HOG2"
+#define HOG_TAG_LEN (4)
 #define HOG_FILENAME_LEN (36)
 
 typedef struct tHogHeader {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
This PR contains two minor improvements to the code that detects whether or not `.hog` files actually begin with the ASCII characters HOG2. See the commit messages for details.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->