### PR TITLE
Fixed inconsistent use of memory management functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_compile_options("/MP")  # so msbuild builds with multiple processes
 endif()
 
+add_compile_definitions($<$<BOOL:${ENABLE_MEM_RTL}>:MEM_USE_RTL>)
+
 add_compile_definitions($<$<CONFIG:Release>:RELEASE>)
 add_compile_definitions($<$<CONFIG:Debug>:_DEBUG>)
 

--- a/Descent3/CMakeLists.txt
+++ b/Descent3/CMakeLists.txt
@@ -296,9 +296,6 @@ add_executable(Descent3
   WIN32
   ${HEADERS} ${CPPS} ${PLATFORM_CPPS} ${INCS}
 )
-target_compile_definitions(Descent3 PUBLIC
-  $<$<BOOL:${ENABLE_MEM_RTL}>:MEM_USE_RTL>
-)
 target_link_libraries(Descent3
   2dlib AudioEncode bitmap cfile czip d3music dd_video ddebug ddio libmve libacm
   fix grtext manage mem misc model module movie stream_audio


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Before #436 `MEM_USE_RTL` was a define in _lib/mem.h_ that could be uncommented to change the memory management functions. So every library including _mem.h_ was agreeing on the same memory functions.

By changing this to a CMake option and only enabling it on the Descent3 target, all other libraries would never activate this preprocessor definition when the option is enabled and therefore use different memory functions.

Allocating memory from any code of a library and freeing this memory from code compiled as part of Descent3, or vice versa, will result in memory corruption.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #444

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
