### PR TITLE
MVE refactoring

### DIFF
--- a/libmve/movie_sound.cpp
+++ b/libmve/movie_sound.cpp
@@ -34,6 +34,7 @@ MovieSoundDevice::MovieSoundDevice(int sample_rate, uint16_t sample_size, uint8_
 
   m_device_id = SDL_OpenAudioDevice(nullptr, 0, &spec, nullptr, 0);
   m_is_compressed = is_compressed;
+  m_sample_size = sample_size;
 };
 
 MovieSoundDevice::~MovieSoundDevice() {

--- a/libmve/movie_sound.cpp
+++ b/libmve/movie_sound.cpp
@@ -21,15 +21,6 @@
 
 namespace D3 {
 
-void MovieSoundDevice::SDLAudioCallback(void *userdata, unsigned char *stream, int len) {
-  auto device = static_cast<MovieSoundDevice *>(userdata);
-  for (int i = 0; i < len; i += 2) {
-    int16_t sample = device->m_sound_buffer->front();
-    device->m_sound_buffer->pop_front();
-    memcpy(&stream[i], &sample, 2);
-  }
-}
-
 MovieSoundDevice::MovieSoundDevice(int sample_rate, uint16_t sample_size, uint8_t channels, uint32_t buf_size,
                                    bool is_compressed) {
   SDL_AudioFormat format = (sample_size == 2) ? AUDIO_S16LSB : AUDIO_U8;
@@ -37,8 +28,8 @@ MovieSoundDevice::MovieSoundDevice(int sample_rate, uint16_t sample_size, uint8_
   spec.freq = sample_rate;
   spec.format = format;
   spec.channels = channels;
-  spec.size = 4096;
-  spec.callback = &MovieSoundDevice::SDLAudioCallback;
+  spec.size = buf_size;
+  spec.callback = nullptr;
   spec.userdata = this;
 
   m_device_id = SDL_OpenAudioDevice(nullptr, 0, &spec, nullptr, 0);
@@ -48,16 +39,20 @@ MovieSoundDevice::MovieSoundDevice(int sample_rate, uint16_t sample_size, uint8_
 MovieSoundDevice::~MovieSoundDevice() {
   if (m_device_id > 0) {
     SDL_CloseAudioDevice(m_device_id);
+    m_device_id = 0;
   }
-  m_sound_buffer.reset();
 }
+
+void MovieSoundDevice::FillBuffer(char *stream, int len) const {
+  SDL_QueueAudio(m_device_id, stream, len);
+};
 
 void MovieSoundDevice::Play() { SDL_PauseAudioDevice(m_device_id, 0); }
 
 void MovieSoundDevice::Stop() { SDL_PauseAudioDevice(m_device_id, 1); }
 
-void MovieSoundDevice::Lock() { SDL_LockAudioDevice(m_device_id); };
+void MovieSoundDevice::Lock() { SDL_LockAudioDevice(m_device_id); }
 
-void MovieSoundDevice::Unlock() { SDL_UnlockAudioDevice(m_device_id); };
+void MovieSoundDevice::Unlock() { SDL_UnlockAudioDevice(m_device_id); }
 
 } // namespace D3

--- a/libmve/movie_sound.h
+++ b/libmve/movie_sound.h
@@ -29,6 +29,7 @@ namespace D3 {
 class MovieSoundDevice : ISoundDevice {
 private:
   SDL_AudioDeviceID m_device_id = 0;
+  uint16_t m_sample_size = 0;
 
 public:
   /**
@@ -54,6 +55,12 @@ public:
    * @param len length of source buffer
    */
   void FillBuffer(char *stream, int len) const;
+
+  /**
+   * Get sample size
+   * @return 2 (for 16 bit), 1 (for 8 bit)
+   */
+  [[nodiscard]] uint16_t GetSampleSize() const { return m_sample_size; };
 
   void Play() override;
   void Stop() override;

--- a/libmve/movie_sound.h
+++ b/libmve/movie_sound.h
@@ -49,19 +49,17 @@ public:
   [[nodiscard]] bool IsInitialized() const { return m_device_id > 0; }
 
   /**
-   * Callback for filling SDL audio buffer
-   * @param userdata pointer to instance of this class
-   * @param stream stream that will be filled on callback
-   * @param len length of stream
+   * Fill internal audio stream to be played
+   * @param stream source buffer
+   * @param len length of source buffer
    */
-  void static SDLAudioCallback(void *userdata, unsigned char *stream, int len);
+  void FillBuffer(char *stream, int len) const;
 
   void Play() override;
   void Stop() override;
   void Lock() override;
   void Unlock() override;
 
-  using ISoundDevice::GetBuffer;
   using ISoundDevice::IsCompressed;
 
 };

--- a/libmve/mve_audio.cpp
+++ b/libmve/mve_audio.cpp
@@ -61,23 +61,23 @@ static int16_t getWord(unsigned char **fin) {
   return value;
 }
 
-void mveaudio_process(char *buffer, unsigned char *data, bool is_compressed) {
+void mveaudio_process(char *buffer, unsigned char *data, int sample_size, bool is_compressed) {
   if (is_compressed) {
     int nCurOffsets[2];
 
     data += 4;
-    int samples = getWord(&data) / 2;
+    int samples = getWord(&data) / sample_size;
     // Fill predictors
     nCurOffsets[0] = getWord(&data);
     nCurOffsets[1] = getWord(&data);
 
     for (int i = 0; i < samples; i++) {
       nCurOffsets[i & 1] = std::clamp(nCurOffsets[i & 1] + audio_exp_table[data[i]], -32768, 32767);
-      memcpy(buffer + i * 2, &nCurOffsets[i & 1], 2);
+      memcpy(buffer + i * sample_size, &nCurOffsets[i & 1], sample_size);
     }
   } else {
     data += 2;
-    int samples = getWord(&data);
-    memcpy(buffer, &data, samples * 2);
+    int size = getWord(&data);
+    memcpy(buffer, &data, size);
   }
 }

--- a/libmve/mve_audio.h
+++ b/libmve/mve_audio.h
@@ -24,6 +24,6 @@
  * @param data input data
  * @param is_compress true if input data is compressed
  */
-void mveaudio_process(std::unique_ptr<std::deque<int16_t>> &buffer, unsigned char *data, bool is_compressed = true);
+void mveaudio_process(char *buffer, unsigned char *data, bool is_compressed = true);
 
 #endif /* INCLUDED_MVE_AUDIO_H */

--- a/libmve/mve_audio.h
+++ b/libmve/mve_audio.h
@@ -22,8 +22,9 @@
  * Process input data and send parsed data into queue buffer
  * @param buffer output queue buffer
  * @param data input data
+ * @param sample_size size of sample (1 for 8 bit, 2 for 16 bit)
  * @param is_compress true if input data is compressed
  */
-void mveaudio_process(char *buffer, unsigned char *data, bool is_compressed = true);
+void mveaudio_process(char *buffer, unsigned char *data, int sample_size, bool is_compressed = true);
 
 #endif /* INCLUDED_MVE_AUDIO_H */

--- a/libmve/mveplay.cpp
+++ b/libmve/mveplay.cpp
@@ -208,7 +208,7 @@ static int audio_data_handler(unsigned char major, unsigned char minor, unsigned
     if (chan & selected_chan) {
       void *buf = malloc(size);
       if (major == MVE_OPCODE_AUDIOFRAMEDATA) {
-        mveaudio_process((char *)buf, data, snd_ds->IsCompressed());
+        mveaudio_process((char *)buf, data, snd_ds->GetSampleSize(), snd_ds->IsCompressed());
       } else {
         // SILENCE, MORTALS!
         memset(data, 0, size);

--- a/libmve/sound_interface.h
+++ b/libmve/sound_interface.h
@@ -20,19 +20,15 @@
 #define LIBMVE_SOUND_INTERFACE_H_
 
 #include <cstdint>
-#include <deque>
-#include <memory>
 
 namespace D3 {
 
 /// Abstract class for sound device.
 class ISoundDevice {
 protected:
-  std::unique_ptr<std::deque<int16_t>> m_sound_buffer;
   bool m_is_compressed = false;
 
 public:
-  ISoundDevice() { this->m_sound_buffer = std::make_unique<std::deque<int16_t>>(); };
   /// Play stream
   virtual void Play() {};
   /// Stop stream
@@ -42,8 +38,6 @@ public:
   /// Unlock buffer
   virtual void Unlock() {};
 
-  /// Get access to sound buffer
-  std::unique_ptr<std::deque<int16_t>> &GetBuffer() { return m_sound_buffer; }
   /// Check if encoded sound is compressed
   [[nodiscard]] bool IsCompressed() const { return m_is_compressed; };
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [x] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

This PR changes MVE library to use "push" model of filling sound buffer by switching to `SDL_QueueAudio()` instead of "pull" by using SDLAudioCallback. This fixes some issues when the sound buffer gets exhausted before refilling and delays on slow Debug environments.
Additional fix addressed to correct sample_size on `mveaudio_process()` with 8-bit samples (though they don't used in D3).

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Closes #490.

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
