### PR TITLE
Fix compiler warnings

### DIFF
--- a/Descent3/multi.cpp
+++ b/Descent3/multi.cpp
@@ -6418,7 +6418,6 @@ int MultiGetShipChecksum(int ship_index);
 // Starts multiplayer-specific stuff for a new level
 // Anything not specific to multiplayer should be in StartNewLevel()
 bool MultiStartNewLevel(int level) {
-  int i;
   Time_last_taunt_request = 0;
 
   // Figure the ships into the checksum
@@ -6432,7 +6431,7 @@ bool MultiStartNewLevel(int level) {
 
 #ifndef RELEASE
   // Clear our packet tracking
-  for (i = 0; i < 255; i++)
+  for (int i = 0; i < 255; i++)
     Multi_packet_tracking[i] = 0;
 
 #endif
@@ -6446,13 +6445,13 @@ bool MultiStartNewLevel(int level) {
   memset(Multi_additional_shields, 0, MAX_SHIELD_REQUEST_TYPES * 4);
   Multi_requested_damage_amount = 0;
 
-  for (i = 0; i < MAX_OBJECTS; i++) {
+  for (int i = 0; i < MAX_OBJECTS; i++) {
     Server_object_list[i] = 65535;
     Local_object_list[i] = 65535;
     Objects[i].generic_nonvis_flags = 0;
   }
 
-  for (i = 0; i < MAX_SPEW_EFFECTS; i++)
+  for (int i = 0; i < MAX_SPEW_EFFECTS; i++)
     Server_spew_list[i] = 65535;
 
   // SCRIPT POINT!!!
@@ -6461,7 +6460,7 @@ bool MultiStartNewLevel(int level) {
   Num_broke_glass = 0;
 
   // Fill in player object numbers
-  for (i = 0; i < MAX_PLAYERS; i++) {
+  for (int i = 0; i < MAX_PLAYERS; i++) {
     if (Players[i].start_roomnum != -1) {
       int objnum = Players[i].objnum;
 

--- a/Descent3/multi_external.h
+++ b/Descent3/multi_external.h
@@ -313,7 +313,7 @@ inline void MultiAddString(const char *str, uint8_t *data, int *count) {
 
   MultiAddByte((uint8_t)len, data, count);
   memcpy(&data[*count], str, len);
-  *count += len;
+  *count += static_cast<int>(len);
 }
 
 inline uint8_t MultiGetUbyte(uint8_t *data, int *count) {

--- a/editor/DallasMainDlg.cpp
+++ b/editor/DallasMainDlg.cpp
@@ -7151,9 +7151,9 @@ void CDallasMainDlg::FillActionMenu(CMenu *action_menu, int command_offset) {
     // Detach and add this submenu to the action menu
     ColumnizePopupMenu(&category_submenu);
     if (actions_added == 0)
-      action_menu->AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)category_submenu.Detach(), m_FunctionCategories[j]);
+      action_menu->AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)category_submenu.Detach(), m_FunctionCategories[j]);
     else
-      action_menu->AppendMenu(MF_POPUP, (uint32_t)category_submenu.Detach(), m_FunctionCategories[j]);
+      action_menu->AppendMenu(MF_POPUP, (UINT_PTR)category_submenu.Detach(), m_FunctionCategories[j]);
   }
 }
 
@@ -7209,9 +7209,9 @@ void CDallasMainDlg::FillQueryMenu(CMenu *query_menu, int command_offset, int va
     // Detach and add this submenu to the action menu
     ColumnizePopupMenu(&category_submenu);
     if (queries_added == 0)
-      query_menu->AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)category_submenu.Detach(), m_FunctionCategories[j]);
+      query_menu->AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)category_submenu.Detach(), m_FunctionCategories[j]);
     else
-      query_menu->AppendMenu(MF_POPUP, (uint32_t)category_submenu.Detach(), m_FunctionCategories[j]);
+      query_menu->AppendMenu(MF_POPUP, (UINT_PTR)category_submenu.Detach(), m_FunctionCategories[j]);
   }
 }
 
@@ -11836,44 +11836,44 @@ void CDallasMainDlg::FillObjectMenu(CMenu *object_menu, int command_offset, bool
   // Add the powerup submenu
   ColumnizePopupMenu(&powerup_submenu);
   if (powerups_added == 0)
-    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)powerup_submenu.Detach(), "Powerup");
+    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)powerup_submenu.Detach(), "Powerup");
   else
-    object_menu->AppendMenu(MF_POPUP, (uint32_t)powerup_submenu.Detach(), "Powerup");
+    object_menu->AppendMenu(MF_POPUP, (UINT_PTR)powerup_submenu.Detach(), "Powerup");
 
   // Add the robot submenu
   ColumnizePopupMenu(&robot_submenu);
   if (robots_added == 0)
-    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)robot_submenu.Detach(), "Robot");
+    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)robot_submenu.Detach(), "Robot");
   else
-    object_menu->AppendMenu(MF_POPUP, (uint32_t)robot_submenu.Detach(), "Robot");
+    object_menu->AppendMenu(MF_POPUP, (UINT_PTR)robot_submenu.Detach(), "Robot");
 
   // Add the clutter submenu
   ColumnizePopupMenu(&clutter_submenu);
   if (clutter_added == 0)
-    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)clutter_submenu.Detach(), "Clutter");
+    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)clutter_submenu.Detach(), "Clutter");
   else
-    object_menu->AppendMenu(MF_POPUP, (uint32_t)clutter_submenu.Detach(), "Clutter");
+    object_menu->AppendMenu(MF_POPUP, (UINT_PTR)clutter_submenu.Detach(), "Clutter");
 
   // Add the building submenu
   ColumnizePopupMenu(&building_submenu);
   if (buildings_added == 0)
-    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)building_submenu.Detach(), "Building");
+    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)building_submenu.Detach(), "Building");
   else
-    object_menu->AppendMenu(MF_POPUP, (uint32_t)building_submenu.Detach(), "Building");
+    object_menu->AppendMenu(MF_POPUP, (UINT_PTR)building_submenu.Detach(), "Building");
 
   // Add the door submenu
   ColumnizePopupMenu(&door_submenu);
   if (doors_added == 0)
