### PR TITLE
Utilize Windows types

### DIFF
--- a/Descent3/multi_external.h
+++ b/Descent3/multi_external.h
@@ -107,8 +107,11 @@
 #ifndef __MULTI_EXTERNAL_H_
 #define __MULTI_EXTERNAL_H_
 
-#if defined(LINUX)
-#include <string.h>
+#if defined(__LINUX__)
+#include <cstring>
+#include <cstdint>
+typedef uintptr_t DWORD;
+typedef int HANDLE;
 #endif
 
 #include "pstypes.h"
@@ -192,7 +195,7 @@ typedef struct {
   ubyte sequence; // where we are in the sequence chain
   ubyte pps;
   HANDLE hPlayerEvent;      // player event to use for directplay
-  unsigned long dpidPlayer; // directplay ID of player created
+  DWORD dpidPlayer; // directplay ID of player created
   float ping_time;
   float last_ping_time;
   ushort pilot_pic_id;

--- a/ddebug/windebug.cpp
+++ b/ddebug/windebug.cpp
@@ -1054,7 +1054,7 @@ static void PrintFileTime(char *sztime, FILETIME ftime) {
 
 static void ShowModuleInfo(HANDLE LogFile, HINSTANCE ModuleHandle) {
   char FmtString[2000];
-  unsigned long bytesout;
+  DWORD bytesout;
   char ModName[MAX_PATH];
   __try {
     if (GetModuleFileName(ModuleHandle, ModName, sizeof(ModName)) > 0) {
@@ -1099,7 +1099,7 @@ static void ShowModuleInfo(HANDLE LogFile, HINSTANCE ModuleHandle) {
 
 static void RecordModuleList(HANDLE LogFile) {
   char FmtString[2000];
-  unsigned long bytesout;
+  DWORD bytesout;
   wsprintf(FmtString, "\r\n"
                       "Modules:\r\n");
   WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
@@ -1136,7 +1136,7 @@ static void RecordModuleList(HANDLE LogFile) {
 
 static void RecordSystemInformation(HANDLE LogFile) {
   char FmtString[2000];
-  unsigned long bytesout;
+  DWORD bytesout;
   FILETIME CurrentTime;
   GetSystemTimeAsFileTime(&CurrentTime);
   char TimeBuffer[100];
@@ -1218,16 +1218,16 @@ int __cdecl RecordExceptionInfo(PEXCEPTION_POINTERS data, const char *Message) {
     char *p = Debug_DumpInfo();
     lstrcpy(callstack, p);
 
-    unsigned long NumBytes;
+    DWORD NumBytes;
     SetFilePointer(LogFile, 0, 0, FILE_END);
 
     WriteFile(LogFile, topmsg, lstrlen(topmsg), &NumBytes, 0);
     WriteFile(LogFile, FORMATCRLF, lstrlen(FORMATCRLF), &NumBytes, 0);
 
     char Username[100];
-    unsigned long unamelen = 99;
+    DWORD unamelen = 99;
     char Machinename[200];
-    unsigned long cnamelen = 199;
+    DWORD cnamelen = 199;
     GetUserName(Username, &unamelen);
     GetComputerName(Machinename, &cnamelen);
     wsprintf(callstack, "Username: %s\r\nMachineName: %s\r\n", Username, Machinename);

--- a/ddebug/winmono.cpp
+++ b/ddebug/winmono.cpp
@@ -127,7 +127,6 @@ SOCKADDR_IN tcp_log_addr;
 char tcp_log_buffer[MAX_TCPLOG_LEN];
 
 void nw_InitTCPLogging(char *ip, unsigned short port) {
-  unsigned long argp = 1;
   int addrlen = sizeof(SOCKADDR_IN);
   tcp_log_sock = socket(AF_INET, SOCK_STREAM, 0);
   if (INVALID_SOCKET == tcp_log_sock) {
@@ -142,7 +141,8 @@ void nw_InitTCPLogging(char *ip, unsigned short port) {
   if (SOCKET_ERROR == bind(tcp_log_sock, (SOCKADDR *)&tcp_log_addr, sizeof(sockaddr))) {
     return;
   }
-  ioctlsocket(tcp_log_sock, FIONBIO, &argp);
+  unsigned long arg = 1;
+  ioctlsocket(tcp_log_sock, FIONBIO, &arg);
 
   tcp_log_addr.sin_addr.s_addr = inet_addr(ip);
   tcp_log_addr.sin_port = htons(port);

--- a/ddio_win/winfile.cpp
+++ b/ddio_win/winfile.cpp
@@ -572,12 +572,12 @@ const char *ddio_GetCDDrive(const char *vol) {
 
 #define MAX_FSTYPE_LEN 30
   static char drivepath[10];
-  unsigned long volflags;
+  DWORD volflags;
   int i;
   char volume[_MAX_PATH];
   char fsname[MAX_FSTYPE_LEN] = "";
-  unsigned long serial;
-  unsigned long component;
+  DWORD serial;
+  DWORD component;
 
   strcpy(drivepath, "c:\\");
 

--- a/legacy/D3Launch/D3LaunchDlg.cpp
+++ b/legacy/D3Launch/D3LaunchDlg.cpp
@@ -453,8 +453,8 @@ BOOL CD3LaunchDlg::OnInitDialog()
 	if(DlgHeightModifier>0.99 && DlgHeightModifier<1.01) DlgHeightModifier=1.0;
 
 	// Calculate the size and position of the background bitmap
-	m_size.cx = long(m_bmInfo.bmWidth*DlgWidthModifier);
-	m_size.cy = long(m_bmInfo.bmHeight*DlgHeightModifier);
+  m_size.cx = int32_t(m_bmInfo.bmWidth*DlgWidthModifier);
+  m_size.cy = int32_t(m_bmInfo.bmHeight*DlgHeightModifier);
 
 	m_pt.x = 0;		
 	m_pt.y = 0;
@@ -1868,7 +1868,7 @@ void CD3LaunchDlg::OnOK()
 	// Trick main window into thinking that button has been clicked
 	ctrl_id=selected_button->GetDlgCtrlID();
 	hwnd=selected_button->m_hWnd;
-	PostMessage(WM_COMMAND,(BN_CLICKED<<16) + ctrl_id,(long)hwnd);
+  PostMessage(WM_COMMAND,(BN_CLICKED<<16) + ctrl_id,(LPARAM)hwnd);
 
 	//CDialog::OnOK();
 }

--- a/legacy/FontEditor/FontEditor.cpp
+++ b/legacy/FontEditor/FontEditor.cpp
@@ -76,10 +76,10 @@ class appFontKerner: public oeWin32Application
 	bool shutdown;																				 
 
 public:
-	appFontKerner(HInstance hinst): oeWin32Application(APPNAME, OEAPP_FULLSCREEN, hinst) { shutdown = false; };
+  appFontKerner(HINSTANCE hinst): oeWin32Application(APPNAME, OEAPP_FULLSCREEN, hinst) { shutdown = false; };
 
 //	returns 0 if we pass to default window handler.
-	virtual int WndProc( HWnd hwnd, unsigned msg, unsigned wParam, long lParam)
+  virtual int WndProc( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	{
 		switch (msg)
 		{
@@ -114,7 +114,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
                      LPSTR     lpCmdLine,
                      int       nCmdShow)
 {
-	appFontKerner fontkern((HInstance)hInstance);
+  appFontKerner fontkern(hInstance);
 	int i;
 
 	fontkern.init();

--- a/legacy/editor/MainFrm.cpp
+++ b/legacy/editor/MainFrm.cpp
@@ -1577,7 +1577,7 @@ void CMainFrame::OnActivateApp(BOOL bActive, HTASK hTask)
 		mprintf_at((2,0,0, "App Inactive"));
 	}
 
-	((oeWin32Application *)Descent)->run_handler((HWnd)this->m_hWnd, WM_ACTIVATEAPP, (unsigned)bActive, 0); 
+  ((oeWin32Application *)Descent)->run_handler(this->m_hWnd, WM_ACTIVATEAPP, (unsigned)bActive, 0);
 }
 
 

--- a/legacy/editor/TextureGrWnd.cpp
+++ b/legacy/editor/TextureGrWnd.cpp
@@ -615,8 +615,8 @@ void CTextureGrWnd::TexGrStartOpenGL()
 	{
 		app=(oeWin32Application *)Descent;
 		StateLimited=1;
-		save_wnd=(HWND)app->m_hWnd;
-		app->m_hWnd=(HWnd)m_hWnd;
+    save_wnd = app->m_hWnd;
+    app->m_hWnd = m_hWnd;
 		rend_SetOpenGLWindowState (1,Descent,NULL);
 		rend_ClearScreen(0);
 		StateLimited=1;
@@ -630,7 +630,7 @@ void CTextureGrWnd::TexGrStopOpenGL ()
 	if (DoOpenGL)
 	{
 		rend_SetOpenGLWindowState (0,Descent,NULL);
-		app->m_hWnd=(HWnd)save_wnd;
+    app->m_hWnd = save_wnd;
 	}
 }
 
@@ -823,14 +823,14 @@ void CTextureGrWnd::OnPaint()
 
 			app=(oeWin32Application *)Descent;
 
-			save_wnd=(HWND)app->m_hWnd;
-			app->m_hWnd=(HWnd)m_hWnd;
+      save_wnd = app->m_hWnd;
+      app->m_hWnd = m_hWnd;
 			rend_SetOpenGLWindowState (1,Descent,NULL);
 
 			rend_Flip();
 
 			rend_SetOpenGLWindowState (0,Descent,NULL);
-			app->m_hWnd=(HWnd)save_wnd;
+      app->m_hWnd = save_wnd;
 		}
 		else
 		{

--- a/legacy/editor/gameeditor.cpp
+++ b/legacy/editor/gameeditor.cpp
@@ -563,7 +563,7 @@ void InitEditGameSystems();
 void DeswInitMainWindow(HINSTANCE hinst);
 void DeswCloseMainWindow();
 
-LRESULT WINAPI DescentWndProc(HWND hWnd,UINT msg,UINT wParam,LPARAM lParam);
+LRESULT WINAPI DescentWndProc(HWND hWnd,UINT msg,WPARAM wParam,LPARAM lParam);
 
 
 

--- a/legacy/musicutils/musicutilsDlg.cpp
+++ b/legacy/musicutils/musicutilsDlg.cpp
@@ -228,8 +228,8 @@ BOOL CMusicutilsDlg::OnInitDialog()
 
 // TODO: Add extra initialization here
 	tWin32AppInfo appinfo;
-	appinfo.hwnd = (HWnd)m_hWnd;
-	appinfo.hinst = (HInstance)theApp.m_hInstance;
+  appinfo.hwnd = m_hWnd;
+	appinfo.hinst = theApp.m_hInstance;
 	appinfo.flags = OEAPP_WINDOWED;
 
 	MusicUtils = (oeApplication *)new oeWin32Application(&appinfo);

--- a/legacy/renderer/Direct3D.cpp
+++ b/legacy/renderer/Direct3D.cpp
@@ -387,7 +387,7 @@ BOOL WINAPI d3d_Enumerate2DDevice(LPGUID lpGUID, LPSTR lpDeviceDescription, LPST
 }
 
 // Enumerates the zbuffer types we have to choose from
-long WINAPI d3d_EnumZPixelFormats(LPDDPIXELFORMAT pixfmt, LPVOID lpContext) {
+HRESULT WINAPI d3d_EnumZPixelFormats(LPDDPIXELFORMAT pixfmt, LPVOID lpContext) {
   if (NumZDepths >= MAX_ZDEPTHS)
     return D3DENUMRET_OK;
   if (!(pixfmt->dwFlags & DDPF_ZBUFFER))
@@ -399,7 +399,7 @@ long WINAPI d3d_EnumZPixelFormats(LPDDPIXELFORMAT pixfmt, LPVOID lpContext) {
 }
 
 // Enumerates the texture pixel formats we have to choose from
-long WINAPI d3d_EnumTexturePixelFormats(LPDDPIXELFORMAT pixfmt, LPVOID lpContext) {
+HRESULT WINAPI d3d_EnumTexturePixelFormats(LPDDPIXELFORMAT pixfmt, LPVOID lpContext) {
   if (Num_texture_formats >= MAX_TEXTURE_FORMATS)
     return D3DENUMRET_CANCEL;
 

--- a/lib/directplay.h
+++ b/lib/directplay.h
@@ -62,7 +62,7 @@ extern bool Directplay_lobby_launched_game;
 extern DPSESSIONDESC2 Directplay_sessions[MAX_DP_GAMES];
 extern int Num_directplay_games;
 
-extern unsigned long Pending_dp_conn[MAX_PENDING_NEW_CONNECTIONS];
+extern uint32_t Pending_dp_conn[MAX_PENDING_NEW_CONNECTIONS];
 
 // This is called when a game is started, so Directplay will be happy
 int dp_StartGame(char *gamename);
@@ -95,7 +95,7 @@ int dp_DirectPlayJoinGame(LPDPSESSIONDESC2 session);
 // the amount of buffer space you need
 // Otherwise, it will fill in the buffer with a bunch of null delimited
 // strings, with a double null at the end.
-int dp_GetModemChoices(char *buffer, unsigned long *size);
+int dp_GetModemChoices(char *buffer, LPDWORD size);
 
 // Register a DirectPlay lobby aware application
 // Use this so a directplay lobby provider such as zone.com can launch the game

--- a/linux/linux_fix.h
+++ b/linux/linux_fix.h
@@ -38,7 +38,6 @@ char *strupr(char *string);
 #if !defined(MAX_PATH)
 #define MAX_PATH _MAX_PATH
 #endif
-#define HANDLE int
 // _cdecl replacement
 #define __cdecl __attribute__((cdecl))
 // _stdcall replacement

--- a/networking/directplay.cpp
+++ b/networking/directplay.cpp
@@ -109,7 +109,7 @@ LPDPLCONNECTION lpdplconnection = NULL;
 // {915CE160-3125-11d2-BB3D-00104B27BFF0}
 static const GUID DPD3_GUID = {0x915ce160, 0x3125, 0x11d2, {0xbb, 0x3d, 0x0, 0x10, 0x4b, 0x27, 0xbf, 0xf0}};
 
-unsigned long Pending_dp_conn[MAX_PENDING_NEW_CONNECTIONS];
+uint32_t Pending_dp_conn[MAX_PENDING_NEW_CONNECTIONS];
 
 typedef struct _dpconnections {
   char name[100];
@@ -216,7 +216,7 @@ int dp_SelectDirectPlayConnection(char *name) {
 }
 
 int dp_InitDirectPlay(char *conn_name, void *parms, int num_elements) {
-  unsigned long dwAddressSize;
+  DWORD dwAddressSize;
   HRESULT hr;
   char *conn = conn_name;
   for (int i = 0; i < MAX_PENDING_NEW_CONNECTIONS; i++)
@@ -280,7 +280,7 @@ void dp_EndGame() {
 
 // This function gets called when a game is started, so Direcplay knows the title, and to listen
 int dp_StartGame(char *gamename) {
-  long hres;
+  HRESULT hres;
   DPNAME server_player;
   DPSESSIONDESC2 sessionDesc;
 
@@ -498,7 +498,7 @@ int dp_ListDirectPlayGames() {
 void dp_DirectPlayDispatch() {
   HRESULT hr;
   ubyte packet_data[32000];              // MAX_PACKET_SIZE+1];
-  unsigned long dwMsgBufferSize = 32000; // MAX_PACKET_SIZE;
+  DWORD dwMsgBufferSize = 32000; // MAX_PACKET_SIZE;
   DPID idFrom = 0;
   DPID idTo = 0;
   network_address from_addr;
@@ -588,7 +588,7 @@ void dp_DirectPlayDispatch() {
 int dp_DirectPlaySend(network_address *who_to, ubyte *data, int len, bool reliable) {
   DPID idTo;
   HRESULT hr;
-  unsigned long send_flags;
+  uint32_t send_flags;
   if ((!DP_active) || (!lpDirectPlay4A)) {
     mprintf((0, "Can't send DirectPlay message because DirectPlay isn't active!\n"));
     return 0;
@@ -838,7 +838,7 @@ BOOL FAR PASCAL EnumModemAddress(REFGUID lpguidDataType, DWORD dwDataSize, LPCVO
 // the amount of buffer space you need
 // Otherwise, it will fill in the buffer with a bunch of null delimited
 // strings, with a double null at the end.
-int dp_GetModemChoices(char *buffer, unsigned long *size) {
+int dp_GetModemChoices(char *buffer, LPDWORD size) {
   LPDIRECTPLAY4A lpTempDP4;
   HRESULT hr;
   void *connection = NULL;
@@ -975,7 +975,7 @@ void dp_RegisterLobbyApplication(char *appname, char *exefile, char *exepath, ch
 // Returns TRUE if the game was launched from a lobby
 bool dp_DidLobbyLaunchGame() {
   HRESULT hr;
-  unsigned long buffersize = sizeof(DPLCONNECTION);
+  DWORD buffersize = sizeof(DPLCONNECTION);
 
   Directplay_lobby_launched_game = false;
   if (lpDirectPlayLobby3A) {

--- a/networking/networking.cpp
+++ b/networking/networking.cpp
@@ -1957,7 +1957,7 @@ int nw_psnet_buffer_get_next(ubyte *data, int *length, network_address *from) {
 // functions to get the status of a RAS connection
 unsigned int psnet_ras_status() {
   int rval;
-  unsigned long size, num_connections, i;
+  DWORD size, num_connections, i;
   RASCONN rasbuffer[25];
   HINSTANCE ras_handle;
   unsigned long rasip = 0;
@@ -2012,7 +2012,7 @@ unsigned int psnet_ras_status() {
 
   for (i = 0; i < num_connections; i++) {
     RASCONNSTATUS status;
-    unsigned long size;
+    DWORD size;
 
     mprintf((0, "Connection %d:\n", i));
     mprintf((0, "Entry Name: %s\n", rasbuffer[i].szEntryName));

--- a/sndlib/ds3dlib.cpp
+++ b/sndlib/ds3dlib.cpp
@@ -242,7 +242,7 @@ DSSTREAM m_sb_info;
 char m_sound_device_name[256] = ""; // set by set sound card
 
 // Loads a sound buffer with data
-long LoadSoundData(LPDIRECTSOUNDBUFFER lp_dsb, char *sound_data_ptr, ulong total_bytes);
+HRESULT LoadSoundData(LPDIRECTSOUNDBUFFER lp_dsb, char *sound_data_ptr, DWORD total_bytes);
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1213,8 +1213,8 @@ bool win_llsSystem::StartStreaming(void) {
 }
 
 // Creates a 2d, 3d, or Primary direct sound buffer
-long win_llsSystem::CreateDSBuffer(int buffer_type, LPDIRECTSOUNDBUFFER *lp_lp_dsb, LPDIRECTSOUND3DBUFFER *lp_lp_dsb_3d,
-                                   ulong sound_bytes, ulong frequency, bool f_is_stereo, bool f_is_16_bit) {
+HRESULT win_llsSystem::CreateDSBuffer(int buffer_type, LPDIRECTSOUNDBUFFER *lp_lp_dsb, LPDIRECTSOUND3DBUFFER *lp_lp_dsb_3d,
+                                   DWORD sound_bytes, DWORD frequency, bool f_is_stereo, bool f_is_16_bit) {
   DSBUFFERDESC dsbd;
   tWAVEFORMATEX fmt;
   HRESULT result = DS_OK;
@@ -1885,7 +1885,7 @@ void win_llsSystem::StopSound(int sound_uid, unsigned char f_immediately) {
 }
 
 // Copies sound data from the external sound data block to an individual sound buffer
-long LoadSoundData(LPDIRECTSOUNDBUFFER lp_dsb, char *sound_data_ptr, ulong total_bytes) {
+HRESULT LoadSoundData(LPDIRECTSOUNDBUFFER lp_dsb, char *sound_data_ptr, DWORD total_bytes) {
   LPVOID ptr1, ptr2;
   DWORD len1, len2;
   HRESULT result;

--- a/sndlib/ds3dlib.h
+++ b/sndlib/ds3dlib.h
@@ -218,7 +218,7 @@
 #ifndef __ds3dlib_h__
 #define __ds3dlib_h__
 
-// #include <windows.h>
+#include <windows.h>
 // #include <mmsystem.h>		// Multi-media system support
 // #include "dsound.h"			// Direct sound header file
 
@@ -283,8 +283,8 @@ private:
   friend void __cdecl LoopStreamTimer(void *user_ptr);
 
   // Creates a sound buffer
-  long CreateDSBuffer(int buffer_type, LPDIRECTSOUNDBUFFER *lp_lp_dsb, LPDIRECTSOUND3DBUFFER *lp_lp_dsb_3d,
-                      ulong sound_bytes, ulong frequency, bool f_is_stereo, bool f_is_16_bit);
+  HRESULT CreateDSBuffer(int buffer_type, LPDIRECTSOUNDBUFFER *lp_lp_dsb, LPDIRECTSOUND3DBUFFER *lp_lp_dsb_3d,
+                      DWORD sound_bytes, DWORD frequency, bool f_is_stereo, bool f_is_16_bit);
 
   // Finds a free slot for a new sound, slot_uid is an SBID_xxx value.
 #ifdef _DEBUG
@@ -331,7 +331,7 @@ private:
   char m_sound_quality;
 
   // muted looped sound system
-  longlong m_timer_last_frametime;
+  int64_t m_timer_last_frametime;
   float m_cache_stress_timer;
 
 // clean interface


### PR DESCRIPTION
For whatever reason they decided to switch a bunch of Windows types to their underlying types which causes problems when replacing possibly problematic 32-bit long types. This restores the use of the Windows defined types.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
This is a type refactor, it doesn't impact how the code behaves.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [ ] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
Presently no overlap with PR #354
