### PR TITLE
Fix -nomousegrab flag

### DIFF
--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -597,7 +597,7 @@ int opengl_Setup(oeApplication *app, int *width, int *height) {
     return 0;
   }
 
-  if (!FindArg("-nomousecap")) {
+  if (!FindArg("-nomousegrab")) {
     ddio_mouseGrabbed = true;
   }
 


### PR DESCRIPTION
HardwareOpenGL incorrectly has "-nomousecap" instead of "-nomousegrab"


- [x] Runtime changes
  - [x] Input changes

### Description
I ran into the issue where "-nomousegrab" wasn't working and found the cause. Very simple fix.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
