### PR TITLE
Enable all compilation warning on unix platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,8 @@ install(
   DESTINATION ${CMAKE_INSTALL_DOCDIR}
 )
 
-if(UNIX)
-  add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-multichar;${BITS};${EXTRA_CXX_FLAGS}>")
-  add_compile_options("$<$<COMPILE_LANGUAGE:C>:${BITS}>")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_compile_options("-Wno-multichar;-Wall")
 endif()
 
 find_package(SDL2 REQUIRED)


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Enable `-Wall` on Unix compilers, in order to catch more problems in the code. Cleanup global compile options, that referred to unset variables