### PR TITLE
Fix cross-compiling "int $3" build error

### DIFF
--- a/ddebug/windebug.cpp
+++ b/ddebug/windebug.cpp
@@ -189,7 +189,7 @@
  */
 
 #include "d3_version.h"
-#include "Debug.h"
+#include "debug.h"
 #include "mono.h"
 
 #include <windows.h>

--- a/lib/pserror.h
+++ b/lib/pserror.h
@@ -232,7 +232,7 @@ static inline void SetDebugBreakHandlers(void (*stop)(), void (*resume)()) {
     if (_heapchk() != _HEAPOK)                                                                                         \
       Int3();                                                                                                          \
   } while (0)
-#elif defined(LINUX)
+#elif defined(__LINUX__)
 #include "SDL.h"
 // For some reason Linux doesn't like the \ continuation character, so I have to uglify this
 #define DEBUG_BREAK()                                                                                                  \

--- a/libmve/mveasm.cpp
+++ b/libmve/mveasm.cpp
@@ -16,6 +16,7 @@
 **
 */
 #include "pstypes.h"
+#include "pserror.h"
 #include "mvelibl.h"
 #include "mvelibi.h"
 #include <string.h>
@@ -2053,20 +2054,6 @@ void gfxVres(unsigned char misc, unsigned char *crtc);
 void MVE_gfxWaitRetrace(int state);
 void MVE_gfxSetSplit(unsigned line);
 
-#if defined(__LINUX__)
-
-#if !defined(MACOSXPPC) && !defined(__aarch64__)
-
-#define int3 __asm__ __volatile__("int $3");
-#else
-#define int3
-#endif
-#else
-#define int3                                                                                                           \
-  __asm { int 3}                                                                                                        \
-  ;
-#endif
-
 void DECOMP_BODY(bool HI_COLOR_FLAG, const unsigned char *&comp, unsigned int _x, unsigned int _y, unsigned int _w,
                  unsigned int _h) {
   unsigned int HI_COLOR_SCALE = (HI_COLOR_FLAG) ? 2 : 1;
@@ -2322,37 +2309,37 @@ void nfDecompChg(const unsigned short *chgs, const unsigned short *parms, const 
   DECOMP_CHG_BODY(false, chgs, parms, comp, x, y, w, h);
 }
 
-void nfPkDecompH(unsigned char *ops, unsigned char *comp, unsigned x, unsigned y, unsigned w, unsigned h) { int3 }
-void nfPkDecompD(unsigned char *ops, unsigned char *comp, unsigned x, unsigned y, unsigned w, unsigned h) { int3 }
+void nfPkDecompH(unsigned char *ops, unsigned char *comp, unsigned x, unsigned y, unsigned w, unsigned h) { Int3(); }
+void nfPkDecompD(unsigned char *ops, unsigned char *comp, unsigned x, unsigned y, unsigned w, unsigned h) { Int3(); }
 void mve_ShowFrameField(unsigned char *buf, unsigned bufw, unsigned bufh, unsigned sx, unsigned sy, unsigned w,
                         unsigned h, unsigned dstx, unsigned dsty, unsigned field) {
-  int3
+  Int3();
 }
 void mve_ShowFrameFieldHi(unsigned char *buf, unsigned bufw, unsigned bufh, unsigned sx, unsigned sy, unsigned w,
                           unsigned h, unsigned dstx, unsigned dsty, unsigned field) {
-  int3
+  Int3();
 }
 void mve_sfShowFrameChg(bool prvbuf, unsigned x, unsigned y, unsigned w, unsigned h, unsigned short *chgs,
                         unsigned dstx, unsigned dsty) {
-  int3
+  Int3();
 }
 void mve_sfHiColorShowFrameChg(bool prvbuf, unsigned x, unsigned y, unsigned w, unsigned h, unsigned short *chgs,
                                unsigned dstx, unsigned dsty) {
-  int3
+  Int3();
 }
 void mve_sfPkShowFrameChg(bool prvbuf, unsigned x, unsigned y, unsigned w, unsigned h, unsigned char *ops,
                           unsigned dstx, unsigned dsty) {
-  int3
+  Int3();
 }
 void mve_sfPkHiColorShowFrameChg(bool prvbuf, unsigned x, unsigned y, unsigned w, unsigned h, unsigned char *ops,
                                  unsigned dstx, unsigned dsty) {
-  int3
+  Int3();
 }
-void MVE_SetPalette(unsigned char *p, unsigned start, unsigned count) { int3 }
-void palLoadCompPalette(unsigned char *buf) { int3 }
-void gfxMode(unsigned mode) { int3 }
-void gfxLoadCrtc(unsigned char *crtc, unsigned char chain4, unsigned char res) { int3 }
-void gfxGetCrtc(unsigned char *crtc) { int3 }
-void gfxVres(unsigned char misc, unsigned char *crtc) { int3 }
-void MVE_gfxWaitRetrace(int state) { int3 }
-void MVE_gfxSetSplit(unsigned line) { int3 }
+void MVE_SetPalette(unsigned char *p, unsigned start, unsigned count) { Int3(); }
+void palLoadCompPalette(unsigned char *buf) { Int3(); }
+void gfxMode(unsigned mode) { Int3(); }
+void gfxLoadCrtc(unsigned char *crtc, unsigned char chain4, unsigned char res) { Int3(); }
+void gfxGetCrtc(unsigned char *crtc) { Int3(); }
+void gfxVres(unsigned char misc, unsigned char *crtc) { Int3(); }
+void MVE_gfxWaitRetrace(int state) { Int3(); }
+void MVE_gfxSetSplit(unsigned line) { Int3(); }


### PR DESCRIPTION
`libmve/mveasm.cpp` was using a macro to invoke `int $3` instead of using the portable `Int3()` macro in `pserror.h`.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
Replace non-portable macro `int3` with the portable macro `Int3()` from `pserror.h`.
Fixes #311

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
I've cross-compiled a the libmve module but not the rest of the code because I don't have a port of SDL2 for that.