### PR TITLE
Fix cfile warnings

### DIFF
--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -105,7 +105,7 @@ static CFILE *open_file_in_lib(const char *filename);
 // Returns: 0 if error, else library handle that can be used to close the library
 int cf_OpenLibrary(const char *libname) {
   FILE *fp;
-  int i;
+  size_t i;
   uint32_t offset;
   static int first_time = 1;
   tHogHeader header;
@@ -954,7 +954,7 @@ double cf_ReadDouble(CFILE *cfp) {
 // Does not generate an exception on EOF
 int cf_ReadString(char *buf, size_t n, CFILE *cfp) {
   int c;
-  int count;
+  size_t count;
   char *bp;
   if (n == 0)
     return -1;
@@ -1075,8 +1075,8 @@ bool cf_CopyFile(char *dest, const char *src, int copytime) {
     cfclose(infile);
     return false;
   }
-  int progress = 0;
-  int readcount = 0;
+  size_t progress = 0;
+  size_t readcount = 0;
 #define COPY_CHUNK_SIZE 5000
   ubyte copybuf[COPY_CHUNK_SIZE];
   while (!cfeof(infile)) {
@@ -1111,8 +1111,9 @@ void cf_CopyFileTime(char *dest, const char *src) { ddio_CopyFileTime(dest, src)
 
 // Changes a files attributes (ie read/write only)
 void cf_ChangeFileAttributes(const char *name, int attr) {
-  if (_chmod(name, attr) == -1)
+  if (_chmod(name, attr) == -1) {
     Int3(); // Get Jason or Matt, file not found!
+  }
 }
 
 //	rewinds cfile position
@@ -1192,7 +1193,7 @@ unsigned int cf_GetfileCRC(char *src) {
 
 char cfile_search_wildcard[256];
 std::shared_ptr<library> cfile_search_library;
-int cfile_search_curr_index = 0;
+size_t cfile_search_curr_index = 0;
 bool cfile_search_ispattern = false;
 //	the following cf_LibraryFind function are similar to the ddio_Find functions as they look
 //	for files that match the wildcard passed in, however, this is to be used for hog files.


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Converting unsigned to signed int is illegal. Use size_t instead. Resolves compiler warnings.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.