### PR TITLE
Remove unnecessary `find_package(OpenGL)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,6 @@ if(UNIX)
 
   find_package(SDL2 REQUIRED)
   find_package(Curses REQUIRED)
-  find_package(OpenGL REQUIRED)
   # Some versions of the SDL2 find_package set SDL2_INCLUDE_DIR and some set a plural SDL2_INCLUDE_DIRS. Check both.
   message("SDL2 Include Dir is ${SDL2_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS}")
 endif()


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Before this change, `CMakeLists.txt` would run `find_package(OpenGL)`, but it would never use [any of the targets or variables that calling `find_package(OpenGL)` produces][1]. As a result, the call to `find_package(OpenGL)` didn’t really do anything.

[1]: https://cmake.org/cmake/help/latest/module/FindOpenGL.html

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