-    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)door_submenu.Detach(), "Door");
+    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)door_submenu.Detach(), "Door");
   else
-    object_menu->AppendMenu(MF_POPUP, (uint32_t)door_submenu.Detach(), "Door");
+    object_menu->AppendMenu(MF_POPUP, (UINT_PTR)door_submenu.Detach(), "Door");
 
   // Add the other submenu
   ColumnizePopupMenu(&other_submenu);
   if (!show_other || others_added == 0)
-    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)other_submenu.Detach(), "Other");
+    object_menu->AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)other_submenu.Detach(), "Other");
   else
-    object_menu->AppendMenu(MF_POPUP, (uint32_t)other_submenu.Detach(), "Other");
+    object_menu->AppendMenu(MF_POPUP, (UINT_PTR)other_submenu.Detach(), "Other");
 }
 
 // Fills up the given menu with the named objects of the specified type
@@ -12096,15 +12096,15 @@ int CDallasMainDlg::FillLiteralMenu(CMenu *literal_menu, int command_offset, int
       if (j == ENUM_PARAMETER_TYPE) {
         ColumnizePopupMenu(&enum_submenu);
         if (types_added > 0)
-          literal_menu->AppendMenu(MF_POPUP, (uint32_t)enum_submenu.Detach(), param_menu_item[j].name);
+          literal_menu->AppendMenu(MF_POPUP, (UINT_PTR)enum_submenu.Detach(), param_menu_item[j].name);
         else
-          literal_menu->AppendMenu(MF_GRAYED | MF_POPUP, (uint32_t)enum_submenu.Detach(), param_menu_item[j].name);
+          literal_menu->AppendMenu(MF_GRAYED | MF_POPUP, (UINT_PTR)enum_submenu.Detach(), param_menu_item[j].name);
       } else if (j == FLAG_PARAMETER_TYPE) {
         ColumnizePopupMenu(&flag_submenu);
         if (flag_types_added > 0)
-          literal_menu->AppendMenu(MF_POPUP, (uint32_t)flag_submenu.Detach(), param_menu_item[j].name);
+          literal_menu->AppendMenu(MF_POPUP, (UINT_PTR)flag_submenu.Detach(), param_menu_item[j].name);
         else
-          literal_menu->AppendMenu(MF_GRAYED | MF_POPUP, (uint32_t)flag_submenu.Detach(), param_menu_item[j].name);
+          literal_menu->AppendMenu(MF_GRAYED | MF_POPUP, (UINT_PTR)flag_submenu.Detach(), param_menu_item[j].name);
       } else
         literal_menu->AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, command_offset + param_menu_item[j].type,
                                  param_menu_item[j].name);
@@ -12147,9 +12147,9 @@ void CDallasMainDlg::FillConditionMenu(CMenu *condition_menu, int command_offset
   condition_menu->AppendMenu(MF_SEPARATOR, 0, "");
 
   ColumnizePopupMenu(&qbin_submenu);
-  condition_menu->AppendMenu(MF_POPUP, (uint32_t)qbin_submenu.Detach(), "Binary Statement with Query");
+  condition_menu->AppendMenu(MF_POPUP, (UINT_PTR)qbin_submenu.Detach(), "Binary Statement with Query");
   ColumnizePopupMenu(&qcomp_submenu);
-  condition_menu->AppendMenu(MF_POPUP, (uint32_t)qcomp_submenu.Detach(), "Comparison Statement with Query");
+  condition_menu->AppendMenu(MF_POPUP, (UINT_PTR)qcomp_submenu.Detach(), "Comparison Statement with Query");
 }
 
 // Creates the Popup menu for the Script Header node
@@ -12176,15 +12176,15 @@ void CDallasMainDlg::DisplayScriptOwnerNodeMenu(POINT *point) {
   object_submenu.CreatePopupMenu();
   FillObjectMenu(&object_submenu, ASSIGN_OBJECT_ID_RANGE_START, TRUE);
   ColumnizePopupMenu(&object_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)object_submenu.Detach(), "Object");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)object_submenu.Detach(), "Object");
 
   trigger_submenu.CreatePopupMenu();
   triggers_added = FillTriggerMenu(&trigger_submenu, ASSIGN_TRIGGER_ID_RANGE_START);
   ColumnizePopupMenu(&trigger_submenu);
   if (triggers_added == 0)
-    main_menu.AppendMenu(MF_POPUP | MF_GRAYED, (uint32_t)trigger_submenu.Detach(), "Trigger");
+    main_menu.AppendMenu(MF_POPUP | MF_GRAYED, (UINT_PTR)trigger_submenu.Detach(), "Trigger");
   else
-    main_menu.AppendMenu(MF_POPUP, (uint32_t)trigger_submenu.Detach(), "Trigger");
+    main_menu.AppendMenu(MF_POPUP, (UINT_PTR)trigger_submenu.Detach(), "Trigger");
 
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, ASSIGN_LEVEL_ID, "Level");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
@@ -12245,17 +12245,17 @@ void CDallasMainDlg::DisplayLogicalOperatorNodeMenu(POINT *point) {
 
   main_menu.CreatePopupMenu();
   ColumnizePopupMenu(&insert_logop_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)insert_logop_submenu.Detach(), "Insert Logical Operator");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)insert_logop_submenu.Detach(), "Insert Logical Operator");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   ColumnizePopupMenu(&condition_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)condition_submenu.Detach(), "Add a New Condition");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)condition_submenu.Detach(), "Add a New Condition");
   ColumnizePopupMenu(&add_logop_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)add_logop_submenu.Detach(), "Add Logical Operator");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)add_logop_submenu.Detach(), "Add Logical Operator");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   ColumnizePopupMenu(&replace_condition_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_condition_submenu.Detach(), "Replace with a Condition");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_condition_submenu.Detach(), "Replace with a Condition");
   ColumnizePopupMenu(&replace_logop_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_logop_submenu.Detach(), "Replace with a New Logical Operator");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_logop_submenu.Detach(), "Replace with a New Logical Operator");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, DELETE_ALL_ID, "Delete this Operator");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
