### PR TITLE
Fix crash with -nointro

### DIFF
--- a/movie/d3movie.cpp
+++ b/movie/d3movie.cpp
@@ -377,6 +377,7 @@ intptr_t mve_SequenceStart(const char *mvename, void *fhandle, oeApplication *ap
   MVE_memCallbacks(CallbackAlloc, CallbackFree);
   MVE_ioCallbacks(CallbackFileRead);
   MVE_sfCallbacks(CallbackShowFrameNoFlip);
+  MVE_palCallbacks(CallbackSetPalette);
   InitializePalette();
   Movie_bm_handle = -1;
   Movie_looping = looping;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [x] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
When `-no-intro` is used on the command line, the game will crash in https://github.com/DescentDevelopers/Descent3/blob/3c66b13200e929835870cc9445e774cd0742a798/libmve/mveplay.cpp#L327 because the `mve_setpalette` callback was never assigned.

When intros are played, we arrive in `mve_PlayMovie()` which sets the callback with `MVE_palCallbacks(CallbackSetPalette)`. Without intros, we arrive in `mve_SequenceStart()` which doesn't call `MVE_palCallbacks(...)`.

This change will assign the missing callback before we start playing a video.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
#289 introduced the problem

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
