### PR TITLE
keep windows-specific generator expressions on one line

### DIFF
--- a/netcon/lanclient/CMakeLists.txt
+++ b/netcon/lanclient/CMakeLists.txt
@@ -7,9 +7,7 @@ set_target_properties(Direct_TCP_IP PROPERTIES OUTPUT_NAME "Direct TCP~IP")
 target_link_libraries(Direct_TCP_IP PRIVATE
   ddio
   inetfile
-  $<$<PLATFORM_ID:Windows>:
-    ws2_32
-  >
+  $<$<PLATFORM_ID:Windows>:ws2_32>
 )
 
 add_custom_target(Direct_TCP_IP_Hog

--- a/netcon/mtclient/CMakeLists.txt
+++ b/netcon/mtclient/CMakeLists.txt
@@ -13,9 +13,7 @@ set_target_properties(Parallax_Online PROPERTIES OUTPUT_NAME "Parallax Online")
 target_link_libraries(Parallax_Online PRIVATE
   ddio
   inetfile
-  $<$<PLATFORM_ID:Windows>:
-  ws2_32
-  >
+  $<$<PLATFORM_ID:Windows>:ws2_32>
 )
 
 add_custom_target(Parallax_Online_Hog


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
The Android NDK's version of CMake (a customized 3.22 I believe?) apparently has trouble with multi-line generator expressions. Or at least, it had trouble with these ones. Changing them to be a single line fixed the problem.

### Checklist
- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