@@ -12283,12 +12283,12 @@ void CDallasMainDlg::DisplayConditionalStatementNodeMenu(POINT *point) {
 
   main_menu.CreatePopupMenu();
   ColumnizePopupMenu(&log_op_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)log_op_submenu.Detach(), "Insert Logical Operator");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)log_op_submenu.Detach(), "Insert Logical Operator");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   ColumnizePopupMenu(&replace_condition_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_condition_submenu.Detach(), "Replace with a New Condition");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_condition_submenu.Detach(), "Replace with a New Condition");
   ColumnizePopupMenu(&replace_logop_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_logop_submenu.Detach(), "Replace with a Logical Operator");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_logop_submenu.Detach(), "Replace with a Logical Operator");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, DELETE_ALL_ID, "Delete this Condition");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
@@ -12312,9 +12312,9 @@ void CDallasMainDlg::DisplayExpressionNodeMenu(POINT *point, int valid_return_ty
 
   main_menu.CreatePopupMenu();
   ColumnizePopupMenu(&replace_with_query_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_with_query_submenu.Detach(), "Replace with Query");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_with_query_submenu.Detach(), "Replace with Query");
   ColumnizePopupMenu(&replace_with_literal_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_with_literal_submenu.Detach(), "Replace with Literal");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_with_literal_submenu.Detach(), "Replace with Literal");
 
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, CANCEL_COMMAND_ID, "Cancel");
@@ -12356,13 +12356,13 @@ void CDallasMainDlg::DisplayActionStatementNodeMenu(POINT *point) {
 
   main_menu.CreatePopupMenu();
   ColumnizePopupMenu(&insert_actions_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)insert_actions_submenu.Detach(), "Insert a New Action");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)insert_actions_submenu.Detach(), "Insert a New Action");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, ADD_IF_THEN_CLAUSE_ID, "Insert a Nested IF-THEN Clause");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, ADD_IF_THEN_ELSE_CLAUSE_ID,
                        "Insert a Nested IF-THEN-ELSE Clause");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   ColumnizePopupMenu(&replace_actions_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_actions_submenu.Detach(), "Replace with a Different Action");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_actions_submenu.Detach(), "Replace with a Different Action");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, DELETE_ALL_ID, "Delete");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
@@ -12405,19 +12405,19 @@ void CDallasMainDlg::DisplayActionHeaderNodeMenu(POINT *point, int level_type, i
   main_menu.CreatePopupMenu();
   ColumnizePopupMenu(&select_extimes_submenu);
   if (level_type == TOP_LEVEL)
-    main_menu.AppendMenu(MF_POPUP, (uint32_t)select_extimes_submenu.Detach(), "Select Max Times to Execute");
+    main_menu.AppendMenu(MF_POPUP, (UINT_PTR)select_extimes_submenu.Detach(), "Select Max Times to Execute");
   else
-    main_menu.AppendMenu(MF_GRAYED | MF_POPUP, (uint32_t)select_extimes_submenu.Detach(),
+    main_menu.AppendMenu(MF_GRAYED | MF_POPUP, (UINT_PTR)select_extimes_submenu.Detach(),
                          "Select Max Times to Execute");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   if (level_type == TOP_LEVEL)
-    main_menu.AppendMenu(MF_POPUP, (uint32_t)select_chain_submenu.Detach(), "Select Script Chaining Option");
+    main_menu.AppendMenu(MF_POPUP, (UINT_PTR)select_chain_submenu.Detach(), "Select Script Chaining Option");
   else
-    main_menu.AppendMenu(MF_GRAYED | MF_POPUP, (uint32_t)select_chain_submenu.Detach(),
+    main_menu.AppendMenu(MF_GRAYED | MF_POPUP, (UINT_PTR)select_chain_submenu.Detach(),
                          "Select Script Chaining Option");
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   ColumnizePopupMenu(&add_actions_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)add_actions_submenu.Detach(), "Add a New Action");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)add_actions_submenu.Detach(), "Add a New Action");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, ADD_IF_THEN_CLAUSE_ID, "Add a Nested IF-THEN Clause");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, ADD_IF_THEN_ELSE_CLAUSE_ID,
                        "Add a Nested IF-THEN-ELSE Clause");
@@ -12599,9 +12599,9 @@ void CDallasMainDlg::DisplayParameterNodeMenu(POINT *point, int param_type, char
 
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   ColumnizePopupMenu(&replace_with_query_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_with_query_submenu.Detach(), "Replace with Query");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_with_query_submenu.Detach(), "Replace with Query");
   ColumnizePopupMenu(&replace_with_literal_submenu);
-  main_menu.AppendMenu(MF_POPUP, (uint32_t)replace_with_literal_submenu.Detach(), "Replace with Literal");
+  main_menu.AppendMenu(MF_POPUP, (UINT_PTR)replace_with_literal_submenu.Detach(), "Replace with Literal");
 
   main_menu.AppendMenu(MF_SEPARATOR, 0, "");
   main_menu.AppendMenu(MF_ENABLED | MF_UNCHECKED | MF_STRING, CANCEL_COMMAND_ID, "Cancel");

