### PR TITLE
Define OutrageMessageBox regardless of DEBUG

### DIFF
--- a/lib/pserror.h
+++ b/lib/pserror.h
@@ -164,11 +164,9 @@ void Int3MessageBox(const char *file, int line);
 #define MBOX_YESNO 2
 #define MBOX_YESNOCANCEL 3
 #define MBOX_ABORTRETRYIGNORE 4
-#if (defined(EDITOR) || defined(NEWEDITOR) || defined(_DEBUG))
 //	prints out a standard OS messagebox
 void OutrageMessageBox(const char *str, ...);
 int OutrageMessageBox(int type, const char *str, ...);
-#endif
 // Sets the title for future OutrageMessageBox() dialogs
 void SetMessageBoxTitle(const char *title);
 // Write a block of text to the system clipboard


### PR DESCRIPTION
## Pull Request Type
- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
`OutrageMessageBox()` doesn't depend on anything debug-specific - it appears to be conditionally-defined basically just to avoid interrupting the user in release builds. However, the codebase appears to think that `DEBUG` and `RELEASE` are perfect opposites, which is not true. (The `RelWithDebInfo` build, in particular, has neither set.)

Here we define `OutrageMessageBox` regardless of build type, and let the `RELEASE` check determine whether or not it wants to interrupt the user.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
