### PR TITLE
Fixed missing initialization of m_MsgFn array in ctor

### DIFF
--- a/lib/win/win32app.h
+++ b/lib/win/win32app.h
@@ -80,7 +80,7 @@
 #ifndef WIN32APP_H
 #define WIN32APP_H
 
-#define MAX_MSG_FUNCTIONS 64
+#include <array>
 
 /*	Basic Application Win32 data types */
 typedef unsigned int HWnd;
@@ -139,12 +139,11 @@ private:
 #endif
   bool m_WasCreated; // Tells us if this app created the window handle or not.
 
-  int m_NumMsgFn; // Number of message functions.
-
-  struct { // assign functions to messages.
+  struct MessageFunction { // assign functions to messages.
     unsigned msg;
     tOEWin32MsgCallback fn;
-  } m_MsgFn[MAX_MSG_FUNCTIONS];
+  };
+  std::array<MessageFunction, 64> m_MsgFn;
 
   bool m_NTFlag; // Are we in NT?
 

--- a/win32/winapp.cpp
+++ b/win32/winapp.cpp
@@ -201,7 +201,7 @@ bool oeWin32Application::first_time = true;
 LRESULT WINAPI MyWndProc(HWND hWnd, UINT msg, UINT wParam, LPARAM lParam);
 
 //	Creates the window handle and instance
-oeWin32Application::oeWin32Application(const char *name, unsigned flags, HInstance hinst) : oeApplication() {
+oeWin32Application::oeWin32Application(const char *name, unsigned flags, HInstance hinst) : oeApplication(), m_MsgFn{} {
   WNDCLASS wc;
   RECT rect;
 
@@ -544,18 +544,15 @@ int oeWin32Application::WndProc(HWnd hwnd, unsigned msg, unsigned wParam, long l
 
 //	These functions allow you to add message handlers.
 bool oeWin32Application::add_handler(unsigned msg, tOEWin32MsgCallback fn) {
-  int i = 0;
-
   //	search for redundant callbacks.
-  for (i = 0; i < MAX_MSG_FUNCTIONS; i++) {
-    if (m_MsgFn[i].msg == msg && m_MsgFn[i].fn == fn)
+  for (const MessageFunction &rMsgFn : m_MsgFn)
+    if (rMsgFn.msg == msg && rMsgFn.fn == fn)
       return true;
-  }
 
-  for (i = 0; i < MAX_MSG_FUNCTIONS; i++) {
-    if (m_MsgFn[i].fn == NULL) {
-      m_MsgFn[i].msg = msg;
-      m_MsgFn[i].fn = fn;
+  for (MessageFunction &rMsgFn : m_MsgFn) {
+    if (rMsgFn.fn == nullptr) {
+      rMsgFn.msg = msg;
+      rMsgFn.fn = fn;
       return true;
     }
   }
@@ -567,14 +564,12 @@ bool oeWin32Application::add_handler(unsigned msg, tOEWin32MsgCallback fn) {
 
 // These functions remove a handler
 bool oeWin32Application::remove_handler(unsigned msg, tOEWin32MsgCallback fn) {
-  int i;
-
   if (!fn)
     DebugBreak();
 
-  for (i = 0; i < MAX_MSG_FUNCTIONS; i++) {
-    if (msg == m_MsgFn[i].msg && m_MsgFn[i].fn == fn) {
-      m_MsgFn[i].fn = NULL;
+  for (MessageFunction &rMsgFn : m_MsgFn) {
+    if (msg == rMsgFn.msg && rMsgFn.fn == fn) {
+      rMsgFn.fn = nullptr;
       return true;
     }
   }
@@ -584,23 +579,19 @@ bool oeWin32Application::remove_handler(unsigned msg, tOEWin32MsgCallback fn) {
 
 // Run handler for message (added by add_handler)
 bool oeWin32Application::run_handler(HWnd wnd, unsigned msg, unsigned wParam, long lParam) {
-  int j;
   //	run user-defined message handlers
   // the guess here is that any callback that returns a 0, will not want to handle the window's WndProc function.
-  for (j = 0; j < MAX_MSG_FUNCTIONS; j++)
-    if (msg == m_MsgFn[j].msg && m_MsgFn[j].fn) {
-      if (!(*m_MsgFn[j].fn)(wnd, msg, wParam, lParam))
+  for (const MessageFunction &rMsgFn : m_MsgFn)
+    if (msg == rMsgFn.msg && rMsgFn.fn)
+      if (!(*rMsgFn.fn)(wnd, msg, wParam, lParam))
         return false;
-    }
 
   return true;
 }
 
 void oeWin32Application::clear_handlers() {
-  int j;
-
-  for (j = 0; j < MAX_MSG_FUNCTIONS; j++)
-    m_MsgFn[j].fn = NULL;
+  for (MessageFunction &rMsgFn : m_MsgFn)
+    rMsgFn.fn = nullptr;
 }
 
 void oeWin32Application::delay(float secs) {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
The array `oeWin32Application::m_MsgFn` was never initialized and therefor calls to `oeWin32Application::add_handler(...)` might fail to find an empty slot in that array because of the uninitialized memory.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
This might fix the IO init problem mentioned in https://github.com/DescentDevelopers/Descent3/issues/217#issuecomment-2104805603. Because the mouse code might fail to add the RawInputHandler at https://github.com/DescentDevelopers/Descent3/blob/56e61275ce3209d2d69b895d5809e4089def0851/ddio_win/winmouse.cpp#L452

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
