### PR TITLE
Fix crash in DumpTextToClipboard()

### DIFF
--- a/ddebug/windebug.cpp
+++ b/ddebug/windebug.cpp
@@ -937,9 +937,10 @@ void DumpTextToClipboard(char *text) {
   // Length of string with CRs added
   int len = strlen(text) + extra + 1;
 
-  char *h_text = (char *)mem_malloc(len);
+  HGLOBAL h_text = GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, len);
   if (!h_text)
     return;
+  ptr = (char *)GlobalLock(h_text);
   if (!ptr)
     return;
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
`SetClipboardData()` expects its second parameter to be allocated with the `GMEM_MOVEABLE` flag ([see here](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclipboarddata#parameters)) and will call `GlobalSize()` on it internally, so we can't replace it with a plain malloc.
Also the assignment of `h_text` to `ptr` was missing, and `GlobalUnlock()` was still called on h_text even after the change to malloc.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Regression introduced in c41c3a7 by #436.

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
