### PR TITLE
fix PXO chat lobby connection failure on Linux/Mac

### DIFF
--- a/netcon/mtclient/chat_api.cpp
+++ b/netcon/mtclient/chat_api.cpp
@@ -205,7 +205,7 @@ int ConnectToChatServer(const char *serveraddr, int16_t chat_port, char *nicknam
 #ifndef __LINUX__
       if (WSAEWOULDBLOCK == WSAGetLastError())
 #else
-      if (WSAEWOULDBLOCK == ret || EINPROGRESS == ret || 0 == ret)
+      if (EINPROGRESS == ret || 0 == ret)
 #endif
       {
         DLLmprintf(0, "Beginning socket connect\n");

--- a/netcon/mtclient/chat_api.cpp
+++ b/netcon/mtclient/chat_api.cpp
@@ -205,7 +205,7 @@ int ConnectToChatServer(const char *serveraddr, int16_t chat_port, char *nicknam
 #ifndef __LINUX__
       if (WSAEWOULDBLOCK == WSAGetLastError())
 #else
-      if (WSAEWOULDBLOCK == ret || 0 == ret)
+      if (WSAEWOULDBLOCK == ret || EINPROGRESS == ret || 0 == ret)
 #endif
       {
         DLLmprintf(0, "Beginning socket connect\n");


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [x] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
On Linux & Mac `connect()` returns `EINPROGRESS` when the socket is set to non-blocking. This return value was not checked for with the PXO chat lobby connection, which caused the connection to ultimately fail. This change simply adds that missing value check.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
