### PR TITLE
Fixed failing MSVC build

### DIFF
--- a/Descent3/CMakeLists.txt
+++ b/Descent3/CMakeLists.txt
@@ -310,6 +310,7 @@ if(BUILD_TESTING)
 endif()
 
 add_custom_target(LicenseFiles
+  COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:Descent3>
   COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/LICENSE" $<TARGET_FILE_DIR:Descent3>
   COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/third_party_licenses" "$<TARGET_FILE_DIR:Descent3>/Third-party licenses"
   COMMENT "Create license files"


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
When starting from a completely new/empty build directory where `$<TARGET_FILE_DIR:Descent3>` doesn't exist yet, the copy command for `LICENSE` will create a **file** named `Debug` or `Release`, depending on the current configuration, in the Descent3 directory. This then prevents the creation of the output directory for the Descent3 target with the same name and thus failing the build.
I'm not quite sure why this doesn't happen on our CI builds. Maybe it's some difference between IDE and command line builds or just luck in case of parallel builds...

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
