### PR TITLE
Windows CMake preset: use ninja generator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os.runner }}, ${{ matrix.os.cxx }}, ${{ matrix.build_type }}
+    name: ${{ matrix.os.name }}, ${{ matrix.build_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +72,15 @@ jobs:
           sudo apt update
           sudo apt install -y --no-install-recommends \
             ninja-build cmake g++ libgtest-dev libsdl2-dev zlib1g-dev libspdlog-dev
+
+      - name: Install Windows dependencies
+        if: ${{ matrix.os.runner == 'windows-latest' }}
+        run: choco install ninja
+      
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ matrix.os.runner == 'windows-latest' }}
+        with:
+           arch: ${{ matrix.os.preset }}
 
       - name: Configure CMake
         env:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,25 +9,37 @@
 		{
 			"name": "win32",
 			"inherits": "defaults",
-			"generator": "Visual Studio 17 2022",
+			"generator": "Ninja Multi-Config",
 			"condition": {
 				"type": "equals",
 				"lhs": "${hostSystemName}",
 				"rhs": "Windows"
 			},
-			"architecture": "Win32",
+			"architecture": {
+				"strategy": "external",
+				"value": "x86"
+			},
+			"cacheVariables": {
+				"VCPKG_TARGET_TRIPLET": "x86-windows"
+			},
 			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 		},
 		{
 			"name": "win64",
 			"inherits": "defaults",
-			"generator": "Visual Studio 17 2022",
+			"generator": "Ninja Multi-Config",
 			"condition": {
 				"type": "equals",
 				"lhs": "${hostSystemName}",
 				"rhs": "Windows"
 			},
-			"architecture": "x64",
+			"cacheVariables": {
+				"VCPKG_TARGET_TRIPLET": "x64-windows"
+			},
+			"architecture": {
+				"strategy": "external",
+				"value": "x64"
+			},
 			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 		},
 		{

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ setx VCPKG_ROOT="C:\path\to\vcpkg"
 setx PATH=%VCPKG_ROOT%;%PATH%
 ```
 
-Build Descent 3:
+Build Descent 3 using the "x86 native tools command prompt"
 ```sh
-cmake --preset win -D ENABLE_LOGGER=[ON|OFF]
-cmake --build --preset win --config [Debug|Release]
+cmake --preset win32 -D ENABLE_LOGGER=[ON|OFF]
+cmake --build --preset win32 --config [Debug|Release]
 ```
 
 #### Building - MacOS


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Use the Ninja CMake generator on Windows instead of the Visual Studio one. Ninja provides better build output, and handles multi-process builds much better than the previous build system. This also makes Windows on par with the other OSes already using it.

This PR also renames the Github Windows jobs, that had the same name for x86 and x64

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

#421 
