### PR TITLE
Fix deprecation warning about  /Zc:forScope-

### DIFF
--- a/editor/AmbientSoundPattern.cpp
+++ b/editor/AmbientSoundPattern.cpp
@@ -224,11 +224,9 @@ void CAmbientSoundPattern::OnASPNewElement() {
     mem_free(asp->sounds);
 
     asp->sounds = new_sounds;
-    asp->sounds[s] = new_element;
+    asp->sounds[asp->num_sounds++] = new_element;
 
-    asp->num_sounds++;
-
-    m_current_element = s;
+    m_current_element = asp->num_sounds;
 
     UpdateDialog();
   }
@@ -258,7 +256,7 @@ void CAmbientSoundPattern::OnASPDeleteElement() {
       for (int s = 0; s < m_current_element; s++)
         new_sounds[s] = asp->sounds[s];
 
-      for (; s < asp->num_sounds - 1; s++)
+      for (int s = m_current_element; s < asp->num_sounds - 1; s++)
         new_sounds[s] = asp->sounds[s + 1];
 
       mem_free(asp->sounds);

--- a/editor/AnimStatesDialog.cpp
+++ b/editor/AnimStatesDialog.cpp
@@ -608,19 +608,19 @@ void CAnimStatesDialog::UpdateDialog() {
   if (!m_setup_sound_dialogs) {
     m_setup_sound_dialogs = true;
 
-    for (i = 0; i < max_states; i++) {
+    for (int i = 0; i < max_states; i++) {
       SendDlgItemMessage(anim_sounds[i], CB_RESETCONTENT, 0, 0);
     }
-    for (i = 0; i < MAX_SOUNDS; i++) {
-      if (Sounds[i].used) {
+    for (auto & Sound : Sounds) {
+      if (Sound.used) {
         for (int j = 0; j < max_states; j++) {
-          SendDlgItemMessage(anim_sounds[j], CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sounds[i].name);
+          SendDlgItemMessage(anim_sounds[j], CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sound.name);
         }
       }
     }
   }
 
-  for (i = 0; i < max_states; i++) {
+  for (int i = 0; i < max_states; i++) {
     if (m_anim[mc].elem[i].anim_sound_index >= 0 && m_anim[mc].elem[i].anim_sound_index < MAX_SOUNDS &&
         Sounds[m_anim[mc].elem[i].anim_sound_index].used != 0)
       SendDlgItemMessage(anim_sounds[i], CB_SELECTSTRING, 0,
@@ -630,14 +630,14 @@ void CAnimStatesDialog::UpdateDialog() {
   }
 
   SendDlgItemMessage(IDC_CURRENT_STATE_PULLDOWN, CB_RESETCONTENT, 0, 0);
-  for (i = 0; i < NUM_MOVEMENT_CLASSES; i++)
+  for (int i = 0; i < NUM_MOVEMENT_CLASSES; i++)
     SendDlgItemMessage(IDC_CURRENT_STATE_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Movement_class_names[i]);
 
   SendDlgItemMessage(IDC_CURRENT_STATE_PULLDOWN, CB_SELECTSTRING, 0,
                      (LPARAM)(LPCTSTR)Movement_class_names[m_current_state]);
 
   SendDlgItemMessage(IDC_CURRENT_ANIMATION_PULLDOWN, CB_RESETCONTENT, 0, 0);
-  for (i = 0; i < NUM_ANIMS_PER_CLASS; i++)
+  for (int i = 0; i < NUM_ANIMS_PER_CLASS; i++)
     SendDlgItemMessage(IDC_CURRENT_ANIMATION_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Anim_state_names[i]);
 
   SendDlgItemMessage(IDC_CURRENT_ANIMATION_PULLDOWN, CB_SELECTSTRING, 0,

--- a/editor/BriefEdit.cpp
+++ b/editor/BriefEdit.cpp
@@ -669,7 +669,8 @@ bool BEAllocEffect(int *ret_screen, int *ret_effect) {
   int curr_effect = -1;
   int node = Briefing_screens[curr_screen].root_effect;
   tBriefScreen *bscr = &Briefing_screens[curr_screen];
-  for (int i = 0; i < MAX_EFFECTS_PER_SCREEN; i++) {
+  int i;
+  for (i = 0; i < MAX_EFFECTS_PER_SCREEN; i++) {
     if (!bscr->effects[i].used) {
       curr_effect = i;
       break;
@@ -1119,7 +1120,8 @@ bool CBriefEdit::BriefEditAllocateEffect(int *ret_screen, int *ret_effect) {
   int curr_effect = -1;
   int node = Briefing_screens[curr_screen].root_effect;
   tBriefScreen *bscr = &Briefing_screens[curr_screen];
-  for (int i = 0; i < MAX_EFFECTS_PER_SCREEN; i++) {
+  int i;
+  for (i = 0; i < MAX_EFFECTS_PER_SCREEN; i++) {
     if (!bscr->effects[i].used) {
       curr_effect = i;
       break;
@@ -1989,7 +1991,7 @@ void CBriefEdit::ParseLayoutScreenFile(char *filename) {
     }
 
     // read bmp defs
-    for (j = 0; j < layouts[i].num_bmps; j++) {
+    for (int j = 0; j < layouts[i].num_bmps; j++) {
       cf_ReadString(buffer, 512, file);
 
       // now parse to pull out the individual values

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -560,22 +560,52 @@ set(SOURCE
     editor.rc
     ../Descent3/sdlmain.cpp
 )
+set(CMAKE_MFC_FLAG 1)
 
 # Editor only works in Windows, because of MFC and DirectX dependencies
 set(PLATFORM_LIBS linux wsock32.lib winmm.lib dd_grwin32 win32 SDL2::SDL2)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO /NODEFAULTLIB:LIBC")
 
+
 add_executable(Descent3Editor WIN32 ${HEADERS} ${SOURCE})
-
 target_include_directories(Descent3Editor PRIVATE ../lib ../ ../manage/ ${PROJECT_BINARY_DIR}/lib)
-target_compile_definitions(Descent3Editor PUBLIC _AFXDLL EDITOR)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} /Zc:forScope-")
 
-target_link_libraries(Descent3Editor PRIVATE
-  2dlib AudioEncode bitmap cfile dd_video ddebug ddio libmve libacm
-  fix grtext manage mem misc model module stream_audio
-  music networking physics renderer rtperformance sndlib ui unzip vecmat md5
-  ${PLATFORM_LIBS})
+target_compile_definitions(Descent3Editor PUBLIC _AFXDLL EDITOR)
+
+# Link libraries
+target_link_libraries(Descent3Editor
+    2dlib
+    AudioEncode
+    bitmap
+    cfile
+
+    dd_video
+    ddio
+    ddebug
+    libmve
+    libacm
+    fix
+    grtext
+    manage
+    mem
+    misc
+    model
+    module
+
+    stream_audio
+    music
+    networking
+    physics
+    renderer
+    rtperformance
+    sndlib
+    ui
+    unzip
+    vecmat
+    md5
+    ${PLATFORM_LIBS}
+)
+
 target_link_options(Descent3Editor PRIVATE $<$<PLATFORM_ID:Windows>:/DEBUG:FULL>)
 
 add_dependencies(Descent3Editor get_git_hash)

--- a/editor/Erooms.cpp
+++ b/editor/Erooms.cpp
@@ -648,7 +648,8 @@ void GetUVLForRoomPoint(int roomnum, int facenum, int vertnum, roomUVL *uvl) {
 
   // find the center point of this face
   vm_MakeZero(&avg_vert);
-  for (int i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
+  int i;
+  for (i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
     avg_vert += Rooms[roomnum].verts[Rooms[roomnum].faces[facenum].face_verts[i]];
 
   avg_vert /= i;
@@ -766,11 +767,9 @@ void AssignDefaultUVsToRoomFace(room *rp, int facenum) {
 // Searches thru all rooms for a specific name, returns -1 if not found
 // or index of room with name
 int FindRoomName(char *name) {
-  int i;
-
   ASSERT(name != NULL);
 
-  for (i = FIRST_PALETTE_ROOM; i < FIRST_PALETTE_ROOM + MAX_PALETTE_ROOMS; i++)
+  for (int i = FIRST_PALETTE_ROOM; i < FIRST_PALETTE_ROOM + MAX_PALETTE_ROOMS; i++)
     if (Rooms[i].used && Rooms[i].name && !stricmp(name, Rooms[i].name))
       return i;
 
@@ -835,7 +834,7 @@ void SaveRoom(int n, char *filename) {
   cfseek(outfile, savepos, SEEK_SET);
 
   // figure out correct texture ordering
-  for (i = 0; i < Rooms[n].num_faces; i++) {
+  for (int i = 0; i < Rooms[n].num_faces; i++) {
     int16_t index = Rooms[n].faces[i].tmap;
 
     for (found_it = 0, t = 0; t < highest_index; t++) {
@@ -861,7 +860,7 @@ void SaveRoom(int n, char *filename) {
   // Write out how many different textures there are and then write their names
   cf_WriteInt(outfile, highest_index);
 
-  for (i = 0; i < highest_index; i++) {
+  for (int i = 0; i < highest_index; i++) {
     int index = Room_to_texture[i];
     cf_WriteString(outfile, GameTextures[index].used ? GameTextures[index].name : "");
   }
@@ -876,7 +875,7 @@ void SaveRoom(int n, char *filename) {
   facesize = cftell(outfile);
   cf_WriteInt(outfile, -1);
 
-  for (i = 0; i < Rooms[n].num_faces; i++) {
+  for (int i = 0; i < Rooms[n].num_faces; i++) {
     cf_WriteByte(outfile, Rooms[n].faces[i].light_multiple);
     cf_WriteInt(outfile, Rooms[n].faces[i].num_verts);
 
@@ -1073,18 +1072,16 @@ int AllocLoadRoom(char *filename, bool bCenter, bool palette_room) {
 
 // Gets next palette room (from n) that has actually been alloced
 int GetNextRoom(int n) {
-  int i;
-
   ASSERT((n == -1) || ((n >= FIRST_PALETTE_ROOM) && n < FIRST_PALETTE_ROOM + MAX_PALETTE_ROOMS));
 
   if (n == -1) // start at beginning
     n = FIRST_PALETTE_ROOM - 1;
 
-  for (i = n + 1; i < FIRST_PALETTE_ROOM + MAX_PALETTE_ROOMS; i++)
+  for (int i = n + 1; i < FIRST_PALETTE_ROOM + MAX_PALETTE_ROOMS; i++)
     if (Rooms[i].used)
       return i;
 
-  for (i = FIRST_PALETTE_ROOM; i <= n; i++)
+  for (int i = FIRST_PALETTE_ROOM; i <= n; i++)
     if (Rooms[i].used)
       return i;
 
@@ -1206,7 +1203,7 @@ bool FaceIsPlanar(int nv, int16_t *face_verts, vector *normal, vector *verts) {
 
   // Look for points too far from the average
   float d;
-  for (v = 0; v < nv; v++) {
+  for (int v = 0; v < nv; v++) {
     d = verts[face_verts[v]] * *normal;
     if (fabs(d - average_d) > POINT_TO_PLANE_EPSILON)
       return 0;
@@ -1421,8 +1418,6 @@ int RoomAddVertices(room *rp, int num_new_verts) {
 //					num_new_faces - how many faces are being added to the room
 // Returns:		the number of the first new face
 int RoomAddFaces(room *rp, int num_new_faces) {
-  int i;
-
   if (num_new_faces == 0)
     return 0;
 
@@ -1430,7 +1425,7 @@ int RoomAddFaces(room *rp, int num_new_faces) {
 
   ASSERT(newfaces != NULL);
 
-  for (i = 0; i < rp->num_faces; i++)
+  for (int i = 0; i < rp->num_faces; i++)
     newfaces[i] = rp->faces[i];
 
   mem_free(rp->faces);
@@ -1439,7 +1434,7 @@ int RoomAddFaces(room *rp, int num_new_faces) {
   rp->num_faces += num_new_faces;
 
   if (rp->num_bbf_regions) {
-    for (i = 0; i < rp->num_bbf_regions; i++) {
+    for (int i = 0; i < rp->num_bbf_regions; i++) {
       mem_free(rp->bbf_list[i]);
     }
     mem_free(rp->bbf_list);
@@ -1819,6 +1814,7 @@ void DeleteRoomPortal(room *rp, int portalnum) {
   }
 
   // Copy portals over
+  int p;
   for (p = 0; p < portalnum; p++)
     newportals[p] = rp->portals[p];
   for (p++; p < rp->num_portals; p++)
@@ -1954,7 +1950,7 @@ void CopyRoom(room *destp, room *srcp) {
   }
 
   // Copy over the verts
-  for (i = 0; i < destp->num_verts; i++)
+  for (int i = 0; i < destp->num_verts; i++)
     destp->verts[i] = srcp->verts[i];
 
   // Copy doorway info
@@ -1977,14 +1973,13 @@ void CopyRoom(room *destp, room *srcp) {
 // Initializes the flags
 int AddPortal(room *rp) {
   portal *newlist;
-  int i;
 
   newlist = (portal *)mem_malloc(sizeof(*newlist) * (rp->num_portals + 1));
 
   // Copy from old list to new list, and free old list
   if (rp->num_portals) {
 
-    for (i = 0; i < rp->num_portals; i++)
+    for (int i = 0; i < rp->num_portals; i++)
       newlist[i] = rp->portals[i];
 
     mem_free(rp->portals);
@@ -2266,7 +2261,8 @@ int CheckForDuplicateFace(room *rp, int facenum) {
     if (fp0->num_verts == fp1->num_verts)
       for (int v = 0; v < fp1->num_verts; v++) // look for a shared vert
         if (fp1->face_verts[v] == fp0->face_verts[0]) {
-          for (int t = 0; t < fp0->num_verts; t++)
+          int t;
+          for (t = 0; t < fp0->num_verts; t++)
             if (fp0->face_verts[t] != fp1->face_verts[(v + t) % fp1->num_verts])
               break;
           if (t == fp0->num_verts) {
@@ -2552,7 +2548,7 @@ void CountUniqueTextures() {
 
   // Now count totals
   int total = 0, total_with_lights = 0;
-  for (i = 0; i < MAX_TEXTURES; i++) {
+  for (int i = 0; i < MAX_TEXTURES; i++) {
     if (texture_tracking[i]) {
       if (!(GameTextures[i].flags & TF_LIGHT)) {
         total++;
@@ -2568,7 +2564,7 @@ void CountUniqueTextures() {
   if (total > 60)
     CheckError("ERROR: YOU HAVE MORE THAT 60 128x128 TEXTURES...YOU *MUST* FIX THIS!\n");
 
-  for (i = 0; i < MAX_TEXTURES; i++) {
+  for (int i = 0; i < MAX_TEXTURES; i++) {
     if (texture_tracking[i] && !(GameTextures[i].flags & TF_LIGHT)) {
       CheckError("%d : %s %s bmp=%s\n", texture_tracking[i], GameTextures[i].name,
                  (GameTextures[i].flags & TF_ANIMATED) ? "(Animated)" : "",
@@ -2576,7 +2572,7 @@ void CountUniqueTextures() {
     }
   }
 
-  for (i = 0; i < MAX_TEXTURES; i++) {
+  for (int i = 0; i < MAX_TEXTURES; i++) {
     if (texture_tracking[i] && (GameTextures[i].flags & TF_LIGHT)) {
       CheckError("%d : %s %s %s bmp=%s\n", texture_tracking[i], GameTextures[i].name,
                  (GameTextures[i].flags & TF_ANIMATED) ? "(Animated)" : "",
@@ -2916,7 +2912,9 @@ int RemoveDuplicateFacePoints(room *rp) {
         int new_verts[MAX_VERTS_PER_FACE];
         roomUVL new_uvls[MAX_VERTS_PER_FACE];
 
-        for (int t = 0; t < v; t++) {
+        int t;
+
+        for (t = 0; t < v; t++) {
           new_verts[t] = fp->face_verts[t];
           new_uvls[t] = fp->face_uvls[t];
         }
@@ -2991,7 +2989,7 @@ void FixDegenerateFaces() {
                 tverts[i] = fp->face_verts[(v + 2 + i) % fp->num_verts];
                 tuvls[i] = fp->face_uvls[(v + 2 + i) % fp->num_verts];
               }
-              for (i = 0; i < fp->num_verts - 2; i++) {
+              for (int i = 0; i < fp->num_verts - 2; i++) {
                 fp->face_verts[i] = tverts[i];
                 fp->face_uvls[i] = tuvls[i];
               }

--- a/editor/Group.cpp
+++ b/editor/Group.cpp
@@ -346,7 +346,7 @@ group *CopyGroup(int nrooms, int *roomnums, int attachroom, int attachface) {
     // Get memory for triggers
     g->triggers = (trigger *)mem_malloc(sizeof(*g->triggers) * n_triggers);
 
-    for (t = 0; t < Num_triggers; t++)
+    for (int t = 0; t < Num_triggers; t++)
       if (room_xlate[Triggers[t].roomnum] != -1) {
         g->triggers[trignum] = Triggers[t];
         g->triggers[trignum].roomnum = room_xlate[Triggers[t].roomnum];

--- a/editor/HFile.cpp
+++ b/editor/HFile.cpp
@@ -650,7 +650,8 @@ char *IntSpacing(int i) {
 
   i = abs(i);
 
-  for (int n = 1; i >= 10; n++)
+  int n;
+  for (n = 1; i >= 10; n++)
     i /= 10;
 
   ASSERT(n <= 20);

--- a/editor/HRoom.cpp
+++ b/editor/HRoom.cpp
@@ -725,7 +725,7 @@ void AttachRoom() {
     newroomp->verts[i] = ((attroomp->verts[i] - attcenter) * Placed_room_rotmat) + basecenter;
 
   // Copy faces to new room
-  for (i = 0; i < attroomp->num_faces; i++) {
+  for (int i = 0; i < attroomp->num_faces; i++) {
     CopyFace(&newroomp->faces[i], &attroomp->faces[i]);
 #ifdef NEWEDITOR
     LevelTexIncrementTexture(attroomp->faces[i].tmap);
@@ -3043,7 +3043,8 @@ void DeleteVert(room *rp, int facenum, int vertnum) {
 
   // Delete the point on the connected face
   face *fp2 = &rp->faces[f0];
-  for (int v2 = 0; v2 < fp2->num_verts; v2++)
+  int v2;
+  for (v2 = 0; v2 < fp2->num_verts; v2++)
     if (fp2->face_verts[v2] == fp->face_verts[vertnum])
       break;
   ASSERT(v2 < fp2->num_verts);
@@ -3130,7 +3131,7 @@ bool MergeObjectIntoRoom(room *rp, int objnum) {
   int first_new_face = RoomAddFaces(rp, sm->num_faces);
 
   // Copy the faces
-  for (i = 0; i < sm->num_faces; i++) {
+  for (int i = 0; i < sm->num_faces; i++) {
     polyface *pfp = &sm->faces[i];
     face *fp = &rp->faces[first_new_face + i];
 
@@ -3188,7 +3189,7 @@ void DeleteAllConnectedFaces(room *rp, int facenum) {
   MarkFaceForDeletion(rp, facenum);
 
   // Now delete the faces
-  for (f = 0; f < rp->num_faces;) {
+  for (int f = 0; f < rp->num_faces;) {
 
     if (rp->faces[f].tmap == -1)
       DeleteRoomFace(rp, f);

--- a/editor/HTexture.cpp
+++ b/editor/HTexture.cpp
@@ -271,12 +271,10 @@ int HTextureCopyUVsToFace(room *destrp, int destface, room *srcrp, int srcface, 
 //	texture flipping
 
 void HTextureFlipX() {
-  int i;
-
   if (Editor_view_mode == VM_TERRAIN) {
     // terrain_segment oldseg;
 
-    for (i = 0; i < TERRAIN_DEPTH * TERRAIN_WIDTH; i++) {
+    for (int i = 0; i < TERRAIN_DEPTH * TERRAIN_WIDTH; i++) {
       if (TerrainSelected[i]) {
         /*oldseg=Terrain_seg[i];
         Terrain_seg[i].u[0]=oldseg.u[1];
@@ -303,12 +301,10 @@ void HTextureFlipX() {
 }
 
 void HTextureFlipY() {
-  int i;
-
   if (Editor_view_mode == VM_TERRAIN) {
     terrain_segment oldseg;
 
-    for (i = 0; i < TERRAIN_DEPTH * TERRAIN_WIDTH; i++) {
+    for (int i = 0; i < TERRAIN_DEPTH * TERRAIN_WIDTH; i++) {
       if (TerrainSelected[i]) {
         oldseg = Terrain_seg[i];
         /*Terrain_seg[i].v[0]=oldseg.v[3];
@@ -514,9 +510,7 @@ void HTextureRoomStretch(room *rp, int facenum, int edge, int direction) {
 }
 
 void HTextureTerrainStretch(int edge, int direction) {
-  int i;
-
-  for (i = 0; i < TERRAIN_WIDTH * TERRAIN_DEPTH; i++) {
+  for (int i = 0; i < TERRAIN_WIDTH * TERRAIN_DEPTH; i++) {
     if (TerrainSelected[i]) {
     }
   }
@@ -588,7 +582,8 @@ int HTextureGetLeftVertexForFace(int roomnum, int facenum) {
 
   // find the center point of this face
   vm_MakeZero(&avg_vert);
-  for (int i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
+  int i;
+  for (i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
     avg_vert += Rooms[roomnum].verts[Rooms[roomnum].faces[facenum].face_verts[i]];
 
   avg_vert /= i;
@@ -641,7 +636,8 @@ int HTextureGetTopVertexForFace(int roomnum, int facenum) {
 
   // find the center point of this face
   vm_MakeZero(&avg_vert);
-  for (int i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
+  int i;
+  for (i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
     avg_vert += Rooms[roomnum].verts[Rooms[roomnum].faces[facenum].face_verts[i]];
 
   avg_vert /= i;
@@ -695,7 +691,8 @@ int HTextureGetRightVertexForFace(int roomnum, int facenum) {
 
   // find the center point of this face
   vm_MakeZero(&avg_vert);
-  for (int i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
+  int i;
+  for (i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
     avg_vert += Rooms[roomnum].verts[Rooms[roomnum].faces[facenum].face_verts[i]];
 
   avg_vert /= i;
@@ -748,7 +745,8 @@ int HTextureGetBottomVertexForFace(int roomnum, int facenum) {
 
   // find the center point of this face
   vm_MakeZero(&avg_vert);
-  for (int i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
+  int i;
+  for (i = 0; i < Rooms[roomnum].faces[facenum].num_verts; i++)
     avg_vert += Rooms[roomnum].verts[Rooms[roomnum].faces[facenum].face_verts[i]];
 
   avg_vert /= i;

--- a/editor/ObjectDialog.cpp
+++ b/editor/ObjectDialog.cpp
@@ -696,7 +696,7 @@ int CObjectDialog::GetFreePlayerIndex() {
     }
   }
 
-  for (i = 0; i < MAX_NET_PLAYERS; i++) {
+  for (int i = 0; i < MAX_NET_PLAYERS; i++) {
     if (slots[i] == 0) {
       mprintf(0, "Making new ship with id of %d...\n", i);
       return i;

--- a/editor/ProceduralDialog.cpp
+++ b/editor/ProceduralDialog.cpp
@@ -188,7 +188,7 @@ void CProceduralDialog::UpdateDialog() {
 
   uint16_t *data = bm_data(m_palette_bitmap, 0);
 
-  for (i = 0; i < h; i++) {
+  for (int i = 0; i < h; i++) {
     float cur_color = 0;
     float color_delta = 256.0 / (float)w;
     for (int t = 0; t < w; t++, cur_color += color_delta) {
@@ -207,7 +207,7 @@ void CProceduralDialog::UpdateDialog() {
   CComboBox *combo;
   combo = (CComboBox *)GetDlgItem(IDC_PROC_COPY_LIST);
   combo->ResetContent();
-  for (i = 0; i < MAX_TEXTURES; i++) {
+  for (int i = 0; i < MAX_TEXTURES; i++) {
     if (!GameTextures[i].used)
       continue;
     if (i == D3EditState.texdlg_texture)

--- a/editor/SelectRangeDialog.cpp
+++ b/editor/SelectRangeDialog.cpp
@@ -113,7 +113,7 @@ void SelectRangeDialog::OnOK() {
     for (int i = 0; i < TERRAIN_WIDTH * TERRAIN_DEPTH; i++)
       TerrainSelected[i] = 0;
     Num_terrain_selected = 0;
-    for (i = 0; i < TERRAIN_WIDTH * TERRAIN_DEPTH; i++) {
+    for (int i = 0; i < TERRAIN_WIDTH * TERRAIN_DEPTH; i++) {
       int selected = 1;
 
       if (!(Terrain_seg[i].ypos >= LowerBound && Terrain_seg[i].ypos <= UpperBound))

--- a/editor/TerrainDialog.cpp
+++ b/editor/TerrainDialog.cpp
@@ -1652,10 +1652,10 @@ void CTerrainDialog::OnSaveAsPcx() {
   cf_WriteShort(outfile, 256);
   cf_WriteShort(outfile, 2);
 
-  for (i = 0; i < 58; i++)
+  for (int i = 0; i < 58; i++)
     cf_WriteByte(outfile, 0);
 
-  for (i = 0; i < TERRAIN_DEPTH; i++) {
+  for (int i = 0; i < TERRAIN_DEPTH; i++) {
     for (int t = 0; t < TERRAIN_WIDTH; t++) {
       uint8_t val = Terrain_seg[(((TERRAIN_DEPTH - 1) - i) * TERRAIN_WIDTH) + t].ypos;
       uint8_t runlen = 0xc1;
@@ -1666,7 +1666,7 @@ void CTerrainDialog::OnSaveAsPcx() {
   }
 
   cf_WriteByte(outfile, 12);
-  for (i = 0; i < 256; i++) {
+  for (int i = 0; i < 256; i++) {
     cf_WriteByte(outfile, i);
     cf_WriteByte(outfile, i);
     cf_WriteByte(outfile, i);
@@ -1768,12 +1768,12 @@ void CTerrainDialog::OnTerrainOcclusion() {
   memset(save_buffer, 0, TERRAIN_WIDTH * TERRAIN_DEPTH);
   memset(Terrain_fill, 0, TERRAIN_WIDTH * TERRAIN_DEPTH);
 
-  for (i = 0; i < TERRAIN_WIDTH * TERRAIN_DEPTH; i++) {
+  for (int i = 0; i < TERRAIN_WIDTH * TERRAIN_DEPTH; i++) {
     if (Terrain_seg[i].ypos == 255)
       save_buffer[i] = 255;
   }
 
-  for (i = 0; i < OCCLUSION_SIZE; i++) {
+  for (int i = 0; i < OCCLUSION_SIZE; i++) {
     for (int t = 0; t < OCCLUSION_SIZE; t++) {
       int src_occlusion_index = i * OCCLUSION_SIZE + t;
       int start_x = t * OCCLUSION_SIZE;
@@ -1934,7 +1934,7 @@ void CTerrainDialog::OnTerrainOcclusion() {
   mem_free(Terrain_fill);
   mem_free(save_buffer);
 
-  for (i = 0; i < 256; i++)
+  for (int i = 0; i < 256; i++)
     mem_free(touch_buffer[i]);
 
   Terrain_occlusion_checksum = Terrain_checksum + 1;

--- a/editor/WaterProceduralDialog.cpp
+++ b/editor/WaterProceduralDialog.cpp
@@ -150,7 +150,7 @@ void CWaterProceduralDialog::UpdateDialog() {
   CComboBox *combo;
   combo = (CComboBox *)GetDlgItem(IDC_PROC_COPY_LIST);
   combo->ResetContent();
-  for (i = 0; i < MAX_TEXTURES; i++) {
+  for (int i = 0; i < MAX_TEXTURES; i++) {
     if (!GameTextures[i].used)
       continue;
     if (i == D3EditState.texdlg_texture)

--- a/editor/WorldObjectsDoorDialog.cpp
+++ b/editor/WorldObjectsDoorDialog.cpp
@@ -407,9 +407,9 @@ void CWorldObjectsDoorDialog::UpdateDialog() {
   // Update sounds lists
   SendDlgItemMessage(IDC_DOOR_OPEN_SOUND, CB_RESETCONTENT, 0, 0);
   SendDlgItemMessage(IDC_DOOR_OPEN_SOUND, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)NULL_NAME);
-  for (int i = 0; i < MAX_SOUNDS; i++) {
-    if (Sounds[i].used)
-      SendDlgItemMessage(IDC_DOOR_OPEN_SOUND, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sounds[i].name);
+  for (auto & Sound : Sounds) {
+    if (Sound.used)
+      SendDlgItemMessage(IDC_DOOR_OPEN_SOUND, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sound.name);
   }
   if (Doors[n].open_sound == -1)
     SendDlgItemMessage(IDC_DOOR_OPEN_SOUND, CB_SELECTSTRING, 0, (LPARAM)(LPCTSTR)NULL_NAME);
@@ -418,9 +418,9 @@ void CWorldObjectsDoorDialog::UpdateDialog() {
 
   SendDlgItemMessage(IDC_DOOR_CLOSE_SOUND, CB_RESETCONTENT, 0, 0);
   SendDlgItemMessage(IDC_DOOR_CLOSE_SOUND, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)NULL_NAME);
-  for (int i = 0; i < MAX_SOUNDS; i++) {
-    if (Sounds[i].used)
-      SendDlgItemMessage(IDC_DOOR_CLOSE_SOUND, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sounds[i].name);
+  for (auto & Sound : Sounds) {
+    if (Sound.used)
+      SendDlgItemMessage(IDC_DOOR_CLOSE_SOUND, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sound.name);
   }
   if (Doors[n].close_sound == -1)
     SendDlgItemMessage(IDC_DOOR_CLOSE_SOUND, CB_SELECTSTRING, 0, (LPARAM)(LPCTSTR)NULL_NAME);

--- a/editor/WorldWeaponsDialog.cpp
+++ b/editor/WorldWeaponsDialog.cpp
@@ -935,16 +935,16 @@ void CWorldWeaponsDialog::UpdateDialog() {
 
   SendDlgItemMessage(IDC_WEAPON_PULLDOWN, CB_RESETCONTENT, 0, 0);
 
-  for (int i = 0; i < MAX_WEAPONS; i++) {
-    if (Weapons[i].used)
-      SendDlgItemMessage(IDC_WEAPON_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Weapons[i].name);
+  for (auto & Weapon : Weapons) {
+    if (Weapon.used)
+      SendDlgItemMessage(IDC_WEAPON_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Weapon.name);
   }
   SendDlgItemMessage(IDC_WEAPON_PULLDOWN, CB_SELECTSTRING, 0, (LPARAM)(LPCTSTR)Weapons[n].name);
 
   SendDlgItemMessage(IDC_FIRE_SOUND_PULLDOWN, CB_RESETCONTENT, 0, 0);
-  for (int i = 0; i < MAX_SOUNDS; i++) {
-    if (Sounds[i].used)
-      SendDlgItemMessage(IDC_FIRE_SOUND_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sounds[i].name);
+  for (auto & Sound : Sounds) {
+    if (Sound.used)
+      SendDlgItemMessage(IDC_FIRE_SOUND_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sound.name);
   }
   if (Weapons[n].sounds[WSI_FIRE] >= 0 && Weapons[n].sounds[WSI_FIRE] < MAX_SOUNDS &&
       Sounds[Weapons[n].sounds[WSI_FIRE]].used != 0)
@@ -954,9 +954,9 @@ void CWorldWeaponsDialog::UpdateDialog() {
     SendDlgItemMessage(IDC_FIRE_SOUND_PULLDOWN, CB_SELECTSTRING, 0, (LPARAM)(LPCTSTR) "\0");
 
   SendDlgItemMessage(IDC_WEAPON_BOUNCE_SOUND_COMBO, CB_RESETCONTENT, 0, 0);
-  for (int i = 0; i < MAX_SOUNDS; i++) {
-    if (Sounds[i].used)
-      SendDlgItemMessage(IDC_WEAPON_BOUNCE_SOUND_COMBO, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sounds[i].name);
+  for (auto & Sound : Sounds) {
+    if (Sound.used)
+      SendDlgItemMessage(IDC_WEAPON_BOUNCE_SOUND_COMBO, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sound.name);
   }
   if (Weapons[n].sounds[WSI_BOUNCE] >= 0 && Weapons[n].sounds[WSI_BOUNCE] < MAX_SOUNDS &&
       Sounds[Weapons[n].sounds[WSI_BOUNCE]].used != 0)
@@ -966,9 +966,9 @@ void CWorldWeaponsDialog::UpdateDialog() {
     SendDlgItemMessage(IDC_WEAPON_BOUNCE_SOUND_COMBO, CB_SELECTSTRING, 0, (LPARAM)(LPCTSTR) "\0");
 
   SendDlgItemMessage(IDC_WEAPON_WALL_SOUND_PULLDOWN, CB_RESETCONTENT, 0, 0);
-  for (int i = 0; i < MAX_SOUNDS; i++) {
-    if (Sounds[i].used)
-      SendDlgItemMessage(IDC_WEAPON_WALL_SOUND_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sounds[i].name);
+  for (auto & Sound : Sounds) {
+    if (Sound.used)
+      SendDlgItemMessage(IDC_WEAPON_WALL_SOUND_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Sound.name);
   }
   if (Weapons[n].sounds[WSI_IMPACT_WALL] >= 0 && Weapons[n].sounds[WSI_IMPACT_WALL] < MAX_SOUNDS &&
       Sounds[Weapons[n].sounds[WSI_IMPACT_WALL]].used != 0)
@@ -980,9 +980,9 @@ void CWorldWeaponsDialog::UpdateDialog() {
   SendDlgItemMessage(IDC_SMOKE_PULLDOWN, CB_RESETCONTENT, 0, 0);
 
   if (Weapons[n].flags & WF_SMOKE) {
-    for (int i = 0; i < MAX_TEXTURES; i++) {
-      if (GameTextures[i].used)
-        SendDlgItemMessage(IDC_SMOKE_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTextures[i].name);
+    for (auto & GameTexture : GameTextures) {
+      if (GameTexture.used)
+        SendDlgItemMessage(IDC_SMOKE_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTexture.name);
     }
   }
 
@@ -995,9 +995,9 @@ void CWorldWeaponsDialog::UpdateDialog() {
   // Do scorch pulldown
   SendDlgItemMessage(IDC_SCORCH_PULLDOWN, CB_RESETCONTENT, 0, 0);
   SendDlgItemMessage(IDC_SCORCH_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)NULL_NAME);
-  for (int i = 0; i < MAX_TEXTURES; i++) {
-    if (GameTextures[i].used)
-      SendDlgItemMessage(IDC_SCORCH_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTextures[i].name);
+  for (auto & GameTexture : GameTextures) {
+    if (GameTexture.used)
+      SendDlgItemMessage(IDC_SCORCH_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTexture.name);
   }
 
   if ((Weapons[n].scorch_handle >= 0) && GameTextures[Weapons[n].scorch_handle].used)
@@ -1009,9 +1009,9 @@ void CWorldWeaponsDialog::UpdateDialog() {
   // Do icon pulldown
   SendDlgItemMessage(IDC_SMALLIMG_PULLDOWN, CB_RESETCONTENT, 0, 0);
   SendDlgItemMessage(IDC_SMALLIMG_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)NULL_NAME);
-  for (int i = 0; i < MAX_TEXTURES; i++) {
-    if (GameTextures[i].used)
-      SendDlgItemMessage(IDC_SMALLIMG_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTextures[i].name);
+  for (auto & GameTexture : GameTextures) {
+    if (GameTexture.used)
+      SendDlgItemMessage(IDC_SMALLIMG_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTexture.name);
   }
 
   if ((Weapons[n].icon_handle >= 0) && GameTextures[Weapons[n].icon_handle].used)
@@ -1021,9 +1021,9 @@ void CWorldWeaponsDialog::UpdateDialog() {
     SendDlgItemMessage(IDC_SMALLIMG_PULLDOWN, CB_SELECTSTRING, 0, (LPARAM)(LPCTSTR)NULL_NAME);
 
   SendDlgItemMessage(IDC_EXPLODE_PULLDOWN, CB_RESETCONTENT, 0, 0);
-  for (int i = 0; i < MAX_TEXTURES; i++) {
-    if (GameTextures[i].used)
-      SendDlgItemMessage(IDC_EXPLODE_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTextures[i].name);
+  for (auto & GameTexture : GameTextures) {
+    if (GameTexture.used)
+      SendDlgItemMessage(IDC_EXPLODE_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTexture.name);
   }
 
   if (Weapons[n].explode_image_handle >= 0 && GameTextures[Weapons[n].explode_image_handle].used)
@@ -1036,9 +1036,9 @@ void CWorldWeaponsDialog::UpdateDialog() {
 
   // Do particle handle
   SendDlgItemMessage(IDC_PARTICLE_PULLDOWN, CB_RESETCONTENT, 0, 0);
-  for (int i = 0; i < MAX_TEXTURES; i++) {
-    if (GameTextures[i].used)
-      SendDlgItemMessage(IDC_PARTICLE_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTextures[i].name);
+  for (auto & GameTexture : GameTextures) {
+    if (GameTexture.used)
+      SendDlgItemMessage(IDC_PARTICLE_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)GameTexture.name);
   }
 
   if (Weapons[n].particle_handle >= 0 && GameTextures[Weapons[n].particle_handle].used)
@@ -1052,10 +1052,10 @@ void CWorldWeaponsDialog::UpdateDialog() {
   // Do spawn handles
   SendDlgItemMessage(IDC_WEAPON_SPAWN_PULLDOWN, CB_RESETCONTENT, 0, 0);
   SendDlgItemMessage(IDC_SPAWN2_PULLDOWN, CB_RESETCONTENT, 0, 0);
-  for (int i = 0; i < MAX_WEAPONS; i++) {
-    if (Weapons[i].used) {
-      SendDlgItemMessage(IDC_WEAPON_SPAWN_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Weapons[i].name);
-      SendDlgItemMessage(IDC_SPAWN2_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Weapons[i].name);
+  for (auto & Weapon : Weapons) {
+    if (Weapon.used) {
+      SendDlgItemMessage(IDC_WEAPON_SPAWN_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Weapon.name);
+      SendDlgItemMessage(IDC_SPAWN2_PULLDOWN, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)Weapon.name);
     }
   }
 

--- a/editor/editor_lighting.cpp
+++ b/editor/editor_lighting.cpp
@@ -3361,7 +3361,7 @@ void SetupSpecularLighting(int external) {
 
           // Get vertex normals for this punk
           if (GameTextures[fp->tmap].flags & TF_SMOOTH_SPECULAR) {
-            for (k = 0; k < fp->num_verts; k++) {
+            for (int k = 0; k < fp->num_verts; k++) {
               SpecialFaces[n].vertnorms[k] = vertnorms[fp->face_verts[k]];
             }
           }


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
`/Zc:forScope-` was used in old MSVC versions that allows reusing initialized in loops variables outside of these loops. Now this option is deprecated and may be removed in future versions of MSVC (see https://learn.microsoft.com/en-us/cpp/build/reference/zc-forscope-force-conformance-in-for-loop-scope). Fixed out-of-scope variables usage.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
