### PR TITLE
Remove redundant GetMultiCDPath()

### DIFF
--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -919,18 +919,7 @@ bool LoadMission(const char *mssn) {
   ResetMission(); // Reset everything.
                   // open MN3 if filename passed was an mn3 file.
 
-  // Correct for mission split hack
-
-  if (stricmp(mssn, "d3_2.mn3") == 0) {
-    strcpy(mission, "d3_2.mn3");
-    strcpy(pathname, "d3_2.mn3");
-
-  } else if (stricmp(mssn, "d3.mn3") == 0) {
-    strcpy(mission, "d3.mn3");
-    strcpy(pathname, "d3.mn3");
-
-  }
-  else if (IS_MN3_FILE(mssn)) {
+  if (IS_MN3_FILE(mssn)) {
     strcpy(mission, mssn);
     ddio_MakePath(pathname, D3MissionsDir, mission, NULL);
   } else {
@@ -1837,13 +1826,9 @@ bool mn3_Open(const char *mn3file) {
     mn3file = tempMn3File;
   }
 
-  const char *p = GetMultiCDPath((char *)mn3file);
-  // ddio_MakePath(pathname, D3MissionsDir, mn3file, NULL);
-  if (!p)
-    return false;
-  strcpy(pathname, p);
+  ddio_MakePath(pathname, D3MissionsDir, mn3file, NULL);
   // open MN3 HOG.
-  mn3_handle = cf_OpenLibrary(pathname);
+  mn3_handle = cf_OpenLibrary(mn3file);
   if (mn3_handle == 0) {
     return false;
   } else {
@@ -1852,27 +1837,22 @@ bool mn3_Open(const char *mn3file) {
   // do table file stuff.
   ddio_SplitPath(mn3file, NULL, filename, ext);
 
-  //	char voice_hog[_MAX_PATH*2];
+  char voice_hog[_MAX_PATH*2];
   if ((stricmp(filename, "d3") == 0) || (stricmp(filename, "training") == 0)) {
     // Open audio hog file
-    // ddio_MakePath(voice_hog, D3MissionsDir, "d3voice1.hog", NULL);//Audio for levels 1-4
-    const char *v = GetMultiCDPath("d3voice1.hog");
-    if (!v)
-      return false;
-    Mission_voice_hog_handle = cf_OpenLibrary(v);
+    ddio_MakePath(voice_hog, D3MissionsDir, "d3voice1.hog", nullptr); // Audio for levels 1-4
+    Mission_voice_hog_handle = cf_OpenLibrary(voice_hog);
   } else if (stricmp(filename, "d3_2") == 0) {
     // Open audio hog file
-    // ddio_MakePath(voice_hog, D3MissionsDir, "d3voice2.hog", NULL);//Audio for levels 5-17
-    const char *v = GetMultiCDPath("d3voice2.hog");
-    if (!v)
-      return false;
-    Mission_voice_hog_handle = cf_OpenLibrary(v);
+    ddio_MakePath(voice_hog, D3MissionsDir, "d3voice2.hog", nullptr); // Audio for levels 5-17
+    Mission_voice_hog_handle = cf_OpenLibrary(voice_hog);
   }
   strcat(filename, ".gam");
   mng_SetAddonTable(filename);
   Current_mission.mn3_handle = mn3_handle;
   return true;
 }
+
 // returns mission information given the mn3 file.
 bool mn3_GetInfo(const char *mn3file, tMissionInfo *msn) {
   int handle;
@@ -1880,14 +1860,7 @@ bool mn3_GetInfo(const char *mn3file, tMissionInfo *msn) {
   char pathname[_MAX_PATH];
   char filename[PSFILENAME_LEN + 1];
 
-  if (stricmp(mn3file, "d3.mn3") == 0) {
-    const char *p = GetMultiCDPath((char *)mn3file);
-    if (!p)
-      return false;
-    strcpy(pathname, p);
-  } else {
-    ddio_MakePath(pathname, D3MissionsDir, mn3file, NULL);
-  }
+  ddio_MakePath(pathname, D3MissionsDir, mn3file, nullptr);
   handle = cf_OpenLibrary(pathname);
   if (handle == 0) {
     mprintf(0, "MISSION: MN3 failed to open.\n");

--- a/Descent3/descent.cpp
+++ b/Descent3/descent.cpp
@@ -493,9 +493,7 @@ void Descent3() {
         for (auto const &intro : intros) {
           ddio_MakePath(intropath, Base_directory, "movies", intro, nullptr);
           if (cfexist(intropath)) {
-            const char *t = GetMultiCDPath(intro);
-            if (t)
-              PlayMovie(t);
+            PlayMovie(intropath);
           }
         }
       }
@@ -715,55 +713,3 @@ void D3DebugResumeHandler() {
 #endif
 
 void RenderBlankScreen();
-
-struct file_vols {
-  char file[_MAX_PATH];
-  char localpath[_MAX_PATH * 2];
-  int volume;
-  bool localized;
-};
-
-// This function figures out whether or not a file needs to be loaded off of
-// CD or off of the local drive. If it needs to come from a CD, it figures out
-// which CD and prompts the user to enter that CD. If they hit cancel, it
-// returns NULL.
-const char *GetMultiCDPath(const char *file) {
-  // Filename, directory it might be installed on the hard drive, CD number to look for it
-  const std::vector<file_vols> file_volumes = {
-      // file, localpath, volume, localized
-      {"d3.mn3", "missions", 1, false},
-      {"d3_2.mn3", "missions", 2, false},
-      {"level1.mve", "movies", 1, true},
-      {"level5.mve", "movies", 2, true},
-      {"end.mve", "movies", 2, true},
-      {"intro.mve", "movies", 1, true},
-      {"dolby1.mv8", "movies", 1, true},
-      {"d3voice1.hog", "missions", 1, true},
-      {"d3voice2.hog", "missions", 2, true},
-  };
-
-  static char fullpath[_MAX_PATH * 2];
-
-  if ((file == nullptr) || (*file == '\0'))
-    return nullptr;
-
-  auto it = std::find_if(
-      file_volumes.begin(), file_volumes.end(),
-      [&file](const file_vols& file_volume) {
-        return (stricmp(file_volume.file, file) == 0);
-      }
-  );
-
-  // This is a file we don't know about
-  if (it == file_volumes.end()) {
-    return file;
-  }
-
-  ddio_MakePath(fullpath, LocalD3Dir, it->localpath, file, nullptr);
-  // See if the file is in the local dir already.
-  if (cfexist(fullpath)) {
-    return fullpath;
-  }
-
-  return nullptr;
-}

--- a/Descent3/descent.h
+++ b/Descent3/descent.h
@@ -213,12 +213,6 @@ function_mode GetFunctionMode();
 void CreateGameViewport(grViewport **vp);
 void DestroyGameViewport(grViewport *vp);
 
-// This function figures out whether or not a file needs to be loaded off of
-// CD or off of the local drive. If it needs to come from a CD, it figures out
-// which CD and prompts the user to enter that CD. If they hit cancel, it
-// returns NULL.
-const char *GetMultiCDPath(const char *file);
-
 inline void CREATE_VIEWPORT(grViewport **vp) { CreateGameViewport(vp); }
 
 inline void DESTROY_VIEWPORT(grViewport *vp) { DestroyGameViewport(vp); }

--- a/Descent3/gamesequence.cpp
+++ b/Descent3/gamesequence.cpp
@@ -1309,9 +1309,8 @@ void CheckHogfile() {
       (Current_mission.cur_level > 4)) {
     // close the mission hog file and open d3_2.mn3
     mn3_Close();
-    const char *hogp = GetMultiCDPath("d3_2.mn3");
-    if (hogp) {
-      strcpy(hogpath, hogp);
+    ddio_MakePath(hogpath, D3MissionsDir, "d3_2.mn3", nullptr);
+    if (cfexist(hogpath)) {
       mn3_Open(hogpath);
       mem_free(Current_mission.filename);
       Current_mission.filename = mem_strdup("d3_2.mn3");
@@ -1323,9 +1322,8 @@ void CheckHogfile() {
     // Part 2 of the mission is d3_2.mn3
     // close the mission hog file and open d3.mn3
     mn3_Close();
-    const char *hogp = GetMultiCDPath("d3.mn3");
-    if (hogp) {
-      strcpy(hogpath, hogp);
+    ddio_MakePath(hogpath, D3MissionsDir, "d3.mn3", nullptr);
+    if (cfexist(hogpath)) {
       mn3_Open(hogpath);
       mem_free(Current_mission.filename);
       Current_mission.filename = mem_strdup("d3.mn3");
@@ -1644,9 +1642,8 @@ bool LoadAndStartCurrentLevel() {
       (Current_mission.cur_level > 4)) {
     // close the mission hog file and open d3_2.mn3
     mn3_Close();
-    const char *hogp = GetMultiCDPath("d3_2.mn3");
-    if (hogp) {
-      strcpy(hogpath, hogp);
+    ddio_MakePath(hogpath, D3MissionsDir, "d3_2.mn3", nullptr);
+    if (cfexist(hogpath)) {
       mn3_Open(hogpath);
       mem_free(Current_mission.filename);
       Current_mission.filename = mem_strdup("d3_2.mn3");
@@ -1658,9 +1655,8 @@ bool LoadAndStartCurrentLevel() {
     // Part 2 of the mission is d3_2.mn3
     // close the mission hog file and open d3.mn3
     mn3_Close();
-    const char *hogp = GetMultiCDPath("d3.mn3");
-    if (hogp) {
-      strcpy(hogpath, hogp);
+    ddio_MakePath(hogpath, D3MissionsDir, "d3.mn3", nullptr);
+    if (cfexist(hogpath)) {
       mn3_Open(hogpath);
       mem_free(Current_mission.filename);
       Current_mission.filename = mem_strdup("d3.mn3");

--- a/Descent3/menu.cpp
+++ b/Descent3/menu.cpp
@@ -1155,12 +1155,10 @@ bool MenuNewGame() {
 
     FirstGame = true;
 
-    char temppath[_MAX_PATH];
-    const char *moviepath;
-    moviepath = GetMultiCDPath("level1.mve");
-    if (moviepath) {
-      strcpy(temppath, moviepath);
-      PlayMovie(temppath);
+    char moviepath[_MAX_PATH];
+    ddio_MakePath(moviepath, LocalD3Dir, "movies", "level1.mve", nullptr);
+    if (cfexist(moviepath)) {
+      PlayMovie(moviepath);
     }
     Skip_next_movie = true;
 

--- a/Descent3/mission_download.cpp
+++ b/Descent3/mission_download.cpp
@@ -601,11 +601,7 @@ int msn_CheckGetMission(network_address *net_addr, char *filename) {
 #ifdef OEM
   return 1;
 #else
-  if ((stricmp(filename, "d3_2.mn3") == 0) || (stricmp(filename, "d3.mn3") == 0)) {
-    const char *p = GetMultiCDPath(filename);
-    return p ? 1 : 0;
-  }
-
+  // Don't download local missions
   char pathname[_MAX_PATH];
   ddio_MakePath(pathname, D3MissionsDir, filename, NULL);
   if (cfexist(filename) || cfexist(pathname)) {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Function `GetMultiCDPath()` was used to determine location of files placed on CD/DVD. Since CD/DVD support was removed, this function is now has no use.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
