### PR TITLE
Replace ioctl with fcntl, fix ioctlsocket calls (64-bit fix)

### DIFF
--- a/ddebug/lnxmono.cpp
+++ b/ddebug/lnxmono.cpp
@@ -64,7 +64,6 @@
 #include <sys/types.h>
 #include <arpa/inet.h>
 #include <unistd.h>
-#include <sys/ioctl.h>
 
 #define MAX_TCPLOG_LEN 2000
 #define SOCKET int

--- a/legacy/inetfile/Chttpget.cpp
+++ b/legacy/inetfile/Chttpget.cpp
@@ -201,15 +201,9 @@ void ChttpGet::PrepSocket(char *URL)
 	{
 		m_State = HTTP_STATE_SOCKET_ERROR;
 		return;
-	}
-	unsigned long arg;
+  }
 
-	arg = true;
-#if defined(WIN32)
-	ioctlsocket( m_DataSock, FIONBIO, &arg );
-#elif defined(__LINUX__)
-	ioctl( m_DataSock, FIONBIO, &arg );
-#endif
+  make_nonblocking(m_DataSock);
 
 	char *pURL = URL;
 	if(strnicmp(URL,"http:",5)==0)
@@ -758,16 +752,6 @@ uint32_t ChttpGet::ReadDataChannel()
 		return 1;
 	}
 }	
-
-
-typedef struct _async_dns_lookup
-{
-	uint32_t ip;	//resolved host. Write only to worker thread.
-	char * host;//host name to resolve. read only to worker thread
-	bool done;	//write only to the worker thread. Signals that the operation is complete
-	bool error; //write only to worker thread. Thread sets this if the name doesn't resolve
-	bool abort;	//read only to worker thread. If this is set, don't fill in the struct.
-}async_dns_lookup;
 
 async_dns_lookup httpaslu;
 async_dns_lookup *http_lastaslu = NULL;

--- a/legacy/mtclient/chat_api.cpp
+++ b/legacy/mtclient/chat_api.cpp
@@ -30,9 +30,9 @@
 #include "game.h"
 #include "pilot.h"
 #include "ddio_common.h"
+#include "networking.h"
 
 #ifdef __LINUX__
-#include "networking.h"
 #include <sys/time.h>
 #include <unistd.h>
 #endif
@@ -133,8 +133,7 @@ int ConnectToChatServer(char *serveraddr,char *nickname,char *trackerid)
 {
 	int16_t chat_port;
 	char chat_server[50];
-	char *p;
-	unsigned long argp = 1;
+  char *p;
 	char signon_str[100];
 
 	//if(Socket_connected && ) return -2;
@@ -186,12 +185,7 @@ int ConnectToChatServer(char *serveraddr,char *nickname,char *trackerid)
 			return -1;
 		}
 
-#ifdef WIN32
-	ioctlsocket( Chatsock, FIONBIO, &argp );
-#elif defined(__LINUX__)
-	ioctl(Chatsock,FIONBIO,&argp);
-#endif
-
+                make_nonblocking(Chatsock);
 		
 		/*
 		HOSTENT *he;

--- a/lib/networking.h
+++ b/lib/networking.h
@@ -237,7 +237,10 @@ static inline void INADDR_GET_SUN_SUNB(struct in_addr *st, uint8_t *s_b1, uint8_
 #define WSAEINVAL EINVAL
 #define WSAENOPROTOOPT ENOPROTOOPT
 
-static inline int WSAGetLastError() { return errno; }
+#ifndef WSAGetLastError
+#define WSAGetLastError() errno
+#endif
+
 extern bool Use_DirectPlay;
 
 // helper macros for working with SOCKADDR_IN to make it look nicer between windows and Linux
@@ -343,6 +346,10 @@ typedef struct {
 extern BOOL DP_active;
 extern BOOL TCP_active;
 extern BOOL IPX_active;
+
+// create a new non-blocking socket
+int make_nonblocking(SOCKET sock);
+
 // Get the info from RAS
 uint32_t psnet_ras_status();
 

--- a/netcon/includes/Chttpget.h
+++ b/netcon/includes/Chttpget.h
@@ -65,6 +65,7 @@
 #define _CHTTPGET_HEADER_
 
 #include <cstdint>
+#include "networking.h"
 
 #define HTTP_STATE_INTERNAL_ERROR 0
 #define HTTP_STATE_SOCKET_ERROR 1

--- a/netcon/includes/inetgetfile.h
+++ b/netcon/includes/inetgetfile.h
@@ -93,7 +93,6 @@
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
 #include <netdb.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -126,8 +125,8 @@
 #define WSAEISCONN EISCONN
 #define SOCKET_ERROR -1
 
-#ifndef NETWORKING_H
-static inline int WSAGetLastError() { return errno; }
+#ifndef WSAGetLastError
+#define WSAGetLastError() errno
 #endif
 
 

--- a/netcon/inetfile/Chttpget.cpp
+++ b/netcon/inetfile/Chttpget.cpp
@@ -210,14 +210,8 @@ void ChttpGet::PrepSocket(char *URL) {
     m_State = HTTP_STATE_SOCKET_ERROR;
     return;
   }
-  uint32_t arg = 1;
-  
-  #ifdef WIN32
-    u_long argWin = static_cast<u_long>(arg);
-    ioctlsocket(m_DataSock, FIONBIO, &argWin);
-  #elif defined(__linux__)
-    ioctl(m_DataSock, FIONBIO, &arg);
-  #endif
+
+  make_nonblocking(m_DataSock);
 
   char *pURL = URL;
   if (strnicmp(URL, "http:", 5) == 0) {
@@ -668,18 +662,6 @@ uint32_t ChttpGet::ReadDataChannel() {
     return 1;
   }
 }
-
-typedef struct _async_dns_lookup {
-  uint32_t ip; // resolved host. Write only to worker thread.
-  char *host;      // host name to resolve. read only to worker thread
-  bool done;       // write only to the worker thread. Signals that the operation is complete
-  bool error;      // write only to worker thread. Thread sets this if the name doesn't resolve
-  bool abort;      // read only to worker thread. If this is set, don't fill in the struct.
-
-#ifdef __LINUX__
-  SDL_Thread *threadId;
-#endif
-} async_dns_lookup;
 
 static async_dns_lookup httpaslu;
 static async_dns_lookup *http_lastaslu = NULL;


### PR DESCRIPTION
These take two different types of arguments but worked in the past due to long being 32-bit.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [x] Network changes
  - [ ] Other changes

### Description
The `ioctl` argument for UNIX systems is `int*` while the `ioctlsocket` argument for Windows is `unsigned long*`. On 32-bit systems theses coincided so no problems but not on 64-bit. However, the behavior of `ioctl` calls is non-standard which is why [code should use `fnctl`.](https://stackoverflow.com/questions/1150635/unix-nonblocking-i-o-o-nonblock-vs-fionbio#answers)

See also:
- [ioctlsocket documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-ioctlsocket)
- [fnctl documentation](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fcntl.html)
- [ioctl documentation](https://pubs.opengroup.org/onlinepubs/9699919799/functions/ioctl.html)

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
