### PR TITLE
Only close SDL audio if it's open.

### DIFF
--- a/sndlib/sdlsound.cpp
+++ b/sndlib/sdlsound.cpp
@@ -133,8 +133,10 @@ bool lnxsound::GetDeviceSettings(SDL_AudioDeviceID *device, uint32_t *freq, uint
 
 // Cleans up after the Sound Library
 void lnxsound::DestroySoundLib() {
-  SDL_CloseAudioDevice(sound_device);
-  sound_device = 0;
+  if (sound_device) {
+    SDL_CloseAudioDevice(sound_device);
+    sound_device = 0;
+  }
 }
 
 // Locks and unlocks sounds (used when changing play_info data)


### PR DESCRIPTION
### Description
There wasn't anything preventing D3 from trying to close an invalid device id. This is simple check to ensure that `sound_device` actually contained a valid value.

## Pull Request Type
- [x] Runtime changes
  - [x] Audio changes