### PR TITLE
Bump MAX_CELLS_TO_RENDER

### DIFF
--- a/Descent3/terrain.h
+++ b/Descent3/terrain.h
@@ -41,7 +41,7 @@
 
 #define MAX_LOD_SIZE (1 << (MAX_TERRAIN_LOD - 1))
 
-#define MAX_CELLS_TO_RENDER 8000 // The maximum number of cells we can render in a frame
+#define MAX_CELLS_TO_RENDER 32768 // The maximum number of cells we can render in a frame
 
 #define MAX_TERRAIN_HEIGHT 350.0f                              // Max height of our terrain
 #define TERRAIN_HEIGHT_INCREMENT (MAX_TERRAIN_HEIGHT / 255.0f) // Incremental jumps
@@ -50,9 +50,7 @@
 // Sky defines
 #define MAX_STARS 600    // how many stars in our sky
 #define MAX_SATELLITES 5 // max satellites in our sky
-#define MAX_HORIZON_PIECES                                                                                             \
-  16 // how many segments of the horizon
-     // there are around our sphere
+#define MAX_HORIZON_PIECES 16 // how many segments of the horizon there are around our sphere
 
 // Sky flags
 #define TF_STARS 1      // whether or not our terrain is starred


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Bump max cells to 32678 from 8000, allowing a much larger render distance for outdoor terrain. This commit also fixes MAX_HORIZON_PIECES, which may have been broken during a clang-format.

Testing on Level 7 yielded no performance loss, and in fact revealed an existing bug with z-ranges where blue electricity effects from disabled turrets are visible overtop of terrain.

![image](https://github.com/DescentDevelopers/Descent3/assets/47716344/b9c474a2-da7c-48f5-927b-389bfe40977d)


### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #280 