### PR TITLE
opengl: use SDL_WINDOW_FULLSCREEN_DESKTOP and an FBO.

### DIFF
--- a/ddio/lnxkey_sdl.cpp
+++ b/ddio/lnxkey_sdl.cpp
@@ -386,10 +386,11 @@ int sdlKeyFilter(const SDL_Event *event) {
       if ((kc == KEY_ENTER) || (kc == KEY_PADENTER)) {
         extern SDL_Window *GSDLWindow;
         Uint32 flags = SDL_GetWindowFlags(GSDLWindow);
+        // (In SDL2, SDL_WINDOW_FULLSCREEN_DESKTOP is SDL_WINDOW_FULLSCREEN plus an extra bit set, so just check for _any_ fullscreen in this bitwise AND.)
         if (flags & SDL_WINDOW_FULLSCREEN) {
           flags &= ~SDL_WINDOW_FULLSCREEN_DESKTOP;
         } else {
-          flags |= SDL_WINDOW_FULLSCREEN;  // !!! FIXME: FULLSCREEN_DESKTOP
+          flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
         }
         SDL_SetWindowFullscreen(GSDLWindow, flags);
         return(0);

--- a/legacy/renderer/opengl.cpp
+++ b/legacy/renderer/opengl.cpp
@@ -964,7 +964,7 @@ D3DError:
 }
 
 // Releases the rendering context
-void opengl_Close() {
+void opengl_Close(const bool just_resizing) {
   CHECK_ERROR(5)
 
   uint32_t *delete_list = (uint32_t *)mem_malloc(Cur_texture_object_num * sizeof(int));

--- a/lib/rend_opengl.h
+++ b/lib/rend_opengl.h
@@ -28,7 +28,7 @@ class oeApplication;
 int opengl_Init(oeApplication *app, renderer_preferred_state *pref_state);
 
 // Closes down opengl
-void opengl_Close();
+void opengl_Close(const bool just_resizing=false);
 void opengl_Shutdown();
 
 // The main drawing function...draws a flat/textured/gouraud polygon

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -34,6 +34,7 @@
 #include "rend_opengl.h"
 #include "grdefs.h"
 #include "mem.h"
+#include "config.h"
 #include "rtperformance.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -155,6 +156,23 @@ int Already_loaded = 0;
 bool opengl_Blending_on = 0;
 
 static oeApplication *ParentApplication = NULL;
+
+/* framebuffer object for backbuffer, scale to window size without changing resolution.  --ryan, 2019. */
+#define GL_DEPTH_COMPONENT16_EXT              0x81A5
+#define GL_READ_FRAMEBUFFER_EXT               0x8CA8
+#define GL_DRAW_FRAMEBUFFER_EXT               0x8CA9
+#define GL_FRAMEBUFFER_COMPLETE_EXT           0x8CD5
+#define GL_COLOR_ATTACHMENT0_EXT              0x8CE0
+#define GL_DEPTH_ATTACHMENT_EXT               0x8D00
+#define GL_STENCIL_ATTACHMENT_EXT             0x8D20
+#define GL_FRAMEBUFFER_EXT                    0x8D40
+#define GL_RENDERBUFFER_EXT                   0x8D41
+static GLuint GOpenGLFBO = 0;
+static GLuint GOpenGLRBOColor = 0;
+static GLuint GOpenGLRBODepth = 0;
+static GLuint GOpenGLFBOWidth = 0;
+static GLuint GOpenGLFBOHeight = 0;
+
 
 #if 0
 int checkForGLErrors( const char *file, int line )
@@ -491,19 +509,25 @@ extern bool ddio_mouseGrabbed;
 int SDLCALL d3SDLEventFilter(void *userdata, SDL_Event *event);
 
 int opengl_Setup(oeApplication *app, int *width, int *height) {
+  int winw = Video_res_list[Game_video_resolution].width;
+  int winh = Video_res_list[Game_video_resolution].height;
+
   // rcg09182000 don't need to quitsubsystem anymore...
   //    SDL_QuitSubSystem(SDL_INIT_VIDEO);  // here goes nothing...
   //    Already_loaded = false;
   SDL_ClearError();
-  int rc = SDL_Init(SDL_INIT_VIDEO);
-  if (rc != 0) {
-    char buffer[512];
-    snprintf(buffer, sizeof(buffer), "SDL_GetError() reports \"%s\".\n", SDL_GetError());
-    fprintf(stderr, "SDL: SDL_Init() failed! rc == (%d).\n", rc);
-    fprintf(stderr, "%s", buffer);
-    rend_SetErrorMessage(buffer);
-    return (0);
-  } // if
+  if (!SDL_WasInit(SDL_INIT_VIDEO)) {
+    const int rc = SDL_Init(SDL_INIT_VIDEO);
+    if (rc != 0) {
+      char buffer[512];
+      snprintf(buffer, sizeof(buffer), "SDL_GetError() reports \"%s\".\n", SDL_GetError());
+      fprintf(stderr, "SDL: SDL_Init() failed! rc == (%d).\n", rc);
+      fprintf(stderr, "%s", buffer);
+      rend_SetErrorMessage(buffer);
+      return (0);
+    }
+  }
+
   SDL_SetEventFilter(d3SDLEventFilter, NULL);
 
   bool fullscreen = true;
@@ -571,30 +595,129 @@ int opengl_Setup(oeApplication *app, int *width, int *height) {
   } // if
 #endif
 
-  SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 5);
-  SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 5);
-  SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 5);
+  SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8 );
+  SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+  SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 16);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   Uint32 flags = SDL_WINDOW_OPENGL;
 
   if (fullscreen) {
-    flags |= SDL_WINDOW_FULLSCREEN;
+    flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
   }
 
