### PR TITLE
Use `POSIX` instead of `__LINUX__` for general OS checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,11 @@ message("SDL2 Include Dir is ${SDL2_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS}")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   message("Building for Linux")
-  add_compile_definitions(__LINUX__ _USE_OGL_ACTIVE_TEXTURES PRIMARY_HOG=\"d3-linux.hog\")
+  add_compile_definitions(POSIX __LINUX__ _USE_OGL_ACTIVE_TEXTURES PRIMARY_HOG=\"d3-linux.hog\")
   set(PLATFORM_INCLUDES "lib/linux" ${SDL2_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS})
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   message("Building for MAC OSX")
-  add_compile_definitions(__LINUX__ MACOSX=1 _USE_OGL_ACTIVE_TEXTURES PRIMARY_HOG=\"d3-osx.hog\")
+  add_compile_definitions(POSIX MACOSX=1 _USE_OGL_ACTIVE_TEXTURES PRIMARY_HOG=\"d3-osx.hog\")
   set(PLATFORM_INCLUDES "lib/linux" ${SDL2_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS})
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   # Windows.h defines to avoid as many issues as possible.

--- a/Descent3/BriefingParse.h
+++ b/Descent3/BriefingParse.h
@@ -50,7 +50,7 @@
 #ifndef __BRIEFPARSE_H_
 #define __BRIEFPARSE_H_
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include "linux_fix.h" //for stricmp
 #endif
 

--- a/Descent3/ConfigItem.h
+++ b/Descent3/ConfigItem.h
@@ -58,7 +58,7 @@
 
 #include "newui.h"
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 void CIListBoxCallback(int ID, void *);
 void CISliderCallback(int ID, void *);
 #endif

--- a/Descent3/Game2DLL.cpp
+++ b/Descent3/Game2DLL.cpp
@@ -92,7 +92,7 @@ struct game_api {
   tOSIRISModuleInit *osiris_functions;
 };
 // The exported DLL function call prototypes
-#if defined(__LINUX__)
+#if defined(POSIX)
 typedef void DLLFUNCCALL (*DLLGameCall_fp)(int eventnum, dllinfo *data);
 typedef void DLLFUNCCALL (*DLLGameInit_fp)(int *api_func, uint8_t *all_ok, int num_teams_to_use);
 typedef void DLLFUNCCALL (*DLLGameClose_fp)();

--- a/Descent3/LoadLevel.cpp
+++ b/Descent3/LoadLevel.cpp
@@ -3240,7 +3240,7 @@ void ReadTerrainSkyAndLightChunk(CFILE *fp, int version) {
 
   Terrain_sky.flags = cf_ReadInt(fp);
 
-#ifdef __LINUX__
+#if defined(POSIX)
   if (FindArg("-noterrainfog") > 0) {
     Terrain_sky.flags &= ~TF_FOG;
   }

--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -1694,12 +1694,12 @@ void InitLevelScript() {
     ddio_SplitPath(Current_level->filename, NULL, filename, ext);
 #if defined(WIN32)
     strcat(filename, ".dll");
-#else
-#if defined(MACOSX)
+#elif defined(MACOSX)
     strcat(filename, ".dylib");
-#else
+#elif defined(__LINUX__)
     strcat(filename, ".so");
-#endif
+#else
+    #error Unsupported platform!
 #endif
     Osiris_LoadLevelModule(filename);
   }

--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -438,7 +438,7 @@ bool Show_osiris_debug = false;
        // 0, only when the level ends
 
 // The exported DLL function call prototypes
-#if defined(__LINUX__)
+#if defined(POSIX)
 typedef char DLLFUNCCALL (*InitializeDLL_fp)(tOSIRISModuleInit *function_list);
 typedef void DLLFUNCCALL (*ShutdownDLL_fp)(void);
 typedef int DLLFUNCCALL (*GetGOScriptID_fp)(const char *name, uint8_t isdoor);
@@ -3144,7 +3144,7 @@ int Osiris_ExtractScriptsFromHog(int library_handle, bool is_mission_hog) {
   int count = 0;
 
   const char *script_extension;
-#if defined(__LINUX__)
+#if defined(POSIX)
 #if defined(MACOSX)
   script_extension = "*.dylib";
 #else

--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -3144,14 +3144,14 @@ int Osiris_ExtractScriptsFromHog(int library_handle, bool is_mission_hog) {
   int count = 0;
 
   const char *script_extension;
-#if defined(POSIX)
 #if defined(MACOSX)
   script_extension = "*.dylib";
-#else
+#elif defined(__LINUX__)
   script_extension = "*.so";
-#endif
-#else
+#elif defined(WIN32)
   script_extension = "*.dll";
+#else
+  #error Unsupported platform!
 #endif
 
   int index;
@@ -4037,4 +4037,3 @@ void Osiris_CreateModuleInitStruct(tOSIRISModuleInit *mi) {
     mi->fp[i] = NULL;
   }
 }
-

--- a/Descent3/config.cpp
+++ b/Descent3/config.cpp
@@ -679,7 +679,7 @@ struct video_menu {
     sheet->AddLongRadioButton("1600x1200");
     *resolution = iTemp;
 
-#if !defined(__LINUX__)
+#if !defined(POSIX)
     // renderer bit depth
     switch (Render_preferred_bitdepth) {
     case 16:
@@ -708,7 +708,7 @@ struct video_menu {
 
     sheet->NewGroup(TXT_MONITOR, 0, 180);
     vsync = sheet->AddLongCheckBox(TXT_CFG_VSYNCENABLED, (Render_preferred_state.vsync_on != 0));
-#ifndef __LINUX__
+#if !defined(POSIX)
     sheet->AddText("");
     sheet->AddLongButton(TXT_AUTO_GAMMA, IDV_AUTOGAMMA);
 #endif
@@ -723,7 +723,7 @@ struct video_menu {
       Render_preferred_state.mipping = (*mipmapping) ? 1 : 0;
     if (vsync)
       Render_preferred_state.vsync_on = (*vsync) ? 1 : 0;
-#if !defined(__LINUX__)
+#if !defined(POSIX)
     if (bitdepth)
       Render_preferred_bitdepth = (*bitdepth) == 1 ? 32 : 16;
 #endif
@@ -753,7 +753,7 @@ struct video_menu {
 
   // process
   void process(int res) {
-#ifndef __LINUX__
+#if !defined(POSIX)
     switch (res) {
     case IDV_AUTOGAMMA:
       config_gamma();

--- a/Descent3/credits.cpp
+++ b/Descent3/credits.cpp
@@ -94,7 +94,7 @@
 #include <math.h>
 #include "psrand.h"
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 

--- a/Descent3/dedicated_server.cpp
+++ b/Descent3/dedicated_server.cpp
@@ -108,7 +108,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#ifndef __LINUX__
+#if !defined(POSIX)
 typedef int socklen_t;
 #endif
 
@@ -788,7 +788,7 @@ void PrintDedicatedMessage(const char *fmt, ...) {
   DedicatedSocketputs(buf);
 }
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>

--- a/Descent3/gamesave.cpp
+++ b/Descent3/gamesave.cpp
@@ -511,7 +511,7 @@ struct tLoadGameDialogData {
   chunked_bitmap chunk;
 };
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 void LoadGameDialogCB(newuiTiledWindow *wnd, void *data)
 #else
 void __cdecl LoadGameDialogCB(newuiTiledWindow *wnd, void *data)

--- a/Descent3/matcen.cpp
+++ b/Descent3/matcen.cpp
@@ -1904,7 +1904,7 @@ void InitMatcens() {
   atexit(DestroyAllMatcens);
 }
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 void DestroyAllMatcens()
 #else
 void __cdecl DestroyAllMatcens()

--- a/Descent3/mission_download.cpp
+++ b/Descent3/mission_download.cpp
@@ -826,7 +826,7 @@ int msn_ExtractZipFile(char *zipfilename, char *mn3name) {
   return 1;
 }
 
-#ifdef __LINUX__
+#if defined(POSIX)
 char *_strlwr(char *string) {
   char *ptr = string;
   while (*ptr) {

--- a/Descent3/mmItem.h
+++ b/Descent3/mmItem.h
@@ -103,7 +103,7 @@ enum tmmItemFX {
 void MenuScene(); // display menu scene
 /////////////////////////////////////////////////////////////////////
 // gcc doesn't like the tQueue template in psclass.h
-#ifdef __LINUX__
+#if defined(POSIX)
 //	tQueue
 //		a circular queue implementation
 class tmmItemQueue {
@@ -144,7 +144,7 @@ class mmItem : public UIGadget {
   int16_t m_alpha; // alpha for text item
   int16_t m_satcount;
   tmmItemFX m_curfx; // current effect
-#ifndef __LINUX__
+#if !defined(POSIX)
   tQueue<tmmItemFX, 8> m_fxqueue; // special effects queue
 #else
   tmmItemQueue m_fxqueue;

--- a/Descent3/multi.h
+++ b/Descent3/multi.h
@@ -498,7 +498,7 @@
 #include "object_external.h"
 #include "player_external.h"
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 

--- a/Descent3/multi_dll_mgr.cpp
+++ b/Descent3/multi_dll_mgr.cpp
@@ -328,7 +328,7 @@ extern bool Multi_Gamelist_changed;
 int CheckMissionForScript(char *mission, char *script, int dedicated_server_num_teams);
 void ShowNetgameInfo(network_game *game);
 // The exported DLL function call prototypes
-#if defined(__LINUX__)
+#if defined(POSIX)
 typedef void DLLFUNCCALL (*DLLMultiCall_fp)(int eventnum);
 typedef void DLLFUNCCALL (*DLLMultiScoreCall_fp)(int eventnum, void *data);
 typedef void DLLFUNCCALL (*DLLMultiInit_fp)(int *api_fp);

--- a/Descent3/multi_external.h
+++ b/Descent3/multi_external.h
@@ -107,7 +107,7 @@
 #ifndef __MULTI_EXTERNAL_H_
 #define __MULTI_EXTERNAL_H_
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include <cstring>
 #include <cstdint>
 typedef uintptr_t DWORD;

--- a/Descent3/newui.h
+++ b/Descent3/newui.h
@@ -187,7 +187,7 @@
 #ifndef NEWUI_H
 #define NEWUI_H
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include "linux_fix.h" //fix some of the stricmp's
 #endif
 

--- a/Descent3/sdlmain.cpp
+++ b/Descent3/sdlmain.cpp
@@ -142,13 +142,13 @@ void just_exit(void) {
 #endif
 
   SDL_Quit();
-#ifdef __LINUX__
+#if defined(POSIX)
   sync(); // just in case.
 #endif
   _exit(0);
 }
 
-#ifdef __LINUX__
+#if defined(POSIX)
 void fatal_signal_handler(int signum) {
   switch (signum) {
   case SIGHUP:
@@ -612,7 +612,7 @@ int main(int argc, char *argv[]) {
     }
 
     bool run_d3 = true;
-#ifdef __LINUX__
+#if defined(POSIX)
     if (flags & APPFLAG_USESERVICE) {
       run_d3 = false;
       pid_t np = fork();

--- a/Descent3/terrainrender.cpp
+++ b/Descent3/terrainrender.cpp
@@ -2717,7 +2717,7 @@ static g3Point *slist[256];
 // Draws the 2 triangles of the Terrainlist[index] (software)
 int DrawTerrainTrianglesSoftware(int index, int bm_handle, int upper_left, int lower_right) {
   /*
-  #ifndef __LINUX__
+  #if !defined(POSIX)
           int i,tlist[4],close=0,lit=0;
           float closest_z=9999;
           int color;

--- a/bitmap/lightmap.cpp
+++ b/bitmap/lightmap.cpp
@@ -24,7 +24,7 @@
 #include "bitmap.h"
 #include "mono.h"
 #include "mem.h"
-#ifndef __LINUX__
+#if !defined(POSIX)
 #include "Macros.h"
 #endif
 

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -28,7 +28,7 @@
 #include <memory>
 #include <vector>
 
-#ifndef __LINUX__
+#if !defined(POSIX)
 // Non-Linux Build Includes
 #include <io.h>
 #else
@@ -425,7 +425,7 @@ CFILE *open_file_in_directory(const std::filesystem::path &filename, const char 
   fp = fopen(using_filename.u8string().c_str(), tmode);
 
   if (!fp) {
-#ifdef __LINUX__
+#if defined(POSIX)
     // If we tried to open file for reading, assume there maybe case-sensitive files
     if (tmode[0] == 'r') {
       // Try different cases of the filename

--- a/ddebug/debug.h
+++ b/ddebug/debug.h
@@ -133,7 +133,7 @@
 #define IDNO 7
 #endif
 // #define DEBUG_LEVEL 0		//DAJ
-#if defined(WIN32) || defined(__LINUX__)
+#if defined(WIN32) || defined(POSIX)
 constexpr const int OSMBOX_OK = 1;
 constexpr const int OSMBOX_YESNO = 2;
 constexpr const int OSMBOX_YESNOCANCEL = 3;
@@ -172,7 +172,7 @@ void Debug_ConsolePrintfAt(int n, int row, int col, const char *format, ...);
 #if !defined(RELEASE)
 #include "debugbreak.h"
 #if defined(WIN32)
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 void ddio_InternalKeyClose();
 #else
 #define debug_break()

--- a/ddio/lnxio.cpp
+++ b/ddio/lnxio.cpp
@@ -118,7 +118,7 @@ bool ddio_GetBinaryPath(char *exec_path, size_t len) {
    fprintf(stderr, "Buffer too small; need size %u\n", size);
    return false;
   }
-#elif defined(POSIX)
+#elif defined(__LINUX__)
   if (realpath("/proc/self/exe", exec_path) == NULL) {
    perror("realpath");
    return false;

--- a/ddio/lnxio.cpp
+++ b/ddio/lnxio.cpp
@@ -118,7 +118,7 @@ bool ddio_GetBinaryPath(char *exec_path, size_t len) {
    fprintf(stderr, "Buffer too small; need size %u\n", size);
    return false;
   }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   if (realpath("/proc/self/exe", exec_path) == NULL) {
    perror("realpath");
    return false;

--- a/legacy/briefinglocalizer/briefinglocalizerDlg.cpp
+++ b/legacy/briefinglocalizer/briefinglocalizerDlg.cpp
@@ -23,7 +23,7 @@
 #include "briefinglocalizer.h"
 #include "briefinglocalizerDlg.h"
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 

--- a/legacy/inetfile/CFtp.cpp
+++ b/legacy/inetfile/CFtp.cpp
@@ -63,7 +63,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef __LINUX__
+#if defined(POSIX)
 // sorry, I'm lazy, I guess we could copy the defines
 // that we need to transalte winsock->linux into this header...but no need to now
 #include "inetgetfile.h"
@@ -75,14 +75,14 @@
 
 #include "CFtp.h"
 
-#ifdef __LINUX__
+#if defined(POSIX)
 void *FTPObjThread(void *obj)
 #else
 void FTPObjThread(void *obj)
 #endif
 {
   ((CFtpGet *)obj)->WorkerThread();
-#ifdef __LINUX__
+#if defined(POSIX)
   return NULL;
 #endif
 }
@@ -199,7 +199,7 @@ CFtpGet::CFtpGet(char *URL, char *localfile, char *Username, char *Password) {
     m_State = FTP_STATE_INTERNAL_ERROR;
     return;
   }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   pthread_t thread;
   if (!inet_LoadThreadLib()) {
     m_State = FTP_STATE_INTERNAL_ERROR;
@@ -216,7 +216,7 @@ CFtpGet::CFtpGet(char *URL, char *localfile, char *Username, char *Password) {
 CFtpGet::~CFtpGet() {
   if (m_ListenSock != INVALID_SOCKET) {
     shutdown(m_ListenSock, 2);
-#ifndef __LINUX__
+#if !defined(POSIX)
     closesocket(m_ListenSock);
 #else
     close(m_ListenSock);
@@ -224,7 +224,7 @@ CFtpGet::~CFtpGet() {
   }
   if (m_DataSock != INVALID_SOCKET) {
     shutdown(m_DataSock, 2);
-#ifndef __LINUX__
+#if !defined(POSIX)
     closesocket(m_DataSock);
 #else
     close(m_DataSock);
@@ -232,7 +232,7 @@ CFtpGet::~CFtpGet() {
   }
   if (m_ControlSock != INVALID_SOCKET) {
     shutdown(m_ControlSock, 2);
-#ifndef __LINUX__
+#if !defined(POSIX)
     closesocket(m_ControlSock);
 #else
     close(m_ControlSock);
@@ -317,7 +317,7 @@ uint32_t CFtpGet::GetFile() {
 
   m_DataSock = accept(m_ListenSock, NULL, NULL); //(SOCKADDR *)&sockaddr,&iAddrLength);
                                                  // Close the listen socket
-#ifndef __LINUX__
+#if !defined(POSIX)
   closesocket(m_ListenSock);
 #else
   close(m_ListenSock);
@@ -388,7 +388,7 @@ uint32_t CFtpGet::IssuePort() {
   // Tell the server which port to use for data.
   nReplyCode = SendFTPCommand(szCommandString);
   if (nReplyCode != 200) {
-#ifdef __LINUX__
+#if defined(POSIX)
     // I don't know if this is just Linux or do to a bug I fixed while porting to linux
     // for some reason I kept getting reply 250 here and have to read again to get the
     // "200 PORT Command OK" or whatever
@@ -485,7 +485,7 @@ uint32_t CFtpGet::ReadFTPServerReply() {
 
     if (iBytesRead == SOCKET_ERROR) {
       int iWinsockErr = WSAGetLastError();
-#ifdef __LINUX__
+#if defined(POSIX)
       if (0 == iWinsockErr) {
         continue;
       }
@@ -531,7 +531,7 @@ uint32_t CFtpGet::ReadDataChannel() {
       return 0;
     nBytesRecv = recv(m_DataSock, (char *)&sDataBuffer, sizeof(sDataBuffer), 0);
 
-#ifdef __LINUX__
+#if defined(POSIX)
     if (nBytesRecv == -1) {
       int iWinsockErr = WSAGetLastError();
       if (iWinsockErr == 0) {

--- a/legacy/inetfile/Chttpget.cpp
+++ b/legacy/inetfile/Chttpget.cpp
@@ -129,7 +129,7 @@
 #define mem_free(a) free(a)
 #endif
 
-#ifdef __LINUX__
+#if defined(POSIX)
 
 inline void Sleep(int millis) {
   struct timeval tv;
@@ -143,7 +143,7 @@ inline void Sleep(int millis) {
 #define NW_AGHBN_LOOKUP 2
 #define NW_AGHBN_READ 3
 
-#ifndef __LINUX__
+#if !defined(POSIX)
 void __cdecl http_gethostbynameworker(void *parm);
 #else
 void *http_gethostbynameworker(void *parm);
@@ -151,7 +151,7 @@ void *http_gethostbynameworker(void *parm);
 
 int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname);
 
-#ifndef __LINUX__
+#if !defined(POSIX)
 void HTTPObjThread(void *obj)
 #else
 void *HTTPObjThread(void *obj)
@@ -161,7 +161,7 @@ void *HTTPObjThread(void *obj)
   ((ChttpGet *)obj)->m_Aborted = true;
   // OutputDebugString("http transfer exiting....\n");
 
-#ifdef __LINUX__
+#if defined(POSIX)
   return NULL;
 #endif
 }
@@ -264,7 +264,7 @@ void ChttpGet::GetFile(char *URL, char *localfile) {
     m_State = HTTP_STATE_INTERNAL_ERROR;
     return;
   }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   pthread_t thread;
   if (!inet_LoadThreadLib()) {
     m_State = HTTP_STATE_INTERNAL_ERROR;
@@ -280,7 +280,7 @@ void ChttpGet::GetFile(char *URL, char *localfile) {
 ChttpGet::~ChttpGet() {
   if (m_DataSock != INVALID_SOCKET) {
     shutdown(m_DataSock, 2);
-#ifndef __LINUX__
+#if !defined(POSIX)
     closesocket(m_DataSock);
 #else
     close(m_DataSock);
@@ -484,7 +484,7 @@ int ChttpGet::ConnectSocket() {
   int serr = connect(m_DataSock, (SOCKADDR *)&hostaddr, sizeof(SOCKADDR));
   int cerr = WSAGetLastError();
   if (serr) {
-#ifdef __LINUX__
+#if defined(POSIX)
     while ((cerr == WSAEALREADY) || (cerr == WSAEINVAL) || (cerr == WSAEWOULDBLOCK) || (cerr == EINPROGRESS))
 #else
     while ((cerr == WSAEALREADY) || (cerr == WSAEINVAL) || (cerr == WSAEWOULDBLOCK))
@@ -529,7 +529,7 @@ char *ChttpGet::GetHTTPLine() {
 
       if (SOCKET_ERROR == iBytesRead) {
         int error = WSAGetLastError();
-#ifdef __LINUX__
+#if defined(POSIX)
         if (WSAEWOULDBLOCK == error || 0 == error)
 #else
         if (WSAEWOULDBLOCK == error)
@@ -552,7 +552,7 @@ char *ChttpGet::GetHTTPLine() {
 
         if (SOCKET_ERROR == iBytesRead) {
           int error = WSAGetLastError();
-#ifdef __LINUX__
+#if defined(POSIX)
           if (WSAEWOULDBLOCK == error || 0 == error)
 #else
           if (WSAEWOULDBLOCK == error)
@@ -612,7 +612,7 @@ uint32_t ChttpGet::ReadDataChannel() {
 
     if (SOCKET_ERROR == nBytesRecv) {
       int error = WSAGetLastError();
-#ifdef __LINUX__
+#if defined(POSIX)
       if (WSAEWOULDBLOCK == error || 0 == error)
 #else
       if (WSAEWOULDBLOCK == error)
@@ -648,7 +648,7 @@ uint32_t ChttpGet::ReadDataChannel() {
 async_dns_lookup httpaslu;
 async_dns_lookup *http_lastaslu = NULL;
 
-#ifndef __LINUX__
+#if !defined(POSIX)
 void __cdecl http_gethostbynameworker(void *parm);
 #else
 void *http_gethostbynameworker(void *parm);
@@ -672,7 +672,7 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
 
 #ifdef WIN32
     _beginthread(http_gethostbynameworker, 0, newaslu);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
     pthread_t thread;
     if (!inet_LoadThreadLib()) {
       return 0;
@@ -704,20 +704,20 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
 }
 
 // This is the worker thread which does the lookup.
-#ifndef __LINUX__
+#if !defined(POSIX)
 void __cdecl http_gethostbynameworker(void *parm)
 #else
 void *http_gethostbynameworker(void *parm)
 #endif
 {
-#ifdef __LINUX__
+#if defined(POSIX)
   df_pthread_detach(df_pthread_self());
 #endif
   async_dns_lookup *lookup = (async_dns_lookup *)parm;
   HOSTENT *he = gethostbyname(lookup->host);
   if (he == NULL) {
     lookup->error = true;
-#ifdef __LINUX__
+#if defined(POSIX)
     return NULL;
 #else
     return;
@@ -729,7 +729,7 @@ void *http_gethostbynameworker(void *parm)
   }
   mem_free(lookup);
 
-#ifdef __LINUX__
+#if defined(POSIX)
   return NULL;
 #endif
 }

--- a/legacy/inetfile/inetgetfile.cpp
+++ b/legacy/inetfile/inetgetfile.cpp
@@ -90,7 +90,7 @@
 extern char *Proxy_server;
 extern int16_t Proxy_port;
 
-#ifdef __LINUX__
+#if defined(POSIX)
 pthread_create_fp df_pthread_create = NULL;
 pthread_exit_fp df_pthread_exit = NULL;
 pthread_detach_fp df_pthread_detach = NULL;

--- a/legacy/renderer/opengl.cpp
+++ b/legacy/renderer/opengl.cpp
@@ -19,7 +19,7 @@
 #if defined(WIN32)
 #include <windows.h>
 #include "ddraw.h"
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 #include "linux_fix.h"
 #include "lnxscreenmode.h"
 #else
@@ -83,7 +83,7 @@ static HWND hOpenGLWnd = NULL;
 static HDC hOpenGLDC = NULL;
 HGLRC ResourceContext;
 static WORD Saved_gamma_values[256 * 3];
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 static Display *OpenGL_Display = NULL;
 static Window OpenGL_Window;
 static XVisualInfo OpenGL_VisualInfo;
@@ -355,7 +355,7 @@ void opengl_SetDefaults() {
   Last_texel_unit_set = -1;
   OpenGL_multitexture_state = false;
 
-#ifdef __LINUX__
+#if defined(POSIX)
   OpenGL_UseLists = (FindArg("-gllists")) ? true : false;
   if (OpenGL_UseLists) {
 #endif
@@ -366,7 +366,7 @@ void opengl_SetDefaults() {
     dglVertexPointer(3, GL_FLOAT, 0, GL_verts);
     dglColorPointer(4, GL_FLOAT, 0, GL_colors);
     dglTexCoordPointer(4, GL_FLOAT, 0, GL_tex_coords);
-#ifdef __LINUX__
+#if defined(POSIX)
   }
 #endif
 
@@ -494,7 +494,7 @@ int opengl_Setup(HDC glhdc) {
 
   return 1;
 }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 bool opengl_GetXConfig(Display *dpy, XVisualInfo *vis, int attrib, int *value) {
   int res;
 
@@ -783,7 +783,7 @@ int opengl_Init(oeApplication *app, renderer_preferred_state *pref_state) {
   // Save gamma values for later
   GetDeviceGammaRamp(hOpenGLDC, (LPVOID)Saved_gamma_values);
 
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   /***********************************************************
    *               LINUX OPENGL
    ***********************************************************
@@ -985,7 +985,7 @@ void opengl_Close(const bool just_resizing) {
   // Change our display back
   if (!WindowGL)
     ChangeDisplaySettings(NULL, 0);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   // Restore our video mode
   LinuxVideoMode.Lock(false);
   LinuxVideoMode.RestoreVideoMode();
@@ -1034,7 +1034,7 @@ void opengl_Close(const bool just_resizing) {
   SetDeviceGammaRamp(hOpenGLDC, (LPVOID)Saved_gamma_values);
   //	I'm freeing the DC here - samir
   ReleaseDC(hOpenGLWnd, hOpenGLDC);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 
 #else
 
@@ -1561,11 +1561,11 @@ void opengl_DrawMultitexturePolygon(int handle, g3Point **p, int nv, int map_typ
   opengl_SetMultitextureBlendMode(true);
 
   // And draw!
-#ifdef __LINUX__
+#if defined(POSIX)
   if (OpenGL_UseLists) {
 #endif
     dglDrawArrays(GL_POLYGON, 0, nv);
-#ifdef __LINUX__
+#if defined(POSIX)
   } else {
     dglBegin(GL_POLYGON);
     for (i = 0; i < nv; i++) {
@@ -1746,7 +1746,7 @@ void opengl_DrawPolygon(int handle, g3Point **p, int nv, int map_type) {
       colorp->a = alpha;
     }
 
-#ifdef __LINUX__
+#if defined(POSIX)
     // MY TEST HACK...MAYBE BAD DRIVERS? OR MAYBE THIS IS
     // HOW IT SHOULD BE DONE (STILL BUGGY)
     // Texture this polygon!
@@ -1778,11 +1778,11 @@ void opengl_DrawPolygon(int handle, g3Point **p, int nv, int map_type) {
   }
 
   // And draw!
-#ifdef __LINUX__
+#if defined(POSIX)
   if (OpenGL_UseLists) {
 #endif
     dglDrawArrays(GL_POLYGON, 0, nv);
-#ifdef __LINUX__
+#if defined(POSIX)
   } else {
     dglBegin(GL_POLYGON);
     for (i = 0; i < nv; i++) {
@@ -1880,7 +1880,7 @@ void opengl_Flip() {
 
 #if defined(WIN32)
   SwapBuffers((HDC)hOpenGLDC);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   glXWaitGL();
   glXSwapBuffers(OpenGL_Display, OpenGL_Window);
 #endif
@@ -2561,7 +2561,7 @@ void opengl_GetStatistics(tRendererStats *stats) {
   stats->texture_uploads = OpenGL_last_uploaded;
 }
 
-#ifdef __LINUX__
+#if defined(POSIX)
 void CreateFullScreenWindow(Display *dpy, Window rootwin, Window window, int DisplayScreen, int DisplayWidth,
                             int DisplayHeight) {
   // see if a motif based window manager is running.  do this by

--- a/legacy/renderer/renderer.cpp
+++ b/legacy/renderer/renderer.cpp
@@ -439,7 +439,7 @@
 #endif
 
 // Renderers for Linux version
-#if defined(__LINUX__)
+#if defined(POSIX)
 #define USE_OPENGL
 #define USE_GLIDE
 // #define USE_D3D

--- a/lib/CZip.h
+++ b/lib/CZip.h
@@ -21,7 +21,7 @@
 
 #include <cstdio>
 #include <cstdint>
-#ifdef __LINUX__
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 

--- a/lib/bitmap.h
+++ b/lib/bitmap.h
@@ -23,7 +23,7 @@
 
 #include "cfile.h"
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include "linux_fix.h" //needed for stricmp's throughout bitmap lib
 #endif
 

--- a/lib/lnxscreenmode.h
+++ b/lib/lnxscreenmode.h
@@ -52,7 +52,7 @@
 #ifndef __LNXVIDEOMODE_H__
 #define __LNXVIDEOMODE_H__
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 #include <SDL.h>

--- a/lib/manage.h
+++ b/lib/manage.h
@@ -26,7 +26,7 @@
 #include "bitmap.h"
 #include "manage_external.h"
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include "linux_fix.h" //for strnicmp,etc.
 #endif
 

--- a/lib/module.h
+++ b/lib/module.h
@@ -105,7 +105,7 @@ struct module {
   HINSTANCE handle; // handle to the DLL
 };
 //=======================================================================
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 //==========================Linux Definitions============================
 
 #define MODPROCADDRESS void *

--- a/lib/networking.h
+++ b/lib/networking.h
@@ -189,7 +189,7 @@ static inline void INADDR_GET_SUN_SUNB(struct in_addr *st, uint8_t *s_b1, uint8_
   *s_b4 = st->S_un.S_un_b.s_b4;
 }
 
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 // Linux includes/defines
 
 #include <sys/types.h>
@@ -490,7 +490,7 @@ struct async_dns_lookup {
   bool abort;      // read only to worker thread. If this is set, don't fill in the struct.
 
   // rcg06212000 added to let us join the thread at completion...
-#ifdef __LINUX__
+#if defined(POSIX)
   SDL_Thread *threadId;
 #endif
 };
@@ -500,7 +500,7 @@ struct async_dns_lookup {
 #else
 #define CDECLCALL
 #endif
-#ifdef __LINUX__
+#if defined(POSIX)
 // rcg06192000 used to return void *.
 int CDECLCALL gethostbynameworker(void *parm);
 #else

--- a/lib/pstypes.h
+++ b/lib/pstypes.h
@@ -22,7 +22,7 @@
 #include <cstdlib>
 #include <cstdint>
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 

--- a/lib/rtperformance.h
+++ b/lib/rtperformance.h
@@ -26,8 +26,8 @@
 #define USE_RTP
 #endif
 
-#if defined(__LINUX__)
-// #if defined(__LINUX__)
+#if defined(POSIX)
+// #if defined(POSIX)
 #ifdef USE_RTP
 #undef USE_RTP // no rtp for now
 #endif
@@ -35,7 +35,7 @@
 
 // use INT64 for 64bit integers
 #ifdef USE_RTP
-#if defined(__LINUX__)
+#if defined(POSIX)
 #define INT64 int64_t
 #else
 #define INT64 signed __int64

--- a/lib/ui.h
+++ b/lib/ui.h
@@ -267,7 +267,7 @@
 #ifndef UI_H
 #define UI_H
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include "linux_fix.h" //for stricmp's through code
 #endif
 
@@ -399,7 +399,7 @@ private:
   void CheckFocusOnSlaves(int mx, int my);
 
 //	universal variables
-#ifdef __LINUX__ // gcc has a hard time tracing through some of the derived classes that access m_Wnd
+#if defined(POSIX) // gcc has a hard time tracing through some of the derived classes that access m_Wnd
 public:
 #else
 protected:
@@ -421,7 +421,7 @@ protected:
   void UnlockFocus();              // releases lock on input to gadget.
 
 //	called from outside gadget hierarchy.
-#ifdef __LINUX__ // gcc has a hard time tracing through the dervived classes of newuiButton and thinks it can't access
+#if defined(POSIX) // gcc has a hard time tracing through the dervived classes of newuiButton and thinks it can't access
                  // OnFormat()
 public:
 #else

--- a/linux/lnxapp.cpp
+++ b/linux/lnxapp.cpp
@@ -70,7 +70,7 @@
 
 #include <cstdlib>
 #include <cctype>
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <sys/time.h>
 #include <term.h>
 #include <termios.h>
@@ -85,7 +85,7 @@
 #undef buttons
 #endif
 
-#ifdef __LINUX__
+#if defined(POSIX)
 static struct termios Linux_initial_terminal_settings;
 #endif
 
@@ -122,7 +122,7 @@ void LnxAppShutdown() {
   LinuxAppDontCallShutdown = true;
   if (LinuxAppFlags & OEAPP_CONSOLE) {
     con_Destroy();
-#ifdef __LINUX__
+#if defined(POSIX)
     tcsetattr(0, TCSANOW, &Linux_initial_terminal_settings);
 #endif
   }
@@ -134,7 +134,7 @@ oeLnxApplication::oeLnxApplication(unsigned flags) {
   m_AppActive = true;
 
   if (flags & OEAPP_CONSOLE) {
-#ifdef __LINUX__
+#if defined(POSIX)
     tcgetattr(0, &Linux_initial_terminal_settings);
 #endif
     con_Create(m_Flags);
@@ -150,7 +150,7 @@ oeLnxApplication::oeLnxApplication(unsigned flags) {
 
 //	Create object with a premade info
 oeLnxApplication::oeLnxApplication(tLnxAppInfo *appinfo) {
-#ifdef __LINUX__
+#if defined(POSIX)
   tcgetattr(0, &Linux_initial_terminal_settings);
 #endif
   m_Flags = appinfo->flags;

--- a/linux/lnxapp.h
+++ b/linux/lnxapp.h
@@ -19,7 +19,7 @@
 #ifndef LNXAPP_H
 #define LNXAPP_H
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 

--- a/linux/lnxdata.cpp
+++ b/linux/lnxdata.cpp
@@ -45,7 +45,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <unistd.h>
 #include <pwd.h>
 #else
@@ -215,7 +215,7 @@ bool oeLnxAppDatabase::write(const char *label, int entry) {
 
 // get the current user's name from the os
 void oeLnxAppDatabase::get_user_name(char *buffer, size_t *size) {
-#ifdef __LINUX__
+#if defined(POSIX)
   struct passwd *pwuid = getpwuid(geteuid());
 
   if ((pwuid != NULL) && (pwuid->pw_name != NULL)) {

--- a/manage/manage.cpp
+++ b/manage/manage.cpp
@@ -441,7 +441,7 @@
 #include <cstring>
 #include <filesystem>
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 #include "descent.h"

--- a/mem/mem.cpp
+++ b/mem/mem.cpp
@@ -188,7 +188,7 @@
  *
  * $NoKeywords: $
  */
-#ifndef __LINUX__
+#if !defined(POSIX)
 #include <new.h>
 #endif
 #if defined(MACOSX)
@@ -247,7 +247,7 @@ bool Mem_superlow_memory_mode = false;
 // If this is set, the mem library ignores mem_free() calls.  All the memory is then freed at once on exit.
 bool Mem_quick_exit = false;
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 // Linux memory management
 int LnxTotalMemUsed;
 
@@ -308,7 +308,7 @@ bool mem_dumpmallocstofile(char *filename) { return false; }
 
 #pragma mark -
 
-#else // defined(__LINUX__)
+#else // defined(POSIX)
 // Windows memory management
 
 // Uncomment this to detect memory leaks and memory overwrites. Slows down mallocs and frees a little.
@@ -368,7 +368,7 @@ void operator delete(void *ptr)
 int handle_program_memory_depletion(size_t size);
 HANDLE Heap;
 void mem_Init() {
-#if defined(WIN32) || defined(__LINUX__)
+#if defined(WIN32) || defined(POSIX)
   //	allocate failsafe block for memory used by any functions after we run out of memory.
   // (printf for instance needs heap memory, as well as our error library.)
   MEMORYSTATUS ms;
@@ -443,7 +443,7 @@ void mem_Init() {
   }
   return;
 #endif
-#if defined(WIN32) || defined(__LINUX__)
+#if defined(WIN32) || defined(POSIX)
   Mem_failsafe_block = mem_malloc(128);
   if (!Mem_failsafe_block) {
     Error("No available heap memory.");

--- a/misc/pserror.h
+++ b/misc/pserror.h
@@ -234,7 +234,7 @@ static inline void SetDebugBreakHandlers(void (*stop)(), void (*resume)()) {
     if (_heapchk() != _HEAPOK)                                                                                         \
       Int3();                                                                                                          \
   } while (0)
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 #include "SDL.h"
 // For some reason Linux doesn't like the \ continuation character, so I have to uglify this
 #define DEBUG_BREAK()                                                                                                  \

--- a/misc/psglob.cpp
+++ b/misc/psglob.cpp
@@ -39,7 +39,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <ctype.h>
 #endif
 

--- a/module/module.cpp
+++ b/module/module.cpp
@@ -96,7 +96,7 @@
 #include "pserror.h"
 #include "ddio.h"
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <dlfcn.h>
 
 static bool mod_FindRealFileNameCaseInsenstive(const char *directory, const char *filename, char *new_filename);
@@ -108,7 +108,7 @@ static bool mod_FindRealFileNameCaseInsenstive(const char *directory, const char
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include "linux_fix.h"
 #endif
 #if defined(WIN32) // INSTEAD OF MAKING MODULE HAVE DEPENDENCIES, PUT THE 2 DDIO FUNCTIONS I NEED HERE
@@ -158,7 +158,7 @@ static void dd_MakePath(char *newPath, const char *absolutePathHeader, const cha
   }
   va_end(args);
 }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 // Split a pathname into its component parts
 static void dd_SplitPath(const char *srcPath, char *path, char *filename, char *ext) {
   int pathStart = -1;
@@ -281,7 +281,7 @@ void mod_GetRealModuleName(const char *modfilename, char *realmodfilename) {
   if (*extension == '\0')
 #if defined(WIN32)
     strcat(filename, ".dll");
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 #if defined(MACOSX)
     strcat(filename, ".dylib");
 #else
@@ -294,12 +294,12 @@ void mod_GetRealModuleName(const char *modfilename, char *realmodfilename) {
       strcat(filename, ".dll");
     else
       strcat(filename, extension);
-#elif defined(__LINUX__) && !defined(MACOSX)
+#elif defined(POSIX) && !defined(MACOSX)
     if (!stricmp(extension, ".dll") || !stricmp(extension, "msl") || !stricmp(extension, "dylib"))
       strcat(filename, ".so");
     else
       strcat(filename, extension);
-#elif defined(__LINUX__) && defined(MACOSX)
+#elif defined(POSIX) && defined(MACOSX)
       if (!stricmp(extension, ".dll") || !stricmp(extension, "msl") || !stricmp(extension, "so"))
         strcat(filename, ".dylib");
       else
@@ -348,7 +348,7 @@ bool mod_LoadModule(module *handle, const char *imodfilename, int flags) {
     }
     return false;
   }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   int f = 0;
   if (flags & MODF_LAZY)
     f |= RTLD_LAZY;
@@ -398,7 +398,7 @@ bool mod_FreeModule(module *handle) {
   }
 #if defined(WIN32)
   ret = (FreeLibrary(handle->handle) != 0);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   dlclose(handle->handle); // dlclose() returns an int, but no docs say what values!!!
 #endif
   handle->handle = NULL;
@@ -460,7 +460,7 @@ MODPROCADDRESS mod_GetSymbol(module *handle, const char *symstr, uint8_t parmbyt
     }
     return NULL;
   }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   sym = dlsym(handle->handle, symstr);
   if (!sym) {
     ModLastError = MODERR_OTHER;
@@ -476,7 +476,7 @@ int mod_GetLastError(void) {
   // Clear out the errors
 #if defined(WIN32)
   SetLastError(0);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   dlerror();
 #endif
   int ret = ModLastError;
@@ -484,7 +484,7 @@ int mod_GetLastError(void) {
   return ret;
 }
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <assert.h>
 #include <stdarg.h>
 #include <sys/stat.h>

--- a/module/module.cpp
+++ b/module/module.cpp
@@ -281,12 +281,12 @@ void mod_GetRealModuleName(const char *modfilename, char *realmodfilename) {
   if (*extension == '\0')
 #if defined(WIN32)
     strcat(filename, ".dll");
-#elif defined(POSIX)
-#if defined(MACOSX)
+#elif defined(__LINUX__)
+    strcat(filename, ".so");
+#elif defined(MACOSX)
     strcat(filename, ".dylib");
 #else
-    strcat(filename, ".so");
-#endif
+    #error Unsupported platform!
 #endif
   else {
 #if defined(WIN32)
@@ -294,17 +294,18 @@ void mod_GetRealModuleName(const char *modfilename, char *realmodfilename) {
       strcat(filename, ".dll");
     else
       strcat(filename, extension);
-#elif defined(POSIX) && !defined(MACOSX)
+#elif defined(__LINUX__)
     if (!stricmp(extension, ".dll") || !stricmp(extension, "msl") || !stricmp(extension, "dylib"))
       strcat(filename, ".so");
     else
       strcat(filename, extension);
-#elif defined(POSIX) && defined(MACOSX)
+#elif defined(MACOSX)
       if (!stricmp(extension, ".dll") || !stricmp(extension, "msl") || !stricmp(extension, "so"))
         strcat(filename, ".dylib");
       else
         strcat(filename, extension);
-
+#else
+  #error Unsupported platform!
 #endif
   }
   if (*pathname != '\0')

--- a/movie/d3movie.cpp
+++ b/movie/d3movie.cpp
@@ -72,7 +72,7 @@ void mve_SetCallback(MovieFrameCallback_fp callBack) {
 // used to tell movie library how to render movies.
 void mve_SetRenderProperties(int16_t x, int16_t y, int16_t w, int16_t h, renderer_type type, bool hicolor) {}
 
-#ifdef __LINUX__
+#if defined(POSIX)
 // locates the case-sensitive movie file name
 std::filesystem::path mve_FindMovieFileRealName(const std::filesystem::path &movie) {
   // split into directory and file...
@@ -104,7 +104,7 @@ int mve_PlayMovie(const std::filesystem::path &pMovieName, oeApplication *pApp) 
 #ifndef NO_MOVIES
   // first, find that movie..
   std::filesystem::path real_name;
-#ifdef __LINUX__
+#if defined(POSIX)
   real_name = mve_FindMovieFileRealName(pMovieName);
   if (real_name.empty()) {
     mprintf(0, "MOVIE: No such file %s\n", pMovieName.u8string().c_str());
@@ -356,7 +356,7 @@ intptr_t mve_SequenceStart(const char *mvename, void *fhandle, oeApplication *ap
 #ifndef NO_MOVIES
   // first, find that movie..
   std::filesystem::path real_name;
-#ifdef __LINUX__
+#if defined(POSIX)
   real_name = mve_FindMovieFileRealName(mvename);
   if (real_name.empty()) {
     mprintf(0, "MOVIE: No such file %s\n", mvename);

--- a/netcon/includes/CFtp.h
+++ b/netcon/includes/CFtp.h
@@ -81,7 +81,7 @@
 typedef UINT_PTR SOCKET;
 #endif
 
-#ifdef __LINUX__
+#if defined(POSIX)
 extern int FTPObjThread(void *obj);
 #else
 extern void FTPObjThread(void *obj);

--- a/netcon/includes/con_dll.h
+++ b/netcon/includes/con_dll.h
@@ -267,7 +267,7 @@
 #include "ship.h"
 #include "pstypes.h"
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <string.h>
 #include "linux_fix.h"
 #endif
@@ -827,7 +827,7 @@ typedef void(DLLFUNCCALL DLLAVCall_fp)(int eventnum);
 typedef void(DLLFUNCCALL DLLAVClose_fp)();
 typedef void(DLLFUNCCALL DLLAVGetVersion_fp)(int *version);
 typedef void(DLLFUNCCALL DLLRunCheck_fp)(char *d3_path);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 typedef void DLLFUNCCALL(DLLAVInit_fp)(int *ptr);
 typedef void DLLFUNCCALL(DLLAVCall_fp)(int eventnum);
 typedef void DLLFUNCCALL(DLLAVClose_fp)();

--- a/netcon/includes/inetgetfile.h
+++ b/netcon/includes/inetgetfile.h
@@ -100,7 +100,7 @@
 #include "linux_fix.h"
 
 // Linux includes/defines
-#if !MACOSX
+#if defined(__LINUX__)
 #include <linux/types.h>
 // #include <linux/if.h>
 #endif

--- a/netcon/includes/inetgetfile.h
+++ b/netcon/includes/inetgetfile.h
@@ -86,7 +86,7 @@
 
 // At the end of this file is an example of usage
 
-#if defined(__LINUX__)
+#if defined(POSIX)
 #include <ctype.h>
 #include <errno.h>
 #include <netinet/in.h>

--- a/netcon/inetfile/CFtp.cpp
+++ b/netcon/inetfile/CFtp.cpp
@@ -74,7 +74,7 @@ typedef int socklen_t;
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef __LINUX__
+#if defined(POSIX)
 // sorry, I'm lazy, I guess we could copy the defines
 // that we need to transalte winsock->linux into this header...but no need to now
 #include "SDL_thread.h"
@@ -84,14 +84,14 @@ typedef int socklen_t;
 #include "CFtp.h"
 
 // MTS: only used in this file?
-#ifdef __LINUX__
+#if defined(POSIX)
 int FTPObjThread(void *obj)
 #else
 void FTPObjThread(void *obj)
 #endif
 {
   ((CFtpGet *)obj)->WorkerThread();
-#ifdef __LINUX__
+#if defined(POSIX)
   return 0;
 #endif
 }
@@ -208,7 +208,7 @@ CFtpGet::CFtpGet(char *URL, char *localfile, char *Username, char *Password) {
     m_State = FTP_STATE_INTERNAL_ERROR;
     return;
   }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   //	pthread_t thread;
 
   SDL_Thread *thread;
@@ -231,7 +231,7 @@ CFtpGet::CFtpGet(char *URL, char *localfile, char *Username, char *Password) {
 CFtpGet::~CFtpGet() {
   if (m_ListenSock != INVALID_SOCKET) {
     shutdown(m_ListenSock, 2);
-#ifndef __LINUX__
+#if !defined(POSIX)
     closesocket(m_ListenSock);
 #else
     close(m_ListenSock);
@@ -239,7 +239,7 @@ CFtpGet::~CFtpGet() {
   }
   if (m_DataSock != INVALID_SOCKET) {
     shutdown(m_DataSock, 2);
-#ifndef __LINUX__
+#if !defined(POSIX)
     closesocket(m_DataSock);
 #else
     close(m_DataSock);
@@ -247,7 +247,7 @@ CFtpGet::~CFtpGet() {
   }
   if (m_ControlSock != INVALID_SOCKET) {
     shutdown(m_ControlSock, 2);
-#ifndef __LINUX__
+#if !defined(POSIX)
     closesocket(m_ControlSock);
 #else
     close(m_ControlSock);
@@ -332,7 +332,7 @@ uint32_t CFtpGet::GetFile() {
 
   m_DataSock = accept(m_ListenSock, NULL, NULL); //(SOCKADDR *)&sockaddr,&iAddrLength);
                                                  // Close the listen socket
-#ifndef __LINUX__
+#if !defined(POSIX)
   closesocket(m_ListenSock);
 #else
   close(m_ListenSock);
@@ -403,7 +403,7 @@ uint32_t CFtpGet::IssuePort() {
   // Tell the server which port to use for data.
   nReplyCode = SendFTPCommand(szCommandString);
   if (nReplyCode != 200) {
-#ifdef __LINUX__
+#if defined(POSIX)
     // I don't know if this is just Linux or do to a bug I fixed while porting to linux
     // for some reason I kept getting reply 250 here and have to read again to get the
     // "200 PORT Command OK" or whatever
@@ -500,7 +500,7 @@ uint32_t CFtpGet::ReadFTPServerReply() {
 
     if (iBytesRead == SOCKET_ERROR) {
       int iWinsockErr = WSAGetLastError();
-#ifdef __LINUX__
+#if defined(POSIX)
       if (0 == iWinsockErr) {
         continue;
       }
@@ -546,7 +546,7 @@ uint32_t CFtpGet::ReadDataChannel() {
       return 0;
     nBytesRecv = recv(m_DataSock, (char *)&sDataBuffer, sizeof(sDataBuffer), 0);
 
-#ifdef __LINUX__
+#if defined(POSIX)
     if (nBytesRecv == -1) {
       int iWinsockErr = WSAGetLastError();
       if (iWinsockErr == 0) {

--- a/netcon/inetfile/Chttpget.cpp
+++ b/netcon/inetfile/Chttpget.cpp
@@ -138,7 +138,7 @@
 #define mem_free(a) free(a)
 #endif
 
-#ifdef __LINUX__
+#if defined(POSIX)
 
 #include "SDL_thread.h"
 
@@ -154,7 +154,7 @@ inline void Sleep(int millis) {
 #define NW_AGHBN_LOOKUP 2
 #define NW_AGHBN_READ 3
 
-#ifndef __LINUX__
+#if !defined(POSIX)
 static void HTTPObjThread(void *obj);
 static void __cdecl http_gethostbynameworker(void *parm);
 #else
@@ -164,7 +164,7 @@ static int http_gethostbynameworker(void *parm);
 
 static int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname);
 
-#ifndef __LINUX__
+#if !defined(POSIX)
 void HTTPObjThread(void *obj)
 #else
 int HTTPObjThread(void *obj)
@@ -174,7 +174,7 @@ int HTTPObjThread(void *obj)
   ((ChttpGet *)obj)->m_Aborted = true;
   // OutputDebugString("http transfer exiting....\n");
 
-#ifdef __LINUX__
+#if defined(POSIX)
   return 0;
 #endif
 }
@@ -282,7 +282,7 @@ void ChttpGet::GetFile(char *URL, char *localfile) {
     m_State = HTTP_STATE_INTERNAL_ERROR;
     return;
   }
-#elif defined(__LINUX__)
+#elif defined(POSIX)
   //	pthread_t thread;
   SDL_Thread *thread;
 
@@ -303,7 +303,7 @@ void ChttpGet::GetFile(char *URL, char *localfile) {
 ChttpGet::~ChttpGet() {
   if (m_DataSock != INVALID_SOCKET) {
     shutdown(m_DataSock, 2);
-#ifndef __LINUX__
+#if !defined(POSIX)
     closesocket(m_DataSock);
 #else
     close(m_DataSock);
@@ -507,7 +507,7 @@ int ChttpGet::ConnectSocket() {
   int serr = connect(m_DataSock, (SOCKADDR *)&hostaddr, sizeof(SOCKADDR));
   int cerr = WSAGetLastError();
   if (serr) {
-#ifdef __LINUX__
+#if defined(POSIX)
     while ((cerr == WSAEALREADY) || (cerr == WSAEINVAL) || (cerr == WSAEWOULDBLOCK) || (cerr == EINPROGRESS))
 #else
     while ((cerr == WSAEALREADY) || (cerr == WSAEINVAL) || (cerr == WSAEWOULDBLOCK))
@@ -552,7 +552,7 @@ char *ChttpGet::GetHTTPLine() {
 
       if (SOCKET_ERROR == iBytesRead) {
         int error = WSAGetLastError();
-#ifdef __LINUX__
+#if defined(POSIX)
         if (WSAEWOULDBLOCK == error || 0 == error)
 #else
         if (WSAEWOULDBLOCK == error)
@@ -575,7 +575,7 @@ char *ChttpGet::GetHTTPLine() {
 
         if (SOCKET_ERROR == iBytesRead) {
           int error = WSAGetLastError();
-#ifdef __LINUX__
+#if defined(POSIX)
           if (WSAEWOULDBLOCK == error || 0 == error)
 #else
           if (WSAEWOULDBLOCK == error)
@@ -635,7 +635,7 @@ uint32_t ChttpGet::ReadDataChannel() {
 
     if (SOCKET_ERROR == nBytesRecv) {
       int error = WSAGetLastError();
-#ifdef __LINUX__
+#if defined(POSIX)
       if (WSAEWOULDBLOCK == error || 0 == error)
 #else
       if (WSAEWOULDBLOCK == error)
@@ -689,7 +689,7 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
 
 #ifdef WIN32
     _beginthread(http_gethostbynameworker, 0, newaslu);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
     //		pthread_t thread;
     if (!inet_LoadThreadLib()) {
       return 0;
@@ -703,7 +703,7 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
     if (http_lastaslu)
       http_lastaslu->abort = true;
 
-#ifdef __LINUX__
+#if defined(POSIX)
     SDL_WaitThread(http_lastaslu->threadId, NULL);
 #endif
 
@@ -713,7 +713,7 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
       return -1;
     if (httpaslu.done) {
       // free(http_lastaslu);
-#ifdef __LINUX__
+#if defined(POSIX)
       SDL_WaitThread(http_lastaslu->threadId, NULL);
 #endif
 
@@ -721,7 +721,7 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
       memcpy(ip, &httpaslu.ip, sizeof(uint32_t));
       return 1;
     } else if (httpaslu.error) {
-#ifdef __LINUX__
+#if defined(POSIX)
       SDL_WaitThread(http_lastaslu->threadId, NULL);
 #endif
 
@@ -735,20 +735,20 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
 }
 
 // This is the worker thread which does the lookup.
-#ifndef __LINUX__
+#if !defined(POSIX)
 void __cdecl http_gethostbynameworker(void *parm)
 #else
 int http_gethostbynameworker(void *parm)
 #endif
 {
-#ifdef __LINUX__
+#if defined(POSIX)
   // df_pthread_detach(df_pthread_self());
 #endif
   async_dns_lookup *lookup = (async_dns_lookup *)parm;
   HOSTENT *he = gethostbyname(lookup->host);
   if (he == NULL) {
     lookup->error = true;
-#ifdef __LINUX__
+#if defined(POSIX)
     return 0;
 #else
     return;
@@ -760,7 +760,7 @@ int http_gethostbynameworker(void *parm)
   }
   mem_free(lookup);
 
-#ifdef __LINUX__
+#if defined(POSIX)
   return 0;
 #endif
 }

--- a/netcon/inetfile/inetgetfile.cpp
+++ b/netcon/inetfile/inetgetfile.cpp
@@ -84,7 +84,7 @@
 extern char *Proxy_server;
 extern int16_t Proxy_port;
 
-#ifdef __LINUX__
+#if defined(POSIX)
 /*  ryan sez: use SDL.
 pthread_create_fp df_pthread_create = NULL;
 pthread_exit_fp df_pthread_exit = NULL;

--- a/netcon/mtclient/chat_api.cpp
+++ b/netcon/mtclient/chat_api.cpp
@@ -23,7 +23,7 @@
 #include <cstdio>
 #include <cstring>
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <sys/time.h>
 #include <unistd.h>
 #endif
@@ -202,7 +202,7 @@ int ConnectToChatServer(const char *serveraddr, int16_t chat_port, char *nicknam
 
     if (SOCKET_ERROR == connect(Chatsock, (SOCKADDR *)&Chataddr, sizeof(SOCKADDR_IN))) {
       int ret = WSAGetLastError();
-#ifndef __LINUX__
+#if !defined(POSIX)
       if (WSAEWOULDBLOCK == WSAGetLastError())
 #else
       if (EINPROGRESS == ret || 0 == ret)
@@ -456,7 +456,7 @@ const char *ChatGetString() {
     bytesread = recv(Chatsock, ch, 1, 0);
     if (bytesread == SOCKET_ERROR) {
       uint32_t lerror = WSAGetLastError();
-#ifndef __LINUX__
+#if !defined(POSIX)
       if (WSAEWOULDBLOCK != lerror)
 #else
       if (WSAEWOULDBLOCK != lerror && 0 != lerror)

--- a/netgames/includes/DMFC.h
+++ b/netgames/includes/DMFC.h
@@ -294,7 +294,7 @@
 #include "gamedll_header.h"
 #include "DMFCKeyCodes.h"
 
-#if ((defined __LINUX__) && (!defined __i386__))
+#if ((defined POSIX) && (!defined __i386__))
 #include <signal.h>
 #endif
 

--- a/netgames/includes/DMFC.h
+++ b/netgames/includes/DMFC.h
@@ -338,7 +338,7 @@
     if (DLLDebugBreak_callback_resume)                                                                                 \
       DLLDebugBreak_callback_resume();                                                                                 \
   } while (0)
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 // For some reason Linux doesn't like the \ continuation character, so I have to uglify this
 #define DLLmprintf(...) DLLDebug_ConsolePrintf(__VA_ARGS__)
 #ifdef DEBUG_BREAK

--- a/networking/networking.cpp
+++ b/networking/networking.cpp
@@ -294,7 +294,7 @@ typedef int socklen_t;
 #endif
 #include <stdlib.h>
 #include <string.h>
-#ifdef __LINUX__
+#if defined(POSIX)
 #if !MACOSX
 #include <netinet/in.h>
 #endif
@@ -519,7 +519,7 @@ struct reliable_socket {
 
 static reliable_socket reliable_sockets[MAXRELIABLESOCKETS];
 //*******************************
-#ifdef __LINUX__
+#if defined(POSIX)
 #include <fcntl.h>
 #endif
 
@@ -2069,7 +2069,7 @@ static async_dns_lookup *lastaslu = NULL;
 #define CDECLCALL
 #endif
 
-#ifdef __LINUX__
+#if defined(POSIX)
 int CDECLCALL gethostbynameworker(void *parm);
 #include "SDL.h"
 #include "SDL_thread.h"
@@ -2123,7 +2123,7 @@ int nw_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
       lastaslu->abort = true;
 
       // rcg06212000 join the thread.
-#ifdef __LINUX__
+#if defined(POSIX)
       SDL_WaitThread(lastaslu->threadId, NULL);
       free(lastaslu);
 #endif
@@ -2131,7 +2131,7 @@ int nw_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
 
     // rcg06262000 don't need all the rigamarole since we join the thread.
 
-#if (!defined(__LINUX__))
+#if (!defined(POSIX))
     async_dns_lookup *newaslu;
     newaslu = (async_dns_lookup *)mem_malloc(sizeof(async_dns_lookup));
     memset(&newaslu->ip, 0, sizeof(uint32_t));
@@ -2153,7 +2153,7 @@ int nw_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
 
 #ifdef WIN32
     _beginthread(gethostbynameworker, 0, newaslu);
-#elif defined(__LINUX__)
+#elif defined(POSIX)
     // rcg06192000 use SDL threads.
     /*
             nw_LoadThreadLibrary();
@@ -2196,7 +2196,7 @@ int nw_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
       lastaslu->abort = true;
 
       // rcg06212000 join the thread.
-#ifdef __LINUX__
+#if defined(POSIX)
       SDL_WaitThread(lastaslu->threadId, NULL);
 #endif
     } // if
@@ -2206,7 +2206,7 @@ int nw_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
       return -1;
     if (aslu.done) {
       // rcg06212000 join the thread.
-#ifdef __LINUX__
+#if defined(POSIX)
       SDL_WaitThread(aslu.threadId, NULL);
 #endif
 
@@ -2215,7 +2215,7 @@ int nw_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
       return 1;
     } else if (aslu.error) {
       // rcg06212000 join the thread.
-#ifdef __LINUX__
+#if defined(POSIX)
       SDL_WaitThread(aslu.threadId, NULL);
 #else
       mem_free(lastaslu);
@@ -2230,14 +2230,14 @@ int nw_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
 }
 
 // This is the worker thread which does the lookup.
-#ifdef __LINUX__
+#if defined(POSIX)
 int CDECLCALL gethostbynameworker(void *parm)
 #else
 void CDECLCALL gethostbynameworker(void *parm)
 #endif
 {
   // rcg06192000 nope.
-  //	#ifdef __LINUX__
+  //	#if defined(POSIX)
   //	dpthread_detach(dpthread_self());
   //	#endif
 
@@ -2249,7 +2249,7 @@ void CDECLCALL gethostbynameworker(void *parm)
 
   if (he == NULL) {
     lookup->error = true;
-#ifdef __LINUX__
+#if defined(POSIX)
     return 0;
 #else
     return;
@@ -2267,11 +2267,11 @@ void CDECLCALL gethostbynameworker(void *parm)
   }
 
 // rcg06252000 don't free this, 'cause we need the threadId.
-#ifndef __LINUX__
+#if !defined(POSIX)
   mem_free(lookup);
 #endif
 
-#ifdef __LINUX__
+#if defined(POSIX)
   return 0;
 #endif
 }

--- a/networking/networking.cpp
+++ b/networking/networking.cpp
@@ -295,7 +295,7 @@ typedef int socklen_t;
 #include <stdlib.h>
 #include <string.h>
 #if defined(POSIX)
-#if !MACOSX
+#if defined(__LINUX__)
 #include <netinet/in.h>
 #endif
 #include <arpa/inet.h>

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -446,7 +446,7 @@ int opengl_Setup(oeApplication *app, int *width, int *height) {
     OpenGLDLLHandle = LoadOpenGLDLL(gl_library);
     if (!(OpenGLDLLHandle)) {
       // rcg07072000 last ditch effort...
-#ifdef __LINUX__
+#if defined(POSIX)
       strcpy(gl_library, "libGL.so.1");
 #else
       strcpy(gl_library, "opengl32.dll");

--- a/renderer/dyna_gl.h
+++ b/renderer/dyna_gl.h
@@ -31,7 +31,7 @@
 
 #if defined(WIN32)
 #define GLFUNCCALL __stdcall
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 #include <unistd.h>
 #define GLFUNCCALL
 #endif
@@ -488,7 +488,7 @@ module *LoadOpenGLDLL(const char *dllname) {
   dwglGetProcAddress = (wglGetProcAddress_fp)mod_GetSymbol(&OpenGLDLLInst, "wglGetProcAddress", 255);
   if (!dwglGetProcAddress)
     goto dll_error;
-#elif defined(__LINUX__)
+#elif defined(POSIX)
 
   // bk000614 - have to fix globals
   extern glAlphaFunc_fp dglAlphaFunc;

--- a/scripts/osiris_import.h
+++ b/scripts/osiris_import.h
@@ -24,7 +24,7 @@
 
 #include "osiris_common.h"
 
-#ifdef __LINUX__
+#if defined(POSIX)
 #include "linux_lib.h"
 #endif
 

--- a/sndlib/soundload.cpp
+++ b/sndlib/soundload.cpp
@@ -241,7 +241,7 @@
 #include "room.h"
 #include "doorway.h"
 
-#if defined(WIN32) || defined(__LINUX__)
+#if defined(WIN32) || defined(POSIX)
 #include "../manage/soundpage.h"
 #include "../Descent3/sounds.h"
 #endif

--- a/ui/UIButton.cpp
+++ b/ui/UIButton.cpp
@@ -125,7 +125,7 @@
 
 #include <string.h>
 
-#ifdef __LINUX__
+#if defined(POSIX)
 int UIButton::m_ButtonFont;
 #endif
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
Per discussion in https://github.com/DescentDevelopers/Descent3/pull/459#discussion_r1653629374, this PR changes the way platform `#define` macros are set up so that we don't need to use `__LINUX__` to represent any linux-_ey_ system.

Changes were tested using [unifdef](https://linux.die.net/man/1/unifdef) to process the entire codebase at the base and tip of the branch. No differences were found after running the preprocessor with appropriate defines before and after, meaning that the compiled code is identical (as intended).

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
