### PR TITLE
Fixed custom target dependency for d3_version.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if(BUILD_TESTING)
 endif()
 
 add_custom_command(
-  OUTPUT ${PROJECT_BINARY_DIR}/Descent3/d3_version.h ALL
+  OUTPUT ${PROJECT_BINARY_DIR}/lib/d3_version.h
   COMMAND ${CMAKE_COMMAND}
     -D SOURCE_DIR=${PROJECT_SOURCE_DIR}
     -D TARGET_DIR=${PROJECT_BINARY_DIR}
@@ -85,9 +85,9 @@ install(
   DESTINATION ${CMAKE_INSTALL_DOCDIR}
 )
 
-# rebuild version.hpp every time
+# rebuild d3_version.h every time
 add_custom_target(get_git_hash ALL
-  DEPENDS ${PROJECT_BINARY_DIR}/Descent3/d3_version.h
+  DEPENDS ${PROJECT_BINARY_DIR}/lib/d3_version.h
 )
 
 if(UNIX)


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
_cmake/CheckGit.cmake_ uses `configure_file()` to create _d3_version.h_ in `${TARGET_DIR}/lib` aka `${PROJECT_BINARY_DIR}/lib`. But `add_custom_command()` and `add_custom_target()` calls in the root CMakeLists.txt use `${PROJECT_BINARY_DIR}/Descent3` as path to that file, expecting it in a different place. While the build still works, since the compiler looks in the right include paths for it, the dependencies between these rules/targets are technically broken.
At least msbuild will generate warnings about missing build outputs. You can see it on CI builds before we switched to Ninja: https://github.com/DescentDevelopers/Descent3/pull/429/checks#step:6:405

Also removed the wrong `ALL` parameter from `add_custom_command()`, it's only a valid parameter for `add_custom_target()`.
See: https://github.com/DescentDevelopers/Descent3/pull/429/checks#step:6:406

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
