### PR TITLE
Fix endian issues with iff importer.

### DIFF
--- a/bitmap/iff.cpp
+++ b/bitmap/iff.cpp
@@ -145,24 +145,6 @@ static int bm_iff_parse_delta(CFILE *ifile, int len, iff_bitmap_header *bmheader
 static int bm_iff_parse_file(CFILE *ifile, iff_bitmap_header *bmheader, iff_bitmap_header *prev_bm);
 static void bm_iff_convert_8_to_16(int dest_bm, iff_bitmap_header *iffbm);
 
-/// Read and return a raw integer (32 bits).
-///
-/// Throws an exception of type (cfile_error *) if the OS returns an error on read
-static int32_t cf_ReadIntRaw(CFILE *cfp) {
-  int32_t i;
-  cf_ReadBytes((uint8_t *)&i, sizeof(i), cfp);
-  return i;
-}
-
-/// Read and return a raw \c int16_t (16 bits)
-///
-/// Throws an exception of type (cfile_error *) if the OS returns an error on read
-static int16_t cf_ReadShortRaw(CFILE *cfp) {
-  int16_t i;
-  cf_ReadBytes((uint8_t *)&i, sizeof(i), cfp);
-  return i;
-}
-
 int bm_iff_get_sig(CFILE *f) {
   char s[4];
   int i;
@@ -194,22 +176,22 @@ int bm_iff_get_sig(CFILE *f) {
 int bm_iff_parse_bmhd(CFILE *ifile, uint32_t len, iff_bitmap_header *bmheader) {
   len = len;
 
-  bmheader->w = D3::convert_be(cf_ReadShortRaw(ifile));
-  bmheader->h = D3::convert_be(cf_ReadShortRaw(ifile));
-  bmheader->x = D3::convert_be(cf_ReadShortRaw(ifile));
-  bmheader->y = D3::convert_be(cf_ReadShortRaw(ifile));
+  bmheader->w = cf_ReadShort(ifile, false);
+  bmheader->h = cf_ReadShort(ifile, false);
+  bmheader->x = cf_ReadShort(ifile, false);
+  bmheader->y = cf_ReadShort(ifile, false);
 
   bmheader->nplanes = cf_ReadByte(ifile);
   bmheader->masking = cf_ReadByte(ifile);
   bmheader->compression = cf_ReadByte(ifile);
   cf_ReadByte(ifile); /* skip pad */
 
-  bmheader->transparentcolor = D3::convert_be(cf_ReadShortRaw(ifile));
+  bmheader->transparentcolor = cf_ReadShort(ifile, false);
   bmheader->xaspect = cf_ReadByte(ifile);
   bmheader->yaspect = cf_ReadByte(ifile);
 
-  bmheader->pagewidth = D3::convert_be(cf_ReadShortRaw(ifile));
-  bmheader->pageheight = D3::convert_be(cf_ReadShortRaw(ifile));
+  bmheader->pagewidth = cf_ReadShort(ifile, false);
+  bmheader->pageheight = cf_ReadShort(ifile, false);
 
   iff_transparent_color = bmheader->transparentcolor;
 
@@ -396,7 +378,7 @@ int bm_iff_parse_file(CFILE *ifile, iff_bitmap_header *bmheader, iff_bitmap_head
 
     sig = bm_iff_get_sig(ifile);
 
-    len = D3::convert_be(cf_ReadIntRaw(ifile));
+    len = cf_ReadInt(ifile, false);
 
     switch (sig) {
     case IFF_SIG_FORM: {
@@ -580,7 +562,7 @@ int bm_iff_read_animbrush(const char *ifilename, int *bm_list) {
     return -1;
 
   sig = bm_iff_get_sig(ifile);
-  form_len = D3::convert_be(cf_ReadIntRaw(ifile));
+  form_len = cf_ReadInt(ifile, false);
 
   if (sig != IFF_SIG_FORM) {
     mprintf(0, "Not a valid IFF file.\n");

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -909,17 +909,17 @@ int cf_ReadBytes(uint8_t *buf, int count, CFILE *cfp) {
 // to be present.
 // Read and return an integer (32 bits)
 // Throws an exception of type (cfile_error *) if the OS returns an error on read
-int32_t cf_ReadInt(CFILE *cfp) {
+int32_t cf_ReadInt(CFILE *cfp, bool little_endian) {
   int32_t i;
   cf_ReadBytes((uint8_t *)&i, sizeof(i), cfp);
-  return INTEL_INT(i);
+  return little_endian ? D3::convert_le(i) : D3::convert_be(i);
 }
 // Read and return a int16_t (16 bits)
 // Throws an exception of type (cfile_error *) if the OS returns an error on read
-int16_t cf_ReadShort(CFILE *cfp) {
+int16_t cf_ReadShort(CFILE *cfp, bool little_endian) {
   int16_t i;
   cf_ReadBytes((uint8_t *)&i, sizeof(i), cfp);
-  return INTEL_SHORT(i);
+  return little_endian ? D3::convert_le(i) : D3::convert_be(i);
 }
 // Read and return a byte (8 bits)
 // Throws an exception of type (cfile_error *) if the OS returns an error on read

--- a/cfile/cfile.h
+++ b/cfile/cfile.h
@@ -227,11 +227,11 @@ int cf_ReadBytes(uint8_t *buf, int count, CFILE *cfp);
 
 // Read and return an integer (32 bits)
 // Throws an exception of type (cfile_error *) if the OS returns an error on read
-int32_t cf_ReadInt(CFILE *cfp);
+int32_t cf_ReadInt(CFILE *cfp, bool little_endian = true);
 
 // Read and return a int16_t (16 bits)
 // Throws an exception of type (cfile_error *) if the OS returns an error on read
-int16_t cf_ReadShort(CFILE *cfp);
+int16_t cf_ReadShort(CFILE *cfp, bool little_endian = true);
 
 // Read and return a byte (8 bits)
 // Throws an exception of type (cfile_error *) if the OS returns an error on read


### PR DESCRIPTION

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [X] Build and Dependency changes
- [X] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [X] Other changes

### Description
There were a couple of places that _weren't_ byte-swapped on little-endian systems. And due to `cf_ReadInt` and `cf_ReadShort` automatically calling `INTEL_INT` which then byte-swaps the value on big-endian machines, the next calls to `MOTOROLA_SHORT` and `MOTOROLA_INT` don't swap the value because it's on a big-endian machine.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [X] I have documented any new or modified functionality.
- [X] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [X] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
