### PR TITLE
Fix libmve bug

### DIFF
--- a/libmve/mveasm.cpp
+++ b/libmve/mveasm.cpp
@@ -15,7 +15,6 @@
 ** attempt to derive source code of this material.
 **
 */
-#include "pstypes.h"
 #include "mvelibl.h"
 #include "mvelibi.h"
 #include <string.h>
@@ -2104,8 +2103,8 @@ void DECOMP_BODY(bool HI_COLOR_FLAG, const unsigned char *&comp, unsigned int _x
           size_t amt = sizeof(unsigned int) * 2 * HI_COLOR_SCALE;
           // memcpy( this_tbuf, compData, amt );
           for (unsigned int ii = 0; ii < (amt / 2); ii++) {
-            unsigned short *destword = (unsigned short *)this_tbuf[ii];
-            unsigned short *srcword = (unsigned short *)compData[ii];
+            unsigned short *destword = (unsigned short *)&this_tbuf[ii];
+            unsigned short *srcword = (unsigned short *)&compData[ii];
             *destword = IntelSwapper(*srcword);
           }
           compData += amt;
@@ -2151,8 +2150,8 @@ void DECOMP_BODY(bool HI_COLOR_FLAG, const unsigned char *&comp, unsigned int _x
           size_t amt = sizeof(unsigned int) * 2 * HI_COLOR_SCALE;
           // memcpy( this_tbuf, src, amt );
           for (unsigned int ii = 0; ii < (amt / 2); ii++) {
-            unsigned short *destword = (unsigned short *)this_tbuf[ii];
-            unsigned short *srcword = (unsigned short *)src[ii];
+            unsigned short *destword = (unsigned short *)&this_tbuf[ii];
+            unsigned short *srcword = (unsigned short *)&src[ii];
             *destword = IntelSwapper(*srcword);
           }
           src += amt + nf_new_line;
@@ -2212,8 +2211,8 @@ void DECOMP_CHG_BODY(bool HI_COLOR_FLAG, const unsigned short *&chgs, const unsi
           // TODO: Do these bytes need swapping? Is this data shorts?
           // memcpy( this_tbuf, compData, amt );
           for (unsigned int ii = 0; ii < (amt / 2); ii++) {
-            unsigned short *dest = (unsigned short *)this_tbuf[ii];
-            unsigned short *src = (unsigned short *)compData[ii];
+            unsigned short *dest = (unsigned short *)&this_tbuf[ii];
+            unsigned short *src = (unsigned short *)&compData[ii];
             *dest = IntelSwapper(*src);
           }
           compData += amt;
@@ -2269,8 +2268,8 @@ void DECOMP_CHG_BODY(bool HI_COLOR_FLAG, const unsigned short *&chgs, const unsi
           size_t amt = sizeof(unsigned int) * 2 * HI_COLOR_SCALE;
           // memcpy( this_tbuf, src, amt );
           for (unsigned int ii = 0; ii < (amt / 2); ii++) {
-            unsigned short *destword = (unsigned short *)this_tbuf[ii];
-            unsigned short *srcword = (unsigned short *)src[ii];
+            unsigned short *destword = (unsigned short *)&this_tbuf[ii];
+            unsigned short *srcword = (unsigned short *)&src[ii];
             *destword = IntelSwapper(*srcword);
           }
           src += amt + nf_new_line;


### PR DESCRIPTION
Correctly dereference the arrays so you don't actually convert the value at the array index to a pointer.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
I'm not sure how this got messed up.  Anyway, this is the fix which also prevents annoying warnings. Does libmve work? I have no idea but if nothing else, I fixed a warning.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [ ] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.