### PR TITLE
Fix DedicatedServerPrintf_fp definition

### DIFF
--- a/netcon/includes/con_dll.h
+++ b/netcon/includes/con_dll.h
@@ -404,7 +404,7 @@ DoUI_fp DLLDoUI;
 typedef void (*Debug_ConsolePrintf_fp)(int n, const char *format, ...);
 Debug_ConsolePrintf_fp DLLDebug_ConsolePrintf;
 
-typedef void (*DedicatedServerPrintf_fp)(char *format, ...);
+typedef void (*DedicatedServerPrintf_fp)(const char *format, ...);
 DedicatedServerPrintf_fp DLLPrintDedicatedMessage;
 /*
 typedef int( *ValidateUser_fp) (validate_id_request *valid_id, char *trackerid);


### PR DESCRIPTION

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [X] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [X] Other changes

### Description
Fix DedicatedServerPrintf_fp to actually match the definition of PrintDedicatedMessage.
This also quiets three warnings about "ISO C++11 does not allow conversion from string literal to 'char *'"

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [X] I have documented any new or modified functionality.
- [X] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [X] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

