### PR TITLE
Code cleanup: Add one macro, remove five others

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,15 +95,15 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   message("Building for Linux")
-  add_compile_definitions(__LINUX__ LINUX _MAX_PATH=260 _MAX_FNAME=256 _REENRANT __32BIT__ HAVEALLOCA_H _USE_OGL_ACTIVE_TEXTURES)
+  add_compile_definitions(__LINUX__ _USE_OGL_ACTIVE_TEXTURES PRIMARY_HOG=\"d3-linux.hog\")
   set(PLATFORM_INCLUDES "lib/linux" ${SDL2_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS})
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   message("Building for MAC OSX")
-  add_compile_definitions(__LINUX__ LINUX _MAX_PATH=260 _MAX_FNAME=256 _REENRANT MACOSX=1 _USE_OGL_ACTIVE_TEXTURES)
+  add_compile_definitions(__LINUX__ MACOSX=1 _USE_OGL_ACTIVE_TEXTURES PRIMARY_HOG=\"d3-osx.hog\")
   set(PLATFORM_INCLUDES "lib/linux" ${SDL2_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS})
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   # Windows.h defines to avoid as many issues as possible.
-  add_compile_definitions(WIN32_LEAN_AND_MEAN NOMINMAX NODRAWTEXT NOBITMAP NOMCX NOSERVICE NOHELP
+  add_compile_definitions(WIN32_LEAN_AND_MEAN NOMINMAX NODRAWTEXT NOBITMAP NOMCX NOSERVICE NOHELP PRIMARY_HOG=\"d3-win.hog\"
           #[[NOGDI]] # We need GDI for now, enable when GDI is actually not needed (or when all windows.h mentions are gone)
   )
 

--- a/Descent3/ConfigItem.h
+++ b/Descent3/ConfigItem.h
@@ -58,7 +58,7 @@
 
 #include "newui.h"
 
-#if defined(LINUX)
+#if defined(__LINUX__)
 void CIListBoxCallback(int ID, void *);
 void CISliderCallback(int ID, void *);
 #endif

--- a/Descent3/dedicated_server.cpp
+++ b/Descent3/dedicated_server.cpp
@@ -881,7 +881,7 @@ void ListenDedicatedSocket(void) {
         shutdown(incoming_socket, 2);
 #if defined(WIN32)
         closesocket(incoming_socket);
-#elif defined(__LINUX__)
+#else
         close(incoming_socket);
 #endif
         return;
@@ -942,7 +942,7 @@ dedicated_socket *DedicatedLogoutTelnet(dedicated_socket *conn) {
   shutdown(conn->sock, 2);
 #if defined(WIN32)
   closesocket(conn->sock);
-#elif defined(__LINUX__)
+#else
   close(conn->sock);
 #endif
 
@@ -1030,7 +1030,7 @@ void DedicatedReadTelnet(void) {
               shutdown(conn->sock, 2);
 #if defined(WIN32)
               closesocket(conn->sock);
-#elif defined(__LINUX__)
+#else
               close(conn->sock);
 #endif
             }

--- a/Descent3/descent.cpp
+++ b/Descent3/descent.cpp
@@ -781,15 +781,12 @@ const char *GetCDVolume(int cd_num) {
       char message_txt[50];
       snprintf(message_txt, sizeof(message_txt), TXT_CDPROMPT, cd_num);
       // We need a background drawn!
-#if defined(LINUX)
+
       void (*ui_cb)() = GetUICallback();
-#else
-      void *ui_cb = GetUICallback();
-#endif
       if (ui_cb == NULL)
         SetUICallback(RenderBlankScreen);
       int res = DoMessageBox(PRODUCT_NAME, message_txt, MSGBOX_OKCANCEL, UICOL_WINDOW_TITLE, UICOL_TEXT_NORMAL);
-      SetUICallback((void (*)(void))ui_cb);
+      SetUICallback(ui_cb);
       //
       if (res == 0) {
         return NULL;

--- a/Descent3/gamesave.cpp
+++ b/Descent3/gamesave.cpp
@@ -507,7 +507,7 @@ typedef struct tLoadGameDialogData {
   chunked_bitmap chunk;
 } tLoadGameDialogData;
 
-#if defined(LINUX)
+#if defined(__LINUX__)
 void LoadGameDialogCB(newuiTiledWindow *wnd, void *data)
 #else
 void __cdecl LoadGameDialogCB(newuiTiledWindow *wnd, void *data)

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1531,15 +1531,7 @@ void InitIOSystems(bool editor) {
 
   // last library opened is the first to be searched for dynamic libs, so put
   // this one at the end to find our newly build script libraries first
-#ifdef __LINUX__
-#ifndef MACOSX
-  ddio_MakePath(fullname, LocalD3Dir, "d3-linux.hog", NULL);
-#else
-  ddio_MakePath(fullname, LocalD3Dir, "d3-osx.hog", NULL);
-#endif
-#elif _WIN32
-  ddio_MakePath(fullname, LocalD3Dir, "d3-win.hog", NULL);
-#endif
+  ddio_MakePath(fullname, LocalD3Dir, PRIMARY_HOG, NULL);
   sys_hid = cf_OpenLibrary(fullname);
 
   // Check to see if there is a -mission command line option

--- a/Descent3/matcen.cpp
+++ b/Descent3/matcen.cpp
@@ -1904,7 +1904,7 @@ void InitMatcens() {
   atexit(DestroyAllMatcens);
 }
 
-#if defined(LINUX)
+#if defined(__LINUX__)
 void DestroyAllMatcens()
 #else
 void __cdecl DestroyAllMatcens()

--- a/Descent3/trigger.cpp
+++ b/Descent3/trigger.cpp
@@ -121,10 +121,7 @@
 #include "osiris_dll.h"
 #include "levelgoal.h"
 
-#ifdef LINUX
 #include <stdlib.h>
-#endif
-
 #include <string.h>
 
 // The maximum number of triggers that can be in the mine

--- a/lib/forcefeedback.h
+++ b/lib/forcefeedback.h
@@ -86,8 +86,7 @@
 #define FF_DEGREES DI_DEGREES
 #define FF_NOMINALMAX DI_FFNOMINALMAX
 #define FF_SECONDS DI_SECONDS
-#elif defined(__LINUX__)
-// LINUX
+#else
 #define FF_DEGREES 360      // fake value
 #define FF_NOMINALMAX 10000 // fake value
 #define FF_SECONDS 1000     // fake value

--- a/lib/pserror.h
+++ b/lib/pserror.h
@@ -232,7 +232,7 @@ static inline void SetDebugBreakHandlers(void (*stop)(), void (*resume)()) {
     if (_heapchk() != _HEAPOK)                                                                                         \
       Int3();                                                                                                          \
   } while (0)
-#elif defined(LINUX)
+#elif defined(__LINUX__)
 #include "SDL.h"
 // For some reason Linux doesn't like the \ continuation character, so I have to uglify this
 #define DEBUG_BREAK()                                                                                                  \

--- a/lib/pstypes.h
+++ b/lib/pstypes.h
@@ -22,6 +22,10 @@
 #include <cstdlib>
 #include <cstdint>
 
+#ifdef __LINUX__
+#include "linux_fix.h"
+#endif
+
 // define unsigned types;
 typedef uint8_t uint8_t;
 typedef int8_t int8_t;

--- a/mem/mem.cpp
+++ b/mem/mem.cpp
@@ -188,7 +188,7 @@
  *
  * $NoKeywords: $
  */
-#ifndef LINUX
+#ifndef __LINUX__
 #include <new.h>
 #endif
 #if defined(MACOSX)

--- a/sndlib/sndrender.cpp
+++ b/sndlib/sndrender.cpp
@@ -49,9 +49,7 @@
  *
  */
 
-#ifdef LINUX
 #include <cstring>
-#endif
 
 #include "hlsoundlib.h"
 #include "ddsndgeometry.h"


### PR DESCRIPTION
### Description
- Add macro PRIMARY_HOG to define the hardcoded hog filename to load.
- Replace instances of `LINUX` with `__LINUX__`
- Replace `#elif __LINUX__` with `#else` because otherwise it omits code completely.
- Remove these macros entirely because they are (now) unused
  - `LINUX`
  - `_REENRANT`
  - `__32BIT__`
- Removed from primary CMakeFile.txt because they defined in `linux_fix.h`
  - `_MAX_PATH=260`
  - `_MAX_FNAME=256`

## Pull Request Type
- [x] Build and Dependency changes

### Checklist
- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.