### PR TITLE
Update CMakePresets.json - Add Win64 preset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,15 @@ jobs:
       matrix:
         os:
           - runner: windows-latest
-            preset: win
+            preset: win32
             cc: cl
             cxx: cl
             name: Windows-x86
+          - runner: windows-latest
+            preset: win64
+            cc: cl
+            cxx: cl
+            name: Windows-x64
           - runner: macos-12 # This is supposed to be Intel for now, and what macos-latest is defaulting to for some reason (as of 04/2024)
             preset: mac
             cc: cc

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,7 +7,7 @@
 			"binaryDir": "${sourceDir}/builds/${presetName}"
 		},
 		{
-			"name": "win",
+			"name": "win32",
 			"inherits": "defaults",
 			"generator": "Visual Studio 17 2022",
 			"condition": {
@@ -16,6 +16,18 @@
 				"rhs": "Windows"
 			},
 			"architecture": "Win32",
+			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+		},
+		{
+			"name": "win64",
+			"inherits": "defaults",
+			"generator": "Visual Studio 17 2022",
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			},
+			"architecture": "x64",
 			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 		},
 		{
@@ -41,8 +53,12 @@
 	],
 	"buildPresets": [
 		{
-			"name": "win",
-			"configurePreset": "win"
+			"name": "win32",
+			"configurePreset": "win32"
+		},
+		{
+			"name": "win64",
+			"configurePreset": "win64"
 		},
 		{
 			"name": "mac",
@@ -62,10 +78,16 @@
 			}
 		},
 		{
-			"name": "win",
+			"name": "win32",
 			"inherits": "defaults",
-			"description": "Testing under Windows",
-			"configurePreset": "win"
+			"description": "Testing under Windows x86",
+			"configurePreset": "win32"
+		},
+		{
+			"name": "win64",
+			"inherits": "defaults",
+			"description": "Testing under Windows x64",
+			"configurePreset": "win64"
 		},
 		{
 			"name": "mac",


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
This pull modifies the `win` preset to `win32` and adds the `win64` preset.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
Important note: 32bit savegames are incompatible with 64bit builds for the moment.
