### PR TITLE
Re-enable git hash generation on changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,11 @@ if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
+# rebuild d3_version.h every time
+add_custom_target(get_git_hash ALL)
+
 add_custom_command(
-  OUTPUT ${PROJECT_BINARY_DIR}/lib/d3_version.h
+  TARGET get_git_hash
   COMMAND ${CMAKE_COMMAND}
     -D SOURCE_DIR=${PROJECT_SOURCE_DIR}
     -D TARGET_DIR=${PROJECT_BINARY_DIR}
@@ -84,11 +87,6 @@ add_custom_command(
 install(
   FILES LICENSE README.md THIRD_PARTY.md
   DESTINATION ${CMAKE_INSTALL_DOCDIR}
-)
-
-# rebuild d3_version.h every time
-add_custom_target(get_git_hash ALL
-  DEPENDS ${PROJECT_BINARY_DIR}/lib/d3_version.h
 )
 
 if(UNIX)


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Previous change 0b68277 fixes paths to generated file, but after that add_custom_command() stops executing every time on build and git hash generation is broken. This PR fixes this issue by inverting dependency between add_custom_target() and add_custom_command() (target now depends on command).


### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
