### PR TITLE
Fix mem_size_sub() for WIN32 in MEM_USE_RTL mode

### DIFF
--- a/mem/mem.cpp
+++ b/mem/mem.cpp
@@ -673,7 +673,11 @@ void *mem_realloc_sub(void *memblock, int size) {
   return retp;
 #endif
 }
+
 int mem_size_sub(void *memblock) {
+#ifdef MEM_USE_RTL
+  return _msize(memblock);
+#else // MEM_USE_RTL
 #if defined(WIN32)
   if (!Heap) {
     return 0;
@@ -683,7 +687,9 @@ int mem_size_sub(void *memblock) {
     return 0;
   }
   return HeapSize(Heap, 0, memblock);
+#endif
 }
+
 void mem_shutdown();
 MemClass::~MemClass() { mem_shutdown(); }
 //	memory routines


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Use `_msize()` instead of `HeapSize()` in RTL memory allocation model. Fixes crash on mission start in Windows.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

Closes #449. 

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