--- a/misc/pserror.h
+++ b/misc/pserror.h
@@ -213,8 +213,8 @@ static inline void SetDebugBreakHandlers(void (*stop)(), void (*resume)()) {
   } while (0)
 #define ASSERT(x)                                                                                                      \
   do {                                                                                                                 \
-    if (!(unsigned)(x)) {                                                                                              \
-      mprintf(0, "Assertion failed (%s) in %s line %d.\n", #x, __FILE__, __LINE__);                                  \
+    if (!(x)) {                                                                                                        \
+      mprintf(0, "Assertion failed (%s) in %s line %d.\n", #x, __FILE__, __LINE__);                                    \
       if (Debug_break)                                                                                                 \
         DEBUG_BREAK();                                                                                                 \
       else                                                                                                             \

--- a/netgames/anarchy/anarchy.cpp
+++ b/netgames/anarchy/anarchy.cpp
@@ -561,7 +561,7 @@ void SaveStatsToFile(char *filename) {
   int sortedslots[MAX_PLAYER_RECORDS];
   player_record *pr, *dpr;
   tPInfoStat stat;
-  int count, length, p;
+  int count, p;
 
   // sort the stats
   DMFCBase->GetSortedPlayerSlots(sortedslots, MAX_PLAYER_RECORDS);
@@ -612,8 +612,7 @@ void SaveStatsToFile(char *filename) {
       snprintf(tempbuffer, sizeof(tempbuffer), "%s", DMFCBase->GetTimeString(DMFCBase->GetTimeInGame(p)));
       memcpy(&buffer[82], tempbuffer, strlen(tempbuffer));
 
-      int pos;
-      pos = 82 + strlen(tempbuffer) + 1;
+      size_t pos = 82 + strlen(tempbuffer) + 1;
       if (pos < BUFSIZE)
         buffer[pos] = '\0';
 
@@ -636,7 +635,7 @@ void SaveStatsToFile(char *filename) {
       // Write out header
       snprintf(buffer, sizeof(buffer), "%d) %s%s", count, (pr->state == STATE_INGAME) ? "" : "*", pr->callsign);
       DLLcf_WriteString(file, buffer);
-      length = strlen(buffer);
+      size_t length = strlen(buffer);
       memset(buffer, '=', length);
       buffer[length] = '\0';
       DLLcf_WriteString(file, buffer);
@@ -652,7 +651,6 @@ void SaveStatsToFile(char *filename) {
         if (stat.slot != p) {
           memset(buffer, ' ', BUFSIZE);
           dpr = DMFCBase->GetPlayerRecord(stat.slot);
-          int pos;
 
           ASSERT(dpr != NULL);
           if (dpr) {
@@ -665,7 +663,7 @@ void SaveStatsToFile(char *filename) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
             memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-            pos = 40 + strlen(tempbuffer) + 1;
+            size_t pos = 40 + strlen(tempbuffer) + 1;
             if (pos < BUFSIZE)
               buffer[pos] = '\0';
 
@@ -676,7 +674,6 @@ void SaveStatsToFile(char *filename) {
 
         while (DMFCBase->FindPInfoStatNext(&stat)) {
           if (stat.slot != p) {
-            int pos;
             memset(buffer, ' ', BUFSIZE);
             dpr = DMFCBase->GetPlayerRecord(stat.slot);
 
@@ -690,7 +687,7 @@ void SaveStatsToFile(char *filename) {
               snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
               memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-              pos = 40 + strlen(tempbuffer) + 1;
+              size_t pos = 40 + strlen(tempbuffer) + 1;
               if (pos < BUFSIZE)
                 buffer[pos] = '\0';
 
@@ -735,9 +732,9 @@ void OnPrintScores(int level) {
   char name[50];
   memset(buffer, ' ', 256);
 
-  int t;
-  int pos[6];
-  int len[6];
+  size_t t;
+  size_t pos[6];
+  size_t len[6];
   pos[0] = 0;
   t = len[0] = 20; // give ample room for pilot name
   pos[1] = pos[0] + t + 1;

--- a/netgames/ctf/ctf.cpp
+++ b/netgames/ctf/ctf.cpp
@@ -1400,7 +1400,7 @@ void SaveStatsToFile(char *filename) {
   player_record *pr, *dpr;
   tPInfoStat stat;
   tPlayerStat *ps;
-  int count, length, p;
+  int count, p;
   int team;
 
   // sort the stats
@@ -1511,8 +1511,7 @@ void SaveStatsToFile(char *filename) {
       snprintf(tempbuffer, sizeof(tempbuffer), "%s", DMFCBase->GetTimeString(DMFCBase->GetTimeInGame(real_slot)));
       memcpy(&buffer[86], tempbuffer, strlen(tempbuffer));
 
-      int pos;
-      pos = 86 + strlen(tempbuffer) + 1;
+      size_t pos = 86 + strlen(tempbuffer) + 1;
       if (pos < BUFSIZE)
         buffer[pos] = '\0';
 
@@ -1537,7 +1536,7 @@ void SaveStatsToFile(char *filename) {
       // Write out header
       snprintf(buffer, sizeof(buffer), "%d) %s%s", count, (pr->state == STATE_INGAME) ? "" : "*", pr->callsign);
       DLLcf_WriteString(file, buffer);
-      length = strlen(buffer);
+      size_t length = strlen(buffer);
       memset(buffer, '=', length);
       buffer[length] = '\0';
       DLLcf_WriteString(file, buffer);
@@ -1553,7 +1552,6 @@ void SaveStatsToFile(char *filename) {
         if (stat.slot != p) {
           memset(buffer, ' ', BUFSIZE);
           dpr = DMFCBase->GetPlayerRecord(stat.slot);
-          int pos;
 
           if (dpr) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%s", dpr->callsign);
@@ -1565,7 +1563,7 @@ void SaveStatsToFile(char *filename) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
             memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-            pos = 40 + strlen(tempbuffer) + 1;
+            size_t pos = 40 + strlen(tempbuffer) + 1;
             if (pos < BUFSIZE)
               buffer[pos] = '\0';
 
@@ -1576,7 +1574,6 @@ void SaveStatsToFile(char *filename) {
 
         while (DMFCBase->FindPInfoStatNext(&stat)) {
           if (stat.slot != p) {
-            int pos;
             memset(buffer, ' ', BUFSIZE);
             dpr = DMFCBase->GetPlayerRecord(stat.slot);
             if (dpr) {
@@ -1589,7 +1586,7 @@ void SaveStatsToFile(char *filename) {
               snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
               memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-              pos = 40 + strlen(tempbuffer) + 1;
+              size_t pos = 40 + strlen(tempbuffer) + 1;
               if (pos < BUFSIZE)
                 buffer[pos] = '\0';
 
@@ -1632,11 +1629,11 @@ void OnDisconnectSaveStatsToFile(void) {
 void OnPrintScores(int level) {
   char buffer[256];
   char name[70];
-  int t, i;
-  int pos[6];
-  int len[6];
+  size_t t;
+  size_t pos[6];
+  size_t len[6];
 
-  for (i = 0; i < CTFNumOfTeams; i++) {
+  for (int i = 0; i < CTFNumOfTeams; i++) {
     snprintf(buffer, sizeof(buffer), "%s:%d\n", DMFCBase->GetTeamString(i), TeamScores[i]);
     DPrintf(buffer);
   }
@@ -1677,7 +1674,7 @@ void OnPrintScores(int level) {
   int sortedplayers[MAX_PLAYER_RECORDS];
   DMFCBase->GetSortedPlayerSlots(sortedplayers, MAX_PLAYER_RECORDS);
 
-  for (i = 0; i < pcount; i++) {
+  for (int i = 0; i < pcount; i++) {
     slot = sortedplayers[i];
     pr = DMFCBase->GetPlayerRecord(slot);
     if ((pr) && (pr->state != STATE_EMPTY)) {

--- a/netgames/entropy/EntropyBase.cpp
+++ b/netgames/entropy/EntropyBase.cpp
@@ -1410,7 +1410,7 @@ void SaveStatsToFile(char *filename) {
   player_record *pr, *dpr;
   tPInfoStat stat;
   tPlayerStat *st;
-  int count, length, p;
+  int count, p;
 
   // sort the stats
   DMFCBase->GetSortedPlayerSlots(sortedslots, MAX_PLAYER_RECORDS);
@@ -1497,8 +1497,7 @@ void SaveStatsToFile(char *filename) {
                pr->dstats.suicides[DSTAT_OVERALL]);
       memcpy(&buffer[69], tempbuffer, strlen(tempbuffer));
 
-      int pos;
-      pos = 69 + strlen(tempbuffer) + 1;
+      size_t pos = 69 + strlen(tempbuffer) + 1;
       if (pos < BUFSIZE)
         buffer[pos] = '\0';
 
@@ -1521,7 +1520,7 @@ void SaveStatsToFile(char *filename) {
       // Write out header
       snprintf(buffer, sizeof(buffer), "%d) %s%s", count, (pr->state == STATE_INGAME) ? "" : "*", pr->callsign);
       DLLcf_WriteString(file, buffer);
-      length = strlen(buffer);
+      size_t length = strlen(buffer);
       memset(buffer, '=', length);
       buffer[length] = '\0';
       DLLcf_WriteString(file, buffer);
@@ -1537,7 +1536,6 @@ void SaveStatsToFile(char *filename) {
         if (stat.slot != p) {
           memset(buffer, ' ', BUFSIZE);
           dpr = DMFCBase->GetPlayerRecord(stat.slot);
-          int pos;
 
           if (dpr) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%s", dpr->callsign);
@@ -1549,7 +1547,7 @@ void SaveStatsToFile(char *filename) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
             memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-            pos = 40 + strlen(tempbuffer) + 1;
+            size_t pos = 40 + strlen(tempbuffer) + 1;
             if (pos < BUFSIZE)
               buffer[pos] = '\0';
 
@@ -1560,7 +1558,6 @@ void SaveStatsToFile(char *filename) {
 
         while (DMFCBase->FindPInfoStatNext(&stat)) {
           if (stat.slot != p) {
-            int pos;
             memset(buffer, ' ', BUFSIZE);
             dpr = DMFCBase->GetPlayerRecord(stat.slot);
 
@@ -1574,7 +1571,7 @@ void SaveStatsToFile(char *filename) {
               snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
               memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-              pos = 40 + strlen(tempbuffer) + 1;
+              size_t pos = 40 + strlen(tempbuffer) + 1;
               if (pos < BUFSIZE)
                 buffer[pos] = '\0';
 
@@ -1918,13 +1915,13 @@ void OnGetTokenString(char *src, char *dest, int dest_size) {
 void OnPrintScores(int level) {
   char buffer[256];
   char name[70];
-  int t, i;
-  int pos[6];
-  int len[6];
+  size_t t;
+  size_t pos[6];
+  size_t len[6];
 
   netplayer *dNetPlayers = DMFCBase->GetNetPlayers();
 
-  for (i = 0; i < NUM_TEAMS; i++) {
+  for (int i = 0; i < NUM_TEAMS; i++) {
     snprintf(buffer, sizeof(buffer), "%s:%d\n", DMFCBase->GetTeamString(i), TeamScore[i]);
     DPrintf(buffer);
   }
@@ -1967,7 +1964,7 @@ void OnPrintScores(int level) {
 
   DMFCBase->GetSortedPlayerSlots(sortedplayers, MAX_PLAYER_RECORDS);
 
-  for (i = 0; i < pcount; i++) {
+  for (int i = 0; i < pcount; i++) {
     slot = sortedplayers[i];
     pr = DMFCBase->GetPlayerRecord(slot);
     if ((pr) && (pr->state != STATE_EMPTY)) {

--- a/netgames/hoard/hoard.cpp
+++ b/netgames/hoard/hoard.cpp
@@ -497,9 +497,9 @@ void OnPrintScores(int level) {
   char name[50];
   memset(buffer, ' ', 256);
 
-  int t;
-  int pos[6];
-  int len[6];
+  size_t t;
+  size_t pos[6];
+  size_t len[6];
   pos[0] = 0;
   t = len[0] = 20; // give ample room for pilot name
   pos[1] = pos[0] + t + 1;
@@ -1041,7 +1041,7 @@ void SaveStatsToFile(char *filename) {
   player_record *pr, *dpr;
   tPInfoStat stat;
   tPlayerStat *ps;
-  int count, length, p;
+  int count, p;
 
   // sort the stats
   SortPlayerScores(sortedslots, MAX_PLAYER_RECORDS);
@@ -1091,8 +1091,6 @@ void SaveStatsToFile(char *filename) {
                pr->dstats.deaths[DSTAT_OVERALL]);
       memcpy(&buffer[59], tempbuffer, strlen(tempbuffer));
 
-      int pos;
-
       snprintf(tempbuffer, sizeof(tempbuffer), "%d[%d]", pr->dstats.suicides[DSTAT_LEVEL],
                pr->dstats.suicides[DSTAT_OVERALL]);
       memcpy(&buffer[70], tempbuffer, strlen(tempbuffer));
@@ -1106,7 +1104,7 @@ void SaveStatsToFile(char *filename) {
       snprintf(tempbuffer, sizeof(tempbuffer), "%s", DMFCBase->GetTimeString(DMFCBase->GetTimeInGame(sortedslots[p])));
       memcpy(&buffer[96], tempbuffer, strlen(tempbuffer));
 
-      pos = 96 + strlen(tempbuffer) + 1;
+      size_t pos = 96 + strlen(tempbuffer) + 1;
 
       if (pos < BUFSIZE)
         buffer[pos] = '\0';
@@ -1130,7 +1128,7 @@ void SaveStatsToFile(char *filename) {
       // Write out header
       snprintf(buffer, sizeof(buffer), "%d) %s%s", count, (pr->state == STATE_INGAME) ? "" : "*", pr->callsign);
       DLLcf_WriteString(file, buffer);
-      length = strlen(buffer);
+      size_t length = strlen(buffer);
       memset(buffer, '=', length);
       buffer[length] = '\0';
       DLLcf_WriteString(file, buffer);
@@ -1146,7 +1144,6 @@ void SaveStatsToFile(char *filename) {
         if (stat.slot != p) {
           memset(buffer, ' ', BUFSIZE);
           dpr = DMFCBase->GetPlayerRecord(stat.slot);
-          int pos;
 
           if (dpr) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%s", dpr->callsign);
@@ -1158,7 +1155,7 @@ void SaveStatsToFile(char *filename) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
             memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-            pos = 40 + strlen(tempbuffer) + 1;
+            size_t pos = 40 + strlen(tempbuffer) + 1;
             if (pos < BUFSIZE)
               buffer[pos] = '\0';
 
@@ -1169,7 +1166,6 @@ void SaveStatsToFile(char *filename) {
 
         while (DMFCBase->FindPInfoStatNext(&stat)) {
           if (stat.slot != p) {
-            int pos;
             memset(buffer, ' ', BUFSIZE);
             dpr = DMFCBase->GetPlayerRecord(stat.slot);
             if (dpr) {
@@ -1182,7 +1178,7 @@ void SaveStatsToFile(char *filename) {
               snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
               memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-              pos = 40 + strlen(tempbuffer) + 1;
+              size_t pos = 40 + strlen(tempbuffer) + 1;
               if (pos < BUFSIZE)
                 buffer[pos] = '\0';
 

--- a/netgames/hyperanarchy/hyperanarchy.cpp
+++ b/netgames/hyperanarchy/hyperanarchy.cpp
@@ -540,9 +540,9 @@ void OnPrintScores(int level) {
   char name[50];
   memset(buffer, ' ', 256);
 
-  int t;
-  int pos[6];
-  int len[6];
+  size_t t;
+  size_t pos[6];
+  size_t len[6];
   pos[0] = 0;
   t = len[0] = 20; // give ample room for pilot name
   pos[1] = pos[0] + t + 1;
@@ -919,7 +919,7 @@ void SaveStatsToFile(char *filename) {
   player_record *pr, *dpr;
   tPInfoStat stat;
   tPlayerStat *ps;
-  int count, length, p;
+  int count, p;
 
   // sort the stats
   SortPlayerScores(sortedslots, MAX_PLAYER_RECORDS);
@@ -967,8 +967,6 @@ void SaveStatsToFile(char *filename) {
                pr->dstats.deaths[DSTAT_OVERALL]);
       memcpy(&buffer[59], tempbuffer, strlen(tempbuffer));
 
-      int pos;
-
       snprintf(tempbuffer, sizeof(tempbuffer), "%d[%d]", pr->dstats.suicides[DSTAT_LEVEL],
                pr->dstats.suicides[DSTAT_OVERALL]);
       memcpy(&buffer[70], tempbuffer, strlen(tempbuffer));
@@ -976,7 +974,7 @@ void SaveStatsToFile(char *filename) {
       snprintf(tempbuffer, sizeof(tempbuffer), "%s", DMFCBase->GetTimeString(DMFCBase->GetTimeInGame(sortedslots[p])));
       memcpy(&buffer[81], tempbuffer, strlen(tempbuffer));
 
-      pos = 81 + strlen(tempbuffer) + 1;
+      size_t pos = 81 + strlen(tempbuffer) + 1;
 
       if (pos < BUFSIZE)
         buffer[pos] = '\0';
@@ -1000,7 +998,7 @@ void SaveStatsToFile(char *filename) {
       // Write out header
       snprintf(buffer, sizeof(buffer), "%d) %s%s", count, (pr->state == STATE_INGAME) ? "" : "*", pr->callsign);
       DLLcf_WriteString(file, buffer);
-      length = strlen(buffer);
+      size_t length = strlen(buffer);
       memset(buffer, '=', length);
       buffer[length] = '\0';
       DLLcf_WriteString(file, buffer);
@@ -1018,8 +1016,6 @@ void SaveStatsToFile(char *filename) {
           dpr = DMFCBase->GetPlayerRecord(stat.slot);
 
           if (dpr) {
-            int pos;
-
             snprintf(tempbuffer, sizeof(tempbuffer), "%s", dpr->callsign);
             memcpy(buffer, tempbuffer, strlen(tempbuffer));
 
@@ -1029,7 +1025,7 @@ void SaveStatsToFile(char *filename) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
             memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-            pos = 40 + strlen(tempbuffer) + 1;
+            size_t pos = 40 + strlen(tempbuffer) + 1;
             if (pos < BUFSIZE)
               buffer[pos] = '\0';
 
@@ -1040,7 +1036,6 @@ void SaveStatsToFile(char *filename) {
 
         while (DMFCBase->FindPInfoStatNext(&stat)) {
           if (stat.slot != p) {
-            int pos;
             memset(buffer, ' ', BUFSIZE);
             dpr = DMFCBase->GetPlayerRecord(stat.slot);
 
@@ -1054,7 +1049,7 @@ void SaveStatsToFile(char *filename) {
               snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
               memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-              pos = 40 + strlen(tempbuffer) + 1;
+              size_t pos = 40 + strlen(tempbuffer) + 1;
               if (pos < BUFSIZE)
                 buffer[pos] = '\0';
 

--- a/netgames/includes/DMFC.h
+++ b/netgames/includes/DMFC.h
@@ -547,7 +547,7 @@ struct t_dstat {
   int kills[2], deaths[2], suicides[2];
 };
 
-struct PInfo;
+class PInfo;
 
 struct player_record {
   slot_state state;                 // state of this slot

--- a/netgames/monsterball/monsterball.cpp
+++ b/netgames/monsterball/monsterball.cpp
@@ -1336,11 +1336,11 @@ quick_exit:;
 void OnPrintScores(int level) {
   char buffer[256];
   char name[50];
-  int t, i;
-  int pos[7];
-  int len[7];
+  size_t t;
+  size_t pos[7];
+  size_t len[7];
 
-  for (i = 0; i < NumOfTeams; i++) {
+  for (int i = 0; i < NumOfTeams; i++) {
     snprintf(buffer, sizeof(buffer), "%s:%d\n", DMFCBase->GetTeamString(i), TeamScores[i]);
     DPrintf(buffer);
   }
@@ -1384,7 +1384,7 @@ void OnPrintScores(int level) {
   int sortedplayers[MAX_PLAYER_RECORDS];
   DMFCBase->GetSortedPlayerSlots(sortedplayers, MAX_PLAYER_RECORDS);
 
-  for (i = 0; i < pcount; i++) {
+  for (int i = 0; i < pcount; i++) {
     slot = sortedplayers[i];
     pr = DMFCBase->GetPlayerRecord(slot);
     tPlayerStat *stat;
@@ -1445,7 +1445,7 @@ void SaveStatsToFile(char *filename) {
   int sortedslots[MAX_PLAYER_RECORDS];
   player_record *pr, *dpr;
   tPInfoStat stat;
-  int count, length, p;
+  int count, p;
   tPlayerStat *st;
 
   // sort the stats
@@ -1537,8 +1537,7 @@ void SaveStatsToFile(char *filename) {
                pr->dstats.suicides[DSTAT_OVERALL]);
       memcpy(&buffer[78], tempbuffer, strlen(tempbuffer));
 
-      int pos;
-      pos = 78 + strlen(tempbuffer) + 1;
+      size_t pos = 78 + strlen(tempbuffer) + 1;
       if (pos < BUFSIZE)
         buffer[pos] = '\0';
 
@@ -1562,7 +1561,7 @@ void SaveStatsToFile(char *filename) {
       snprintf(buffer, sizeof(buffer), "%d) %s%s (%s)", count, (pr->state == STATE_INGAME) ? "" : "*", pr->callsign,
                DMFCBase->GetTeamString(pr->team));
       DLLcf_WriteString(file, buffer);
-      length = strlen(buffer);
+      size_t length = strlen(buffer);
       memset(buffer, '=', length);
       buffer[length] = '\0';
       DLLcf_WriteString(file, buffer);
@@ -1580,8 +1579,6 @@ void SaveStatsToFile(char *filename) {
           dpr = DMFCBase->GetPlayerRecord(stat.slot);
 
           if (dpr) {
-            int pos;
-
             strncpy(tempbuffer, DMFCBase->GetTeamString(dpr->team), sizeof(tempbuffer));
             memcpy(buffer, tempbuffer, strlen(tempbuffer));
 
@@ -1594,7 +1591,7 @@ void SaveStatsToFile(char *filename) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
             memcpy(&buffer[46], tempbuffer, strlen(tempbuffer));
 
-            pos = 46 + strlen(tempbuffer) + 1;
+            size_t pos = 46 + strlen(tempbuffer) + 1;
             if (pos < BUFSIZE)
               buffer[pos] = '\0';
 
@@ -1605,7 +1602,6 @@ void SaveStatsToFile(char *filename) {
 
         while (DMFCBase->FindPInfoStatNext(&stat)) {
           if (stat.slot != p) {
-            int pos;
             memset(buffer, ' ', BUFSIZE);
             dpr = DMFCBase->GetPlayerRecord(stat.slot);
             if (dpr) {
@@ -1618,7 +1614,7 @@ void SaveStatsToFile(char *filename) {
               snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
               memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-              pos = 40 + strlen(tempbuffer) + 1;
+              size_t pos = 40 + strlen(tempbuffer) + 1;
               if (pos < BUFSIZE)
                 buffer[pos] = '\0';
 

--- a/netgames/roboanarchy/roboanarchy.cpp
+++ b/netgames/roboanarchy/roboanarchy.cpp
@@ -556,7 +556,7 @@ void SaveStatsToFile(char *filename) {
   int sortedslots[MAX_PLAYER_RECORDS];
   player_record *pr, *dpr;
   tPInfoStat stat;
-  int count, length, p;
+  int count, p;
 
   // sort the stats
   DMFCBase->GetSortedPlayerSlots(sortedslots, MAX_PLAYER_RECORDS);
@@ -607,8 +607,7 @@ void SaveStatsToFile(char *filename) {
       strcpy(tempbuffer, DMFCBase->GetTimeString(DMFCBase->GetTimeInGame(p)));
       memcpy(&buffer[82], tempbuffer, strlen(tempbuffer));
 
-      int pos;
-      pos = 82 + strlen(tempbuffer) + 1;
+      size_t pos = 82 + strlen(tempbuffer) + 1;
       if (pos < BUFSIZE)
         buffer[pos] = '\0';
 
@@ -631,7 +630,7 @@ void SaveStatsToFile(char *filename) {
       // Write out header
       snprintf(buffer, sizeof(buffer), "%d) %s%s", count, (pr->state == STATE_INGAME) ? "" : "*", pr->callsign);
       DLLcf_WriteString(file, buffer);
-      length = strlen(buffer);
+      size_t length = strlen(buffer);
       memset(buffer, '=', length);
       buffer[length] = '\0';
       DLLcf_WriteString(file, buffer);
@@ -647,7 +646,6 @@ void SaveStatsToFile(char *filename) {
         if (stat.slot != p) {
           memset(buffer, ' ', BUFSIZE);
           dpr = DMFCBase->GetPlayerRecord(stat.slot);
-          int pos;
 
           ASSERT(dpr != NULL);
           if (dpr) {
@@ -660,7 +658,7 @@ void SaveStatsToFile(char *filename) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
             memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-            pos = 40 + strlen(tempbuffer) + 1;
+            size_t pos = 40 + strlen(tempbuffer) + 1;
             if (pos < BUFSIZE)
               buffer[pos] = '\0';
 
@@ -671,7 +669,6 @@ void SaveStatsToFile(char *filename) {
 
         while (DMFCBase->FindPInfoStatNext(&stat)) {
           if (stat.slot != p) {
-            int pos;
             memset(buffer, ' ', BUFSIZE);
             dpr = DMFCBase->GetPlayerRecord(stat.slot);
 
@@ -685,7 +682,7 @@ void SaveStatsToFile(char *filename) {
               snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
               memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-              pos = 40 + strlen(tempbuffer) + 1;
+              size_t pos = 40 + strlen(tempbuffer) + 1;
               if (pos < BUFSIZE)
                 buffer[pos] = '\0';
 
@@ -730,9 +727,9 @@ void OnPrintScores(int level) {
   char name[50];
   memset(buffer, ' ', 256);
 
-  int t;
-  int pos[6];
-  int len[6];
+  size_t t;
+  size_t pos[6];
+  size_t len[6];
   pos[0] = 0;
   t = len[0] = 20; // give ample room for pilot name
   pos[1] = pos[0] + t + 1;

--- a/netgames/tanarchy/tanarchy.cpp
+++ b/netgames/tanarchy/tanarchy.cpp
@@ -633,7 +633,7 @@ void SaveStatsToFile(char *filename) {
   int sortedslots[MAX_PLAYER_RECORDS];
   player_record *pr, *dpr;
   tPInfoStat stat;
-  int count, length, p;
+  int count, p;
 
   // sort the stats
   DMFCBase->GetSortedPlayerSlots(sortedslots, MAX_PLAYER_RECORDS);
@@ -719,8 +719,7 @@ void SaveStatsToFile(char *filename) {
                pr->dstats.suicides[DSTAT_OVERALL]);
       memcpy(&buffer[69], tempbuffer, strlen(tempbuffer));
 
-      int pos;
-      pos = 69 + strlen(tempbuffer) + 1;
+      size_t pos = 69 + strlen(tempbuffer) + 1;
       if (pos < BUFSIZE)
         buffer[pos] = '\0';
 
@@ -743,7 +742,7 @@ void SaveStatsToFile(char *filename) {
       // Write out header
       snprintf(buffer, sizeof(buffer), "%d) %s%s", count, (pr->state == STATE_INGAME) ? "" : "*", pr->callsign);
       DLLcf_WriteString(file, buffer);
-      length = strlen(buffer);
+      size_t length = strlen(buffer);
       memset(buffer, '=', length);
       buffer[length] = '\0';
       DLLcf_WriteString(file, buffer);
@@ -759,7 +758,6 @@ void SaveStatsToFile(char *filename) {
         if (stat.slot != p) {
           memset(buffer, ' ', BUFSIZE);
           dpr = DMFCBase->GetPlayerRecord(stat.slot);
-          int pos;
 
           if (dpr) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%s", dpr->callsign);
@@ -771,7 +769,7 @@ void SaveStatsToFile(char *filename) {
             snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
             memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-            pos = 40 + strlen(tempbuffer) + 1;
+            size_t pos = 40 + strlen(tempbuffer) + 1;
             if (pos < BUFSIZE)
               buffer[pos] = '\0';
 
@@ -782,7 +780,6 @@ void SaveStatsToFile(char *filename) {
 
         while (DMFCBase->FindPInfoStatNext(&stat)) {
           if (stat.slot != p) {
-            int pos;
             memset(buffer, ' ', BUFSIZE);
             dpr = DMFCBase->GetPlayerRecord(stat.slot);
 
@@ -796,7 +793,7 @@ void SaveStatsToFile(char *filename) {
               snprintf(tempbuffer, sizeof(tempbuffer), "%d", stat.deaths);
               memcpy(&buffer[40], tempbuffer, strlen(tempbuffer));
 
-              pos = 40 + strlen(tempbuffer) + 1;
+              size_t pos = 40 + strlen(tempbuffer) + 1;
               if (pos < BUFSIZE)
                 buffer[pos] = '\0';
 
@@ -982,11 +979,11 @@ void DisplayWelcomeMessage(int player_num) {
 void OnPrintScores(int level) {
   char buffer[256];
   char name[70];
-  int t, i;
-  int pos[6];
-  int len[6];
+  size_t t;
+  size_t pos[6];
+  size_t len[6];
 
-  for (i = 0; i < NUM_TEAMS; i++) {
+  for (int i = 0; i < NUM_TEAMS; i++) {
     snprintf(buffer, sizeof(buffer), "%s:%d\n", DMFCBase->GetTeamString(i), TeamScore[i]);
     DPrintf(buffer);
   }
@@ -1029,7 +1026,7 @@ void OnPrintScores(int level) {
   int sortedplayers[MAX_PLAYER_RECORDS];
   DMFCBase->GetSortedPlayerSlots(sortedplayers, MAX_PLAYER_RECORDS);
 
-  for (i = 0; i < pcount; i++) {
+  for (int i = 0; i < pcount; i++) {
     slot = sortedplayers[i];
     pr = DMFCBase->GetPlayerRecord(slot);
     if ((pr) && (pr->state != STATE_EMPTY)) {

--- a/scripts/DallasFuncs.cpp
+++ b/scripts/DallasFuncs.cpp
@@ -1559,7 +1559,6 @@ void aLightningCreateGunpoints(int gunpoint1, int gunpoint2, int objhandle, floa
                                int numtiles, int texture_id, float slidetime, int timesdrawn, int red, int green,
                                int blue, bool autotile) {
   msafe_struct mstruct;
-  int type;
 
   mstruct.objhandle = objhandle;
   MSafe_GetValue(MSAFE_OBJECT_POS, &mstruct);
@@ -6653,7 +6652,7 @@ Parameters:
 $$END
 */
 int qPlayerClosest(int objhandle, int varnum) {
-  vector objpos, playerpos;
+  vector objpos;
   float closest_dist = FLT_MAX;
   int closest_player = OBJECT_HANDLE_NONE;
   msafe_struct mstruct;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
This fixes alot of compiler warnings by going for some low-hanging fruit like includes with lots of warnings or smaller changes leading to a cascade of warnings being removed. The change in `pserror.h` alone removes more than one thousand warnings.
For MSVC this gets down from 2440 to 840 warnings.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
