### PR TITLE
Set default BPP to 32

### DIFF
--- a/Descent3/game.cpp
+++ b/Descent3/game.cpp
@@ -966,7 +966,7 @@ void SetScreenMode(int sm, bool force_res_change) {
     } else {
       scr_width = FIXED_SCREEN_WIDTH;
       scr_height = FIXED_SCREEN_HEIGHT;
-      scr_bitdepth = 16;
+      scr_bitdepth = 32;
     }
 
     if (!rend_initted) {
@@ -999,7 +999,7 @@ void SetScreenMode(int sm, bool force_res_change) {
         rend_initted = 1;
         mprintf(0, "Changing menu settings to default!\n");
         Game_video_resolution = RES_640X480;
-        Render_preferred_state.bit_depth = 16;
+        Render_preferred_state.bit_depth = 32;
         scr_width = 640;
         scr_height = 480;
       }
@@ -1017,7 +1017,7 @@ void SetScreenMode(int sm, bool force_res_change) {
           rend_initted = 1;
           mprintf(0, "Changing menu settings to default!\n");
           Game_video_resolution = RES_640X480;
-          Render_preferred_state.bit_depth = 16;
+          Render_preferred_state.bit_depth = 32;
           scr_width = 640;
           scr_height = 480;
           Render_preferred_state.width = scr_width;

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -780,7 +780,7 @@ int opengl_Init(oeApplication *app, renderer_preferred_state *pref_state) {
     DEVMODE devmode;
 
     devmode.dmSize = sizeof(devmode);
-    devmode.dmBitsPerPel = 16;
+    devmode.dmBitsPerPel = 32;
     // devmode.dmBitsPerPel=gpu_preferred_state.bit_depth;
     devmode.dmPelsWidth = gpu_preferred_state.width;
     devmode.dmPelsHeight = gpu_preferred_state.height;
@@ -794,7 +794,7 @@ int opengl_Init(oeApplication *app, renderer_preferred_state *pref_state) {
     if (retval != DISP_CHANGE_SUCCESSFUL) {
       mprintf(0, "Display mode change failed (err=%d), trying default!\n", retval);
       retval = -1;
-      devmode.dmBitsPerPel = 16;
+      devmode.dmBitsPerPel = 32;
       devmode.dmPelsWidth = 640;
       devmode.dmPelsHeight = 480;
       devmode.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT;
@@ -807,7 +807,7 @@ int opengl_Init(oeApplication *app, renderer_preferred_state *pref_state) {
         opengl_Close();
         return 0;
       } else {
-        gpu_preferred_state.bit_depth = 16;
+        gpu_preferred_state.bit_depth = 32;
         gpu_preferred_state.width = 640;
         gpu_preferred_state.height = 480;
       }


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [x] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

In windows x64, on trying to run the game, ChangeDisplaySettings will fail because the game does not use the new windows api to change these settings. Since Win95 compatibility mode is not an option for Win64, instead change the default BPP to 32.

There may be a more proper way to handle this, and make it more uniform to remove BPP 16 entirely, but this has worked for me since putting it in a fork over a month ago.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

#418
