### PR TITLE
Fixed double delete/free in rend_Screenshot().

### DIFF
--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -2190,8 +2190,6 @@ void rend_Screenshot(int bm_handle) {
       dest_data[(((h - 1) - i) * w) + t] = GR_RGB16(r, g, b);
     }
   }
-
-  mem_free(temp_data);
 }
 
 // Enables/disables writes the depth buffer


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [x] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
I got crashes when saving Savegames on Windows in [rend_Screenshot()](https://github.com/DescentDevelopers/Descent3/blob/86c8681afb58aa9f14413cf27fa571b687e7d85d/renderer/HardwareOpenGL.cpp#L2170) that are introduced with [80c207d](https://github.com/DescentDevelopers/Descent3/commit/80c207d41c195d3aa3bb180ff5e2838a1648d1be).

The `auto screenshot` in the beginning of that function is a `std::unique_ptr<NewBitmap>`. The following `auto *temp_data` is a raw pointer to `NewBitmap::_data` which itself is a std::unique_ptr. So the `mem_free(temp_data)` at the end of that function was freeing the memory held by `_data` and the `auto screenshot` going out of scope after that, was trying to delete that memory again through the dtor of the std::unique_ptr.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
