### PR TITLE
Create new 'win' preset for Ninja (native) builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os.runner }}, ${{ matrix.os.cxx }}, ${{ matrix.build_type }}
+    name: ${{ matrix.os.name }}, ${{ matrix.build_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,6 +31,11 @@ jobs:
             cc: cl
             cxx: cl
             name: Windows-x64
+          - runner: windows-latest
+            preset: win
+            cc: cl
+            cxx: cl
+            name: Windows-Ninja
           - runner: macos-12 # This is supposed to be Intel for now, and what macos-latest is defaulting to for some reason (as of 04/2024)
             preset: mac
             cc: cc
@@ -72,6 +77,13 @@ jobs:
           sudo apt update
           sudo apt install -y --no-install-recommends \
             ninja-build cmake g++ libgtest-dev libsdl2-dev zlib1g-dev libspdlog-dev
+
+      - name: Install Windows dependencies
+        if: ${{ matrix.os.preset == 'win' }}
+        run: choco install ninja
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ matrix.os.preset == 'win' }}
 
       - name: Configure CMake
         env:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,36 +4,42 @@
 		{
 			"name": "defaults",
 			"hidden": true,
+			"generator": "Ninja Multi-Config",
 			"binaryDir": "${sourceDir}/builds/${presetName}"
 		},
 		{
-			"name": "win32",
+			"name": "win-base",
+			"hidden": true,
 			"inherits": "defaults",
-			"generator": "Visual Studio 17 2022",
+			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
 			"condition": {
 				"type": "equals",
 				"lhs": "${hostSystemName}",
 				"rhs": "Windows"
-			},
-			"architecture": "Win32",
-			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+			}
+		},
+		{
+			"name": "vs-base",
+			"inherits": "win-base",
+			"generator": "Visual Studio 17 2022"
+		},
+		{
+			"name": "win32",
+			"inherits": "vs-base",
+			"architecture": "Win32"
 		},
 		{
 			"name": "win64",
-			"inherits": "defaults",
-			"generator": "Visual Studio 17 2022",
-			"condition": {
-				"type": "equals",
-				"lhs": "${hostSystemName}",
-				"rhs": "Windows"
-			},
-			"architecture": "x64",
-			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+			"inherits": "vs-base",
+			"architecture": "x64"
+		},
+		{
+			"name": "win",
+			"inherits": "win-base"
 		},
 		{
 			"name": "mac",
 			"inherits": "defaults",
-			"generator": "Ninja Multi-Config",
 			"condition": {
 				"type": "equals",
 				"lhs": "${hostSystemName}",
@@ -43,7 +49,6 @@
 		{
 			"name": "linux",
 			"inherits": "defaults",
-			"generator": "Ninja Multi-Config",
 			"condition": {
 				"type": "equals",
 				"lhs": "${hostSystemName}",
@@ -59,6 +64,10 @@
 		{
 			"name": "win64",
 			"configurePreset": "win64"
+		},
+		{
+			"name": "win",
+			"configurePreset": "win"
 		},
 		{
 			"name": "mac",
@@ -88,6 +97,12 @@
 			"inherits": "defaults",
 			"description": "Testing under Windows x64",
 			"configurePreset": "win64"
+		},
+		{
+			"name": "win",
+			"inherits": "defaults",
+			"description": "Testing under Windows (native arch)",
+			"configurePreset": "win"
 		},
 		{
 			"name": "mac",


### PR DESCRIPTION
Keep win32 and win64 using MSBuild; do not add build parallelism (it apparently causes races)

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