-
-  GSDLWindow = SDL_CreateWindow("Descent 3", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, *width, *height, flags);
   if (!GSDLWindow) {
-    mprintf(0, "OpenGL: SDL window creation failed: %s", SDL_GetError());
-    return 0;
+    GSDLWindow = SDL_CreateWindow("Descent 3", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, winw, winh, flags);
+    if (!GSDLWindow) {
+      mprintf(0, "OpenGL: SDL window creation failed: %s", SDL_GetError());
+      return 0;
+    }
+  } else {
+    SDL_SetWindowSize(GSDLWindow, winw, winh);
+    SDL_SetWindowFullscreen(GSDLWindow, flags);
   }
 
-  GSDLGLContext = SDL_GL_CreateContext(GSDLWindow);
   if (!GSDLGLContext) {
-    mprintf(0, "OpenGL: OpenGL context creation failed: %s", SDL_GetError());
+    GSDLGLContext = SDL_GL_CreateContext(GSDLWindow);
+    if (!GSDLGLContext) {
+      mprintf(0, "OpenGL: OpenGL context creation failed: %s", SDL_GetError());
+      SDL_DestroyWindow(GSDLWindow);
+      GSDLWindow = NULL;
+      return 0;
+    }
+  }
+
+  // clear the window framebuffer to start.
+  dglClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+  dglClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+  SDL_GL_SwapWindow(GSDLWindow);
+
+  bool fbo_available = true;
+  if (!SDL_GL_ExtensionSupported("GL_EXT_framebuffer_object")) {
+    mprintf(0, "OpenGL: GL_EXT_framebuffer_object extension is not available");
+    fbo_available = false;
+  }
+
+  if (!SDL_GL_ExtensionSupported("GL_EXT_framebuffer_blit")) {
+      mprintf(0, "OpenGL: GL_EXT_framebuffer_blit extension is not available");
+      fbo_available = false;
+  }
+
+  if (fbo_available) {
+    #define LOOKUP_GL_SYM(x) \
+      dgl##x = (gl##x##_fp) SDL_GL_GetProcAddress("gl" #x); \
+      if (dgl##x == NULL) { \
+        mprintf(0, "OpenGL: gl%s function not found!", #x); \
+        fbo_available = false; \
+      }
+    LOOKUP_GL_SYM(GenFramebuffersEXT);
+    LOOKUP_GL_SYM(GenRenderbuffersEXT);
+    LOOKUP_GL_SYM(BindFramebufferEXT);
+    LOOKUP_GL_SYM(BindRenderbufferEXT);
+    LOOKUP_GL_SYM(RenderbufferStorageEXT);
+    LOOKUP_GL_SYM(FramebufferRenderbufferEXT);
+    LOOKUP_GL_SYM(CheckFramebufferStatusEXT);
+    LOOKUP_GL_SYM(DeleteFramebuffersEXT);
+    LOOKUP_GL_SYM(DeleteRenderbuffersEXT);
+    LOOKUP_GL_SYM(BlitFramebufferEXT);
+  }
+
+  if (!fbo_available) {
+    mprintf(0, "OpenGL: We need missing Framebuffer Object support, giving up");
+    SDL_GL_DeleteContext(GSDLGLContext);
     SDL_DestroyWindow(GSDLWindow);
+    GSDLGLContext = NULL;
     GSDLWindow = NULL;
     return 0;
+  }
+
+  /* Tear down the backbuffer and rebuild at new dimensions... */
+  if (GOpenGLFBO) {
+    dglBindFramebufferEXT(GL_FRAMEBUFFER_EXT, GOpenGLFBO);
+    dglFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, 0);
+    dglFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, 0);
+    dglBindRenderbufferEXT(GL_RENDERBUFFER_EXT, 0);
+    dglBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+    dglDeleteFramebuffersEXT(1, &GOpenGLFBO);
+    dglDeleteRenderbuffersEXT(1, &GOpenGLRBOColor);
+    dglDeleteRenderbuffersEXT(1, &GOpenGLRBODepth);
+    GOpenGLFBOWidth = GOpenGLFBOHeight = GOpenGLFBO = GOpenGLRBOColor = GOpenGLRBODepth = 0;
+  }
+
+  const GLsizei w = (GLsizei) *width;
+  const GLsizei h = (GLsizei) *height;
+
+  GOpenGLFBOWidth = w;
+  GOpenGLFBOHeight = h;
+
+  dglGenFramebuffersEXT(1, &GOpenGLFBO);
+  dglBindFramebufferEXT(GL_FRAMEBUFFER_EXT, GOpenGLFBO);
+
+  dglGenRenderbuffersEXT(1, &GOpenGLRBOColor);
+  dglBindRenderbufferEXT(GL_RENDERBUFFER_EXT, GOpenGLRBOColor);
+  dglRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_RGB, w, h);
+  dglFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, GOpenGLRBOColor);
+
+  dglGenRenderbuffersEXT(1, &GOpenGLRBODepth);
+  dglBindRenderbufferEXT(GL_RENDERBUFFER_EXT, GOpenGLRBODepth);
+  dglRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_DEPTH_COMPONENT16_EXT, w, h);
+  dglFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, GOpenGLRBODepth);
+
+  if (dglCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT) != GL_FRAMEBUFFER_COMPLETE_EXT) {
+      mprintf(0, "OpenGL: our framebuffer object is incomplete, giving up");
+      dglFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, 0);
+      dglFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_RENDERBUFFER_EXT, 0);
+      dglBindRenderbufferEXT(GL_RENDERBUFFER_EXT, 0);
+      dglBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+      dglDeleteFramebuffersEXT(1, &GOpenGLFBO);
+      dglDeleteRenderbuffersEXT(1, &GOpenGLRBOColor);
+      dglDeleteRenderbuffersEXT(1, &GOpenGLRBODepth);
+      GOpenGLFBO = GOpenGLRBOColor = GOpenGLRBODepth = 0;
+      SDL_GL_DeleteContext(GSDLGLContext);
+      SDL_DestroyWindow(GSDLWindow);
+      GSDLGLContext = NULL;
+      GSDLWindow = NULL;
+      return 0;
   }
 
   if (!FindArg("-nomousegrab")) {
@@ -920,7 +1043,7 @@ int opengl_Init(oeApplication *app, renderer_preferred_state *pref_state) {
 }
 
 // Releases the rendering context
-void opengl_Close() {
+void opengl_Close(const bool just_resizing) {
   CHECK_ERROR(5)
 
   uint32_t *delete_list = (uint32_t *)mem_malloc(Cur_texture_object_num * sizeof(int));
@@ -951,9 +1074,10 @@ void opengl_Close() {
         SDL_GL_MakeCurrent(NULL, NULL);
         SDL_GL_DeleteContext(GSDLGLContext);
         GSDLGLContext = NULL;
+        GOpenGLFBOWidth = GOpenGLFBOHeight = GOpenGLFBO = GOpenGLRBOColor = GOpenGLRBODepth = 0;
     }
 
-    if (GSDLWindow) {
+    if (!just_resizing && GSDLWindow) {
         SDL_DestroyWindow(GSDLWindow);
         GSDLWindow = NULL;
     }
@@ -1841,11 +1965,52 @@ void rend_Flip(void) {
   OpenGL_polys_drawn = 0;
   OpenGL_verts_processed = 0;
 
+  // if we're rendering to an FBO, scale to the window framebuffer!
+  if (GOpenGLFBO != 0) {
+    #if defined(WIN32)
+    // !!! FIXME: is this expensive?
+    RECT rectWindow;	// rectangle for the client area of the window
+    GetClientRect(hOpenGLWnd, &rectWindow);
+    int w = (int) (rectWindow.right - rectWindow.left);
+    int h = (int) (rectWindow.bottom - rectWindow.top);
+    #else
+    int w, h;
+    SDL_GL_GetDrawableSize(GSDLWindow, &w, &h);
+    #endif
+
+    int scaledHeight, scaledWidth;
+    if (w < h) {
+      scaledWidth = w;
+      scaledHeight = (int) (((((double)GOpenGLFBOHeight) / ((double)GOpenGLFBOWidth))) * ((double)w));
+    } else {
+      scaledHeight = h;
+      scaledWidth = (int) (((((double)GOpenGLFBOWidth) / ((double)GOpenGLFBOHeight))) * ((double)h));
+    }
+
+    const int centeredX = (w - scaledWidth) / 2;
+    const int centeredY = (h - scaledHeight) / 2;
+
+    dglBindFramebufferEXT(GL_DRAW_FRAMEBUFFER_EXT, 0);
+    dglClearColor (0.0f, 0.0f, 0.0f, 1.0f);
+    dglClear(GL_COLOR_BUFFER_BIT);  // in case the Steam Overlay wrote to places we don't blit over.
+    dglBlitFramebufferEXT(0, 0, GOpenGLFBOWidth, GOpenGLFBOHeight,
+                          centeredX, centeredY, centeredX + scaledWidth, centeredY + scaledHeight,
+                          GL_COLOR_BUFFER_BIT, GL_LINEAR);
+    dglBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+  }
+
 #if defined(WIN32)
   SwapBuffers((HDC)hOpenGLDC);
 #elif defined(__LINUX__)
   SDL_GL_SwapWindow(GSDLWindow);
 #endif
+
+  // go back to drawing on the FBO until we want to blit to the window framebuffer again.
+  if (GOpenGLFBO != 0) {
+    dglBindFramebufferEXT(GL_FRAMEBUFFER_EXT, GOpenGLFBO);
+    dglViewport(0, 0, GOpenGLFBOWidth, GOpenGLFBOHeight);
+    dglScissor(0, 0, GOpenGLFBOWidth, GOpenGLFBOHeight);
+  }
 
 #ifdef __PERMIT_GL_LOGGING
   if (__glLog == true) {
@@ -2197,7 +2362,7 @@ void rend_SetZBufferWriteMask(int state) {
 }
 
 int rend_ReInit() {
-  opengl_Close();
+  opengl_Close(true);
   return opengl_Init(NULL, &gpu_preferred_state);
 }
 
@@ -2276,6 +2441,7 @@ void rend_TransformSetToPassthru(void) {
 
   // Viewport
   dglViewport(0, 0, width, height);
+  dglScissor(0, 0, width, height);
 
   // ModelView
   dglMatrixMode(GL_MODELVIEW);

--- a/renderer/dyna_gl.h
+++ b/renderer/dyna_gl.h
@@ -127,6 +127,18 @@ typedef void(GLFUNCCALL *glRasterPos2i_fp)(GLint x, GLint y);
 typedef void(GLFUNCCALL *glBitmap_fp)(GLsizei width, GLsizei height, GLfloat xorig, GLfloat yorig, GLfloat xmove,
                                       GLfloat ymove, const GLubyte *bitmap);
 
+// FBO entry points for render-to-texture ...
+typedef void (GLFUNCCALL *glGenFramebuffersEXT_fp) (GLsizei n, GLuint *framebuffers);
+typedef void (GLFUNCCALL *glGenRenderbuffersEXT_fp) (GLsizei n, GLuint *renderbuffers);
+typedef void (GLFUNCCALL *glBindFramebufferEXT_fp) (GLenum target, GLuint framebuffer);
+typedef void (GLFUNCCALL *glBindRenderbufferEXT_fp)(GLenum target, GLuint renderbuffer);
+typedef void (GLFUNCCALL *glRenderbufferStorageEXT_fp) (GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
+typedef void (GLFUNCCALL *glFramebufferRenderbufferEXT_fp) (GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
+typedef GLenum (GLFUNCCALL *glCheckFramebufferStatusEXT_fp) (GLenum target);
+typedef void (GLFUNCCALL *glDeleteRenderbuffersEXT_fp) (GLsizei n, const GLuint *renderbuffers);
+typedef void (GLFUNCCALL *glDeleteFramebuffersEXT_fp) (GLsizei n, const GLuint *framebuffers);
+typedef void (GLFUNCCALL *glBlitFramebufferEXT_fp) (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+
 #if defined(WIN32)
 typedef HGLRC(GLFUNCCALL *wglCreateContext_fp)(HDC);
 typedef BOOL(GLFUNCCALL *wglDeleteContext_fp)(HGLRC);
@@ -192,6 +204,17 @@ DYNAEXTERN(glViewport_fp, dglViewport);
 DYNAEXTERN(glColor4fv_fp, dglColor4fv);
 DYNAEXTERN(glVertex3fv_fp, dglVertex3fv);
 DYNAEXTERN(glTexCoord4fv_fp, dglTexCoord4fv);
+
+DYNAEXTERN(glGenFramebuffersEXT_fp, dglGenFramebuffersEXT);
+DYNAEXTERN(glGenRenderbuffersEXT_fp, dglGenRenderbuffersEXT);
+DYNAEXTERN(glBindFramebufferEXT_fp, dglBindFramebufferEXT);
+DYNAEXTERN(glBindRenderbufferEXT_fp, dglBindRenderbufferEXT);
+DYNAEXTERN(glRenderbufferStorageEXT_fp, dglRenderbufferStorageEXT);
+DYNAEXTERN(glFramebufferRenderbufferEXT_fp, dglFramebufferRenderbufferEXT);
+DYNAEXTERN(glCheckFramebufferStatusEXT_fp, dglCheckFramebufferStatusEXT);
+DYNAEXTERN(glDeleteFramebuffersEXT_fp, dglDeleteFramebuffersEXT);
+DYNAEXTERN(glDeleteRenderbuffersEXT_fp, dglDeleteRenderbuffersEXT);
+DYNAEXTERN(glBlitFramebufferEXT_fp, dglBlitFramebufferEXT);
 
 #ifdef DECLARE_OPENGL
 static module OpenGLDLLInst;


### PR DESCRIPTION
This now renders to an OpenGL Framebuffer Object at the game's resolution, and blits it to the window at whatever resolution it is currently using, scaling and letterboxing if necessary.

Which is to say: display resolutions are now imaginary, and we never change the physical display mode now. A smaller resolution is simply drawing less pixels and scaling them up with the GPU for display. This solves a few problems: no more resizing background windows or desktop icons shuffling around, no more being stuck in a weird resolution when debugging or if the game crashes, no more waiting on monitors to click over to a new mode, and no more weird rendering when the display didn't exactly support the requested mode.

This also means the game doesn't have to drop down to 640x480 for the config menu screen when it was otherwise using some other resolution.

Some caveats:

- This _requires_ OpenGL Framebuffer Object support; there is currently no fallback if it's missing and the game will refuse to start. But any desktop hardware of the last ~20 years should support it. For weird embedded things or whatnot, it will be possible to add a fallback.

- This currently requires SDL. The OpenGL pieces should work on Windows, but someone would need to adjust the existing win32 code to create a fullscreen window and not change the physical display mode. It should still compile on windows and work as before (untested by me, though).

- This is only OpenGL; it does not touch the Direct3D renderer, which should continue to work as before (again, untested by me).
