### PR TITLE
Use static versions of dependencies linked through vcpkg

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,7 +20,7 @@
 				"value": "x86"
 			},
 			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x86-windows"
+				"VCPKG_TARGET_TRIPLET": "x86-windows-static-md"
 			},
 			"toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 		},
@@ -34,7 +34,7 @@
 				"rhs": "Windows"
 			},
 			"cacheVariables": {
-				"VCPKG_TARGET_TRIPLET": "x64-windows"
+				"VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
 			},
 			"architecture": {
 				"strategy": "external",


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Revisiting the conversation in #319 trying to follow up on the point I raised concerning the CRT linkage, I realized one of the first questions asked was if we can just link all vcpkg dependencies statically (before that whole conversation got sidetracked to pointless license discussions).
Since vcpkg already has a triplet for static ports using dynamic CRT linkage, this will just do that.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
~~If we go for this PR instead of #319, we should still take the change from 8f670d7f0d95ea38fa7efb369394d947070251fb of that PR.~~ Already in main as part of 82c04f8fb925f74ac045b5c4510d890ecfbf19c8.