### PR TITLE
Stop calling `HeapSize()` on `malloc()`’d memory

### DIFF
--- a/mem/mem.cpp
+++ b/mem/mem.cpp
@@ -297,11 +297,7 @@ char *mem_strdup_sub(const char *string, const char *file, int line) {
 void *mem_realloc_sub(void *mem, int size) { return realloc(mem, size); }
 
 int mem_size_sub(void *memblock) {
-#ifdef MACOSX
-  return malloc_size(memblock);
-#else
-  return malloc_usable_size(memblock);
-#endif
+  return native_mem_size(memblock);
 }
 
 bool mem_dumpmallocstofile(char *filename) { return false; }

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -74,12 +74,28 @@
 #ifndef MEM_H
 #define MEM_H
 
+#ifdef MACOSX
+#include <malloc/malloc.h>
+#else
+#include <malloc.h>
+#endif
+
+#ifdef __LINUX__
+#ifdef MACOSX
+#define native_mem_size(d) malloc_size(d)
+#else
+#define native_mem_size(d) malloc_usable_size(d)
+#endif
+#else
+#define native_mem_size(d) _msize(d)
+#endif
+
 // Memory management debugging
 #ifdef MEM_USE_RTL
 #define mem_malloc(d) malloc(d) // Use this if your going to run BoundsChecker
 #define mem_free(d) free(d)
 #define mem_strdup(d) strdup(d)
-#define mem_size(d) mem_size_sub(d)
+#define mem_size(d) native_mem_size(d)
 #define mem_realloc(d, e) realloc(d, e)
 #else
 // Use this if your going to NOT run BoundsChecker


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
This makes the Windows version of Descent 3 less dependent on Windows 95 compatibility mode. Users will still need to run the game in Windows 95 compatibility mode for the moment, but this change is required for us to eventually make Descent 3 not require Windows 95 compatibility mode. See the commit message for details.

Additionally, [I’m working on another PR](https://github.com/DescentDevelopers/Descent3/issues/373#issuecomment-2121090450) that uses `std::filesystem::directory_iterator`. Unfortunately, Microsoft’s implementation of `std::filesystem::directory_iterator` crashes when the program is run in Windows 95 compatibility mode.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
This PR is related to #418, but it doesn’t actually fix that issue.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
I’ve tested the `linux` preset on NixOS 23.11 x86_64, and I’ve tested the `win32` preset on Windows 11 x86_64. [I haven’t been able to test this PR on macOS](https://github.com/quickemu-project/quickemu/discussions/1262), but it changes macOS-specific code.
