### PR TITLE
Fix server crash during client connection

### DIFF
--- a/networking/networking.cpp
+++ b/networking/networking.cpp
@@ -1235,7 +1235,7 @@ void nw_SendReliableAck(SOCKADDR *raddr, uint32_t sig, network_protocol link_typ
   network_address send_address;
   memset(&send_address, 0, sizeof(network_address));
 
-  send_address.connection_type = reliable_sockets[serverconn].connection_type;
+  send_address.connection_type = link_type;
 
   if (NP_TCP == link_type) {
     SOCKADDR_IN *inaddr = (SOCKADDR_IN *)raddr;
@@ -1281,8 +1281,8 @@ void nw_WorkReliable(uint8_t *data, int len, network_address *naddr) {
 
   reliable_socket *rsocket = NULL;
   // Check to see if we need to send a packet out.
-  if ((reliable_sockets[serverconn].status == RNF_LIMBO) &&
-      ((serverconn != -1) && (timer_GetTime() - last_sent_iamhere) > NETRETRYTIME)) {
+  if ((serverconn != -1) && (reliable_sockets[serverconn].status == RNF_LIMBO) &&
+      ((timer_GetTime() - last_sent_iamhere) > NETRETRYTIME)) {
     reliable_header conn_header;
     // Now send I_AM_HERE packet
     conn_header.type = RNT_I_AM_HERE;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [x] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
The serverconn variable identifies the reliable socket used by the server. However this variable is not yet initialized at the very start of the first client connection which causes the server to crash. This fixes a bad safety check for this issue and a further instance of the bug.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
