### PR TITLE
Ensure UTF-8 is used in more places

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ indent_style = space
 indent_size = 2
 tab_width = 8
 end_of_line = lf
+charset = utf-8
 spelling_language = en-US
 
 [*.md]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+if(MSVC)
+  add_compile_options(/source-charset:UTF-8)
+else()
+  add_compile_options(-finput-charset=UTF-8)
+endif()
+
 if(FORCE_COLORED_OUTPUT)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
     set(CMAKE_COLOR_DIAGNOSTICS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,18 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if(MSVC)
-  add_compile_options(/source-charset:UTF-8)
+  add_compile_options(/source-charset:UTF-8 /execution-charset:UTF-8)
 else()
   add_compile_options(-finput-charset=UTF-8)
+  # Unfortunately, Clang doesn’t support -fexec-charset yet so this next part
+  # is GCC only. Luckily, Clang defaults to using UTF-8 for the execution
+  # character set [1], so we’re fine. Once Clang gets support for
+  # -fexec-charset, we should probably start using it.
+  #
+  # [1]: <https://discourse.llvm.org/t/rfc-enabling-fexec-charset-support-to-llvm-and-clang-reposting/71512>
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-fexec-charset=UTF-8)
+  endif()
 endif()
 
 if(FORCE_COLORED_OUTPUT)

--- a/Descent3/CMakeLists.txt
+++ b/Descent3/CMakeLists.txt
@@ -274,6 +274,13 @@ set(CPPS
 if(WIN32)
   set(PLATFORM_LIBS wsock32.lib winmm.lib)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO /NODEFAULTLIB:LIBC")
+  set(MANIFEST ${CMAKE_CURRENT_BINARY_DIR}/Descent3.exe.manifest)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Descent3.exe.manifest.in
+    ${MANIFEST}
+    @ONLY
+    NEWLINE_STYLE WIN32
+  )
 endif()
 
 if(UNIX AND NOT APPLE)
@@ -287,7 +294,7 @@ endif()
 
 file(GLOB_RECURSE INCS "../lib/*.h")
 
-add_executable(Descent3 WIN32 ${HEADERS} ${CPPS} ${INCS})
+add_executable(Descent3 WIN32 ${HEADERS} ${CPPS} ${INCS} ${MANIFEST})
 target_link_libraries(Descent3 PRIVATE
   2dlib AudioEncode bitmap cfile czip d3music dd_video ddebug ddio libmve libacm
   fix grtext manage mem misc model module movie stream_audio linux SDL2::SDL2

--- a/Descent3/Descent3.exe.manifest.in
+++ b/Descent3/Descent3.exe.manifest.in
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="DescentDevelopers.Descent3.engine" version="@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.0" />
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
At the moment, Descent 3 doesn’t always specify which character encoding should be used. As a result, the default character encoding gets used. The default character encoding can change depending on what OS you’re using and how the OS is configured. This PR makes Descent 3 use UTF-8 instead of the default character encoding in some situations. The idea is that if we use UTF-8 everywhere, then users won’t have to change their system configuration or avoid using certain characters in order to make Descent 3 work properly.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #483.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->

@winterheart [had a different idea for how to fix #483](https://github.com/DescentDevelopers/Descent3/issues/483#issuecomment-2225622869). I think that it would be valuable to implement both the fix proposed by this PR and the fix proposed by winterheart. The changes in this PR affect a lot more than just `fopen()` which is why I think that they are valuable. Calling `_wfopen()` instead of `fopen()` on Windows would still be valuable even if this PR gets merged because if would be more efficient. Specifically, if you call `fopen()`, then the `filename` parameter has to be converted to UTF-16. If you call `_wfopen()`, then the `filename` parameter doesn’t have to be converted to UTF-16 because it’s already in UTF-16.
