### PR TITLE
Eliminate glBegin/glEnd usage, unify color calculation, cleanup dead code

### DIFF
--- a/Descent3/TelComAutoMap.cpp
+++ b/Descent3/TelComAutoMap.cpp
@@ -809,9 +809,6 @@ void TCAMCallback(void) {
   rend_SetOverlayType(OT_NONE);
   rend_SetZBufferState(1);
 
-  if (AM_terrain)
-    rend_SetZValues(0, VisibleTerrainZ);
-
   TCAMBuildRoomList(Viewer_object->roomnum);
   // Render all rooms in view
   for (int i = 0; i < Num_AM_rooms; i++) {

--- a/Descent3/render.cpp
+++ b/Descent3/render.cpp
@@ -3468,12 +3468,10 @@ void RenderMine(int viewer_roomnum, int flag_automap, int called_from_terrain) {
     g3_SetFarClipZ(VisibleTerrainZ);
 
     if ((Terrain_sky.flags & TF_FOG) && (UseHardware || (!UseHardware && Lighting_on))) {
-      rend_SetZValues(0, VisibleTerrainZ);
       rend_SetFogState(1);
       rend_SetFogBorders(VisibleTerrainZ * .85, VisibleTerrainZ);
       rend_SetFogColor(Terrain_sky.fog_color);
-    } else
-      rend_SetZValues(0, 5000);
+    }
   }
 
   // First render mirrored rooms

--- a/Descent3/terrainrender.cpp
+++ b/Descent3/terrainrender.cpp
@@ -1409,15 +1409,11 @@ void RenderTerrain(uint8_t from_mine, int left, int top, int right, int bot) {
 
 #ifndef NEWEDITOR
   if ((Terrain_sky.flags & TF_FOG) && (UseHardware || (!UseHardware && Lighting_on))) {
-    rend_SetZValues(0, VisibleTerrainZ);
     rend_SetFogState(1);
     rend_SetFogBorders(VisibleTerrainZ * Terrain_sky.fog_scalar, Far_fog_border);
     rend_SetFogColor(Terrain_sky.fog_color);
-  } else
-#endif
-  {
-    rend_SetZValues(0, 5000);
   }
+#endif
 
   // And display!
   if (nt > 0) {

--- a/lib/3d.h
+++ b/lib/3d.h
@@ -430,7 +430,6 @@ void g3_DrawSpecialLine(g3Point *p0, g3Point *p1);
 // Draws a bitmap on a specific plane.  Also does rotation.  Angle of rotation is passed as 'rot_angle'
 void g3_DrawPlanarRotatedBitmap(vector *pos, vector *norm, angle rot_angle, float width, float height, int bm);
 
-void g3_TransformVert(float res[4], float pt[4], float a[4][4]);
 void g3_TransformMult(float res[4][4], float a[4][4], float b[4][4]);
 void g3_TransformTrans(float res[4][4], float t[4][4]);
 void g3_GetModelViewMatrix(const vector *viewPos, const matrix *viewMatrix, float *mvMat);

--- a/lib/renderer.h
+++ b/lib/renderer.h
@@ -489,9 +489,6 @@ void rend_SetFiltering(int8_t state);
 // Sets the state of zbuffering to on or off
 void rend_SetZBufferState(int8_t state);
 
-// Sets the near and far planes for z buffer
-void rend_SetZValues(float nearz, float farz);
-
 // Sets a bitmap as an overlay to rendered on top of the next texture map
 void rend_SetOverlayMap(int handle);
 

--- a/lib/renderer.h
+++ b/lib/renderer.h
@@ -307,13 +307,6 @@ class oeApplication;
 
 #define TEXTURE_WIDTH 128
 #define TEXTURE_HEIGHT 128
-#define TEXTURE_BPP 2
-
-#define FLAT_SHADE_COLOR 0x7C01
-// If an incoming texture has the above color in it, change that color to this color
-#define REPLACEMENT_COLOR 0x07C0
-
-extern int Triangles_drawn;
 
 // Is this hardware or software rendered?
 enum renderer_type {
@@ -327,29 +320,17 @@ extern renderer_type Renderer_type;
 
 // renderer clear flags
 #define RF_CLEAR_ZBUFFER 1
-#define RF_CLEAR_COLOR 2
 
 // Overlay texture settings
 #define OT_NONE 0           // No overlay
 #define OT_BLEND 1          // Draw a lightmap texture afterwards
-#define OT_REPLACE 2        // Draw a tmap2 style texture afterwards
-#define OT_FLAT_BLEND 3     // Draw a gouraud shaded polygon afterwards
-#define OT_BLEND_VERTEX 4   // Like OT_BLEND, but take constant alpha into account
-#define OT_BUMPMAP 5        // Draw a saturated bumpmap afterwards
-#define OT_BLEND_SATURATE 6 // Add a lightmap in
 
-extern uint8_t Overlay_type;
-extern int Overlay_map;
-extern int Bumpmap_ready, Bump_map;
 extern float Z_bias;
 extern bool UseHardware;
 extern bool StateLimited;
 extern bool NoLightmaps;
 extern bool UseMultitexture;
-extern bool UseWBuffer;
 extern bool UseMipmap;  // DAJ
-extern bool ATIRagePro; // DAJ
-extern bool Formac;     // DAJ
 
 class NewBitmap;
 
@@ -361,8 +342,6 @@ void rend_SetRendererType(renderer_type state);
 
 #define MAP_TYPE_BITMAP 0
 #define MAP_TYPE_LIGHTMAP 1
-#define MAP_TYPE_BUMPMAP 2
-#define MAP_TYPE_UNKNOWN 3
 
 // lighting state
 enum light_state {
@@ -406,18 +385,11 @@ enum texture_type {
 #define AT_CONSTANT_TEXTURE_VERTEX 7   // Use all three (texture constant vertex)
 #define AT_LIGHTMAP_BLEND 8            // dest*src colors
 #define AT_SATURATE_TEXTURE 9          // Saturate up to white when blending
-#define AT_FLAT_BLEND 10               // Like lightmap blend, but uses gouraud shaded flat polygon
-#define AT_ANTIALIAS 11                // Draws an antialiased polygon
 #define AT_SATURATE_VERTEX 12          // Saturation with vertices
 #define AT_SATURATE_CONSTANT_VERTEX 13 // Constant*vertex saturation
 #define AT_SATURATE_TEXTURE_VERTEX 14  // Texture * vertex saturation
-#define AT_LIGHTMAP_BLEND_VERTEX 15    //	Like AT_LIGHTMAP_BLEND, but take vertex alpha into account
-#define AT_LIGHTMAP_BLEND_CONSTANT 16  // Like AT_LIGHTMAP_BLEND, but take constant alpha into account
 #define AT_SPECULAR 32
 #define AT_LIGHTMAP_BLEND_SATURATE 33 // Light lightmap blend, but add instead of multiply
-
-#define LFB_LOCK_READ 0
-#define LFB_LOCK_WRITE 1
 
 enum wrap_type {
   WT_WRAP,  // Texture repeats
@@ -431,7 +403,6 @@ struct rendering_state {
   int8_t cur_bilinear_state;
   int8_t cur_zbuffer_state;
   int8_t cur_fog_state;
-  int8_t cur_mip_state;
 
   texture_type cur_texture_type;
   color_model cur_color_model;
@@ -442,7 +413,6 @@ struct rendering_state {
 
   float cur_fog_start, cur_fog_end;
   float cur_near_z, cur_far_z;
-  float gamma_value;
 
   int cur_alpha;
   ddgr_color cur_color;
@@ -467,7 +437,6 @@ struct renderer_preferred_state {
 struct renderer_lfb {
   int type;
   uint16_t *data;
-  int bytes_per_row;
 };
 
 struct tRendererStats {
@@ -640,9 +609,6 @@ int rend_InitOpenGLWindow(oeApplication *app, renderer_preferred_state *pref_sta
 
 // Shuts down OpenGL in a window
 void rend_CloseOpenGLWindow();
-
-// Sets the state of the OpenGLWindow to on or off
-void rend_SetOpenGLWindowState(int state, oeApplication *app, renderer_preferred_state *pref_state);
 
 // Sets the hardware bias level for coplanar polygons
 // This helps reduce z buffer artifaces

--- a/lib/renderer.h
+++ b/lib/renderer.h
@@ -411,9 +411,6 @@ struct rendering_state {
 
   wrap_type cur_wrap_type;
 
-  float cur_fog_start, cur_fog_end;
-  float cur_near_z, cur_far_z;
-
   int cur_alpha;
   ddgr_color cur_color;
   ddgr_color cur_fog_color;

--- a/lib/renderer.h
+++ b/lib/renderer.h
@@ -330,7 +330,6 @@ extern bool UseHardware;
 extern bool StateLimited;
 extern bool NoLightmaps;
 extern bool UseMultitexture;
-extern bool UseMipmap;  // DAJ
 
 class NewBitmap;
 

--- a/renderer/HardwareBaseGPU.cpp
+++ b/renderer/HardwareBaseGPU.cpp
@@ -517,7 +517,7 @@ void rend_DrawPolygon2D(int handle, g3Point **p, int nv) {
   gpu_RenderPolygon(&vArray[0], nv);
 }
 
-static color_array DeterminePointColor(g3Point const* pnt) {
+color_array DeterminePointColor(g3Point const* pnt) {
   auto alpha = gpu_Alpha_multiplier * gpu_Alpha_factor;
   if (gpu_state.cur_alpha_type & ATF_VERTEX) {
     alpha *= pnt->p3_a;
@@ -528,13 +528,10 @@ static color_array DeterminePointColor(g3Point const* pnt) {
     if (gpu_state.cur_light_state == LS_FLAT_GOURAUD) {
       return {GR_COLOR_RED(gpu_state.cur_color) / 255.0f, GR_COLOR_GREEN(gpu_state.cur_color) / 255.0f,
               GR_COLOR_BLUE(gpu_state.cur_color) / 255.0f, alpha};
+    } else if (gpu_state.cur_color_model == CM_MONO) {
+      return {pnt->p3_l, pnt->p3_l, pnt->p3_l, alpha};
     } else {
-      // Do lighting based on intesity (MONO) or colored (RGB)
-      if (gpu_state.cur_color_model == CM_MONO) {
-        return {pnt->p3_l, pnt->p3_l, pnt->p3_l, alpha};
-      } else {
-        return {pnt->p3_r, pnt->p3_g, pnt->p3_b, alpha};
-      }
+      return {pnt->p3_r, pnt->p3_g, pnt->p3_b, alpha};
     }
   } else {
     return {1, 1, 1, alpha};

--- a/renderer/HardwareBaseGPU.cpp
+++ b/renderer/HardwareBaseGPU.cpp
@@ -574,39 +574,6 @@ void rend_DrawPolygon3D(int handle, g3Point **p, int nv, int map_type) {
     // all points should be original
     ASSERT(pnt->p3_flags & PF_ORIGPOINT);
 
-    ////////////////////////////////////////////
-    if (pnt->p3_flags & PF_ORIGPOINT) {
-      if (!(pnt->p3_flags & PF_PROJECTED)) {
-        g3_ProjectPoint(pnt);
-      }
-
-      // get the original point
-      float origPoint[4];
-      origPoint[0] = pnt->p3_vecPreRot.x;
-      origPoint[1] = pnt->p3_vecPreRot.y;
-      origPoint[2] = pnt->p3_vecPreRot.z;
-      origPoint[3] = 1.0f;
-
-      // transform by the full transform
-      float view[4];
-      g3_TransformVert(view, origPoint, gTransformFull);
-
-      vector tempv = pnt->p3_vecPreRot - View_position;
-      vector testPt = tempv * Unscaled_matrix;
-
-      float screenX = pnt->p3_sx + gpu_state.clip_x1;
-      float screenY = pnt->p3_sy + gpu_state.clip_y1;
-
-      // normalize
-      float oOW = 1.0f / view[3];
-      view[0] *= oOW;
-      view[1] *= oOW;
-      view[2] *= oOW;
-
-      oOW *= 1.0f;
-    }
-    ////////////////////////////////////////////
-
     if (gpu_state.cur_alpha_type & ATF_VERTEX) {
       alpha = pnt->p3_a * gpu_Alpha_multiplier * gpu_Alpha_factor;
     }

--- a/renderer/HardwareBaseGPU.cpp
+++ b/renderer/HardwareBaseGPU.cpp
@@ -450,18 +450,8 @@ void rend_DrawPolygon2D(int handle, g3Point **p, int nv) {
   int xAdd = gpu_state.clip_x1;
   int yAdd = gpu_state.clip_y1;
 
-  float fr, fg, fb;
-  if (gpu_state.cur_light_state == LS_FLAT_GOURAUD || gpu_state.cur_texture_quality == 0) {
-    float scale = 1.0f / 255.0f;
-    fr = GR_COLOR_RED(gpu_state.cur_color) * scale;
-    fg = GR_COLOR_GREEN(gpu_state.cur_color) * scale;
-    fb = GR_COLOR_BLUE(gpu_state.cur_color) * scale;
-  }
-
   // make sure our bitmap is ready to be drawn
   gpu_BindTexture(handle, MAP_TYPE_BITMAP, 0);
-
-  float alpha = gpu_Alpha_multiplier * gpu_Alpha_factor;
 
   PosColorUVVertex *vData = &vArray[0];
 
@@ -470,38 +460,7 @@ void rend_DrawPolygon2D(int handle, g3Point **p, int nv) {
   for (i = 0; i < nv; ++i, ++vData) {
     g3Point *pnt = p[i];
 
-    if (gpu_state.cur_alpha_type & ATF_VERTEX) {
-      // the alpha should come from the vertex
-      alpha = pnt->p3_a * gpu_Alpha_multiplier * gpu_Alpha_factor;
-    }
-
-    // If we have a lighting model, apply the correct lighting!
-    if (gpu_state.cur_light_state == LS_FLAT_GOURAUD || gpu_state.cur_texture_quality == 0) {
-      // pull the color from the constant color data
-      vData->color.r = fr;
-      vData->color.g = fg;
-      vData->color.b = fb;
-      vData->color.a = alpha;
-    } else if (gpu_state.cur_light_state != LS_NONE) {
-      // Do lighting based on intensity (MONO) or colored (RGB)
-      if (gpu_state.cur_color_model == CM_MONO) {
-        vData->color.r = pnt->p3_l;
-        vData->color.g = pnt->p3_l;
-        vData->color.b = pnt->p3_l;
-        vData->color.a = alpha;
-      } else {
-        vData->color.r = pnt->p3_r;
-        vData->color.g = pnt->p3_g;
-        vData->color.b = pnt->p3_b;
-        vData->color.a = alpha;
-      }
-    } else {
-      // force white
-      vData->color.r = 1.0f;
-      vData->color.g = 1.0f;
-      vData->color.b = 1.0f;
-      vData->color.a = alpha;
-    }
+    vData->color = DeterminePointColor(pnt, false, true);
 
     vData->uv.s = pnt->p3_u;
     vData->uv.t = pnt->p3_v;
@@ -517,24 +476,23 @@ void rend_DrawPolygon2D(int handle, g3Point **p, int nv) {
   gpu_RenderPolygon(&vArray[0], nv);
 }
 
-color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud) {
+color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud, bool checkTextureQuality) {
   auto alpha = gpu_Alpha_multiplier * gpu_Alpha_factor;
   if (gpu_state.cur_alpha_type & ATF_VERTEX) {
     alpha *= pnt->p3_a;
   }
 
   // If we have a lighting model, apply the correct lighting!
-  if (gpu_state.cur_light_state != LS_NONE) {
-    if (gpu_state.cur_light_state == LS_FLAT_GOURAUD && !disableGouraud) {
-      return {GR_COLOR_RED(gpu_state.cur_color) / 255.0f, GR_COLOR_GREEN(gpu_state.cur_color) / 255.0f,
-              GR_COLOR_BLUE(gpu_state.cur_color) / 255.0f, alpha};
-    } else if (gpu_state.cur_color_model == CM_MONO) {
-      return {pnt->p3_l, pnt->p3_l, pnt->p3_l, alpha};
-    } else {
-      return {pnt->p3_r, pnt->p3_g, pnt->p3_b, alpha};
-    }
-  } else {
+  if ((gpu_state.cur_light_state == LS_FLAT_GOURAUD && !disableGouraud) ||
+      (gpu_state.cur_texture_quality == 0 && checkTextureQuality)) {
+    return {GR_COLOR_RED(gpu_state.cur_color) / 255.0f, GR_COLOR_GREEN(gpu_state.cur_color) / 255.0f,
+            GR_COLOR_BLUE(gpu_state.cur_color) / 255.0f, alpha};
+  } else if (gpu_state.cur_light_state == LS_NONE) {
     return {1, 1, 1, alpha};
+  } else if (gpu_state.cur_color_model == CM_MONO) {
+    return {pnt->p3_l, pnt->p3_l, pnt->p3_l, alpha};
+  } else {
+    return {pnt->p3_r, pnt->p3_g, pnt->p3_b, alpha};
   }
 }
 

--- a/renderer/HardwareBaseGPU.cpp
+++ b/renderer/HardwareBaseGPU.cpp
@@ -620,7 +620,7 @@ void rend_DrawPolygon3D(int handle, g3Point **p, int nv, int map_type) {
 // as a texture
 void rend_DrawMultitexturePolygon3D(int handle, g3Point **p, int nv, int map_type) {
   g3Point *pnt;
-  int i, fr, fg, fb;
+  int i;
   float alpha;
 
   float one_over_square_res = 1.0 / GameLightmaps[gpu_Overlay_map].square_res;
@@ -628,12 +628,6 @@ void rend_DrawMultitexturePolygon3D(int handle, g3Point **p, int nv, int map_typ
   float yscalar = (float)GameLightmaps[gpu_Overlay_map].height * one_over_square_res;
 
   ASSERT(nv < 100);
-
-  if (gpu_state.cur_light_state == LS_NONE) {
-    fr = GR_COLOR_RED(gpu_state.cur_color);
-    fg = GR_COLOR_GREEN(gpu_state.cur_color);
-    fb = GR_COLOR_BLUE(gpu_state.cur_color);
-  }
 
   alpha = gpu_Alpha_multiplier * gpu_Alpha_factor;
 

--- a/renderer/HardwareBaseGPU.cpp
+++ b/renderer/HardwareBaseGPU.cpp
@@ -127,15 +127,6 @@ void rend_SetFiltering(int8_t state) {
   gpu_state.cur_bilinear_state = state;
 }
 
-// Sets the near and far planes for z buffer
-void rend_SetZValues(float nearz, float farz) {
-  //	mprintf(0,"OPENGL:Setting depth range to %f - %f\n",nearz,farz);
-
-  // JEFF: glDepthRange must take parameters [0,1]
-  // It is set in init
-  //@@dglDepthRange (0,farz);
-}
-
 // Sets a bitmap as a overlay map to rendered on top of the next texture map
 // a -1 value indicates no overlay map
 void rend_SetOverlayMap(int handle) { gpu_Overlay_map = handle; }

--- a/renderer/HardwareBaseGPU.cpp
+++ b/renderer/HardwareBaseGPU.cpp
@@ -129,8 +129,6 @@ void rend_SetFiltering(int8_t state) {
 
 // Sets the near and far planes for z buffer
 void rend_SetZValues(float nearz, float farz) {
-  gpu_state.cur_near_z = nearz;
-  gpu_state.cur_far_z = farz;
   //	mprintf(0,"OPENGL:Setting depth range to %f - %f\n",nearz,farz);
 
   // JEFF: glDepthRange must take parameters [0,1]

--- a/renderer/HardwareBaseGPU.cpp
+++ b/renderer/HardwareBaseGPU.cpp
@@ -662,19 +662,6 @@ void rend_DrawMultitexturePolygon3D(int handle, g3Point **p, int nv, int map_typ
       vData->color.a = alpha;
     }
 
-    /*
-    // Texture this polygon!
-    float texw=1.0/(pnt->p3_z+Z_bias);
-    vData->uv0.s=pnt->p3_u*texw;
-    vData->uv0.t=pnt->p3_v*texw;
-    vData->uv0.r=0;
-    vData->uv0.w=texw;
-
-    vData->uv1.s=pnt->p3_u2*xscalar*texw;
-    vData->uv1.t=pnt->p3_v2*yscalar*texw;
-    vData->uv1.r=0;
-    vData->uv1.w=texw;
-    */
     vData->uv0.s = pnt->p3_u;
     vData->uv0.t = pnt->p3_v;
     vData->uv0.r = 0.0f;
@@ -686,11 +673,6 @@ void rend_DrawMultitexturePolygon3D(int handle, g3Point **p, int nv, int map_typ
     vData->uv1.w = 1.0f;
 
     // Finally, specify a vertex
-    /*
-    vData->pos.x=pnt->p3_sx+x_add;
-    vData->pos.y=pnt->p3_sy+y_add;
-    vData->pos.z = -std::max(0,std::min(1.0,1.0-(1.0/(pnt->p3_z+Z_bias))));
-    */
     vData->pos = pnt->p3_vecPreRot;
   }
 

--- a/renderer/HardwareBaseGPU.cpp
+++ b/renderer/HardwareBaseGPU.cpp
@@ -476,7 +476,7 @@ void rend_DrawPolygon2D(int handle, g3Point **p, int nv) {
   gpu_RenderPolygon(&vArray[0], nv);
 }
 
-color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud, bool checkTextureQuality) {
+color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud, bool checkTextureQuality, bool flatColorForNoLight) {
   auto alpha = gpu_Alpha_multiplier * gpu_Alpha_factor;
   if (gpu_state.cur_alpha_type & ATF_VERTEX) {
     alpha *= pnt->p3_a;
@@ -484,7 +484,8 @@ color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud, bool ch
 
   // If we have a lighting model, apply the correct lighting!
   if ((gpu_state.cur_light_state == LS_FLAT_GOURAUD && !disableGouraud) ||
-      (gpu_state.cur_texture_quality == 0 && checkTextureQuality)) {
+      (gpu_state.cur_texture_quality == 0 && checkTextureQuality) ||
+      (gpu_state.cur_light_state == LS_NONE && flatColorForNoLight)) {
     return {GR_COLOR_RED(gpu_state.cur_color) / 255.0f, GR_COLOR_GREEN(gpu_state.cur_color) / 255.0f,
             GR_COLOR_BLUE(gpu_state.cur_color) / 255.0f, alpha};
   } else if (gpu_state.cur_light_state == LS_NONE) {

--- a/renderer/HardwareInternal.h
+++ b/renderer/HardwareInternal.h
@@ -91,6 +91,6 @@ void gpu_RenderPolygonUV2(PosColorUV2Vertex *vData, uint32_t nv);
 void gpu_DrawFlatPolygon3D(g3Point **p, int nv);
 void rend_DrawMultitexturePolygon3D(int handle, g3Point **p, int nv, int map_type);
 
-color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud = false);
+color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud = false, bool checkTextureQuality = false);
 
 #endif

--- a/renderer/HardwareInternal.h
+++ b/renderer/HardwareInternal.h
@@ -91,6 +91,6 @@ void gpu_RenderPolygonUV2(PosColorUV2Vertex *vData, uint32_t nv);
 void gpu_DrawFlatPolygon3D(g3Point **p, int nv);
 void rend_DrawMultitexturePolygon3D(int handle, g3Point **p, int nv, int map_type);
 
-color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud = false, bool checkTextureQuality = false);
+color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud = false, bool checkTextureQuality = false, bool flatColorForNoLight = false);
 
 #endif

--- a/renderer/HardwareInternal.h
+++ b/renderer/HardwareInternal.h
@@ -91,6 +91,6 @@ void gpu_RenderPolygonUV2(PosColorUV2Vertex *vData, uint32_t nv);
 void gpu_DrawFlatPolygon3D(g3Point **p, int nv);
 void rend_DrawMultitexturePolygon3D(int handle, g3Point **p, int nv, int map_type);
 
-color_array DeterminePointColor(g3Point const* pnt);
+color_array DeterminePointColor(g3Point const* pnt, bool disableGouraud = false);
 
 #endif

--- a/renderer/HardwareInternal.h
+++ b/renderer/HardwareInternal.h
@@ -91,4 +91,6 @@ void gpu_RenderPolygonUV2(PosColorUV2Vertex *vData, uint32_t nv);
 void gpu_DrawFlatPolygon3D(g3Point **p, int nv);
 void rend_DrawMultitexturePolygon3D(int handle, g3Point **p, int nv, int map_type);
 
+color_array DeterminePointColor(g3Point const* pnt);
+
 #endif

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -1580,9 +1580,6 @@ void rend_SetFogBorders(float nearz, float farz) {
   float fogStart = nearz;
   float fogEnd = farz;
 
-  gpu_state.cur_fog_start = fogStart;
-  gpu_state.cur_fog_end = fogEnd;
-
   dglFogi(GL_FOG_MODE, GL_LINEAR);
   dglFogf(GL_FOG_START, fogStart);
   dglFogf(GL_FOG_END, fogEnd);

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -350,7 +350,6 @@ void opengl_SetDefaults() {
   rend_SetTextureType(TT_FLAT);
   rend_SetColorModel(CM_RGB);
   rend_SetZBufferState(1);
-  rend_SetZValues(0, 3000);
   rend_SetGammaValue(gpu_preferred_state.gamma);
   OpenGL_last_bound[0] = 9999999;
   OpenGL_last_bound[1] = 9999999;

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -1281,56 +1282,24 @@ void gpu_SetMultitextureBlendMode(bool state) {
 }
 
 void gpu_DrawFlatPolygon3D(g3Point **p, int nv) {
-  float fr, fg, fb;
-  int i;
-
   if (UseMultitexture) {
     gpu_SetMultitextureBlendMode(false);
   }
 
-  float alpha = gpu_Alpha_multiplier * gpu_Alpha_factor;
+  std::array<PosColorUVVertex, 100> vertices{};
+  std::transform(p, p + nv, std::begin(vertices), [](auto pnt) {
+    return PosColorUVVertex{
+        pnt->p3_vecPreRot,
+        DeterminePointColor(pnt, true, false, true),
+        tex_array{
+            // tex coord can be default-constructed, because it will ultimately be ignored
+            // because this function is only called when cur_texture_quality == 0, and anytime
+            // that is true, GL_TEXTURE_2D is also disabled
+        }
+    };
+  });
 
-  fr = GR_COLOR_RED(gpu_state.cur_color);
-  fg = GR_COLOR_GREEN(gpu_state.cur_color);
-  fb = GR_COLOR_BLUE(gpu_state.cur_color);
-  fr /= 255.0;
-  fg /= 255.0;
-  fb /= 255.0;
-
-  // And draw!
-  dglBegin(GL_POLYGON);
-  for (i = 0; i < nv; i++) {
-    g3Point *pnt = p[i];
-    ASSERT(pnt->p3_flags & PF_ORIGPOINT);
-
-    if (gpu_state.cur_alpha_type & ATF_VERTEX)
-      alpha = pnt->p3_a * gpu_Alpha_multiplier * gpu_Alpha_factor;
-
-    // If we have a lighting model, apply the correct lighting!
-    if (gpu_state.cur_light_state != LS_NONE) {
-      // Do lighting based on intesity (MONO) or colored (RGB)
-      if (gpu_state.cur_color_model == CM_MONO)
-        dglColor4f(pnt->p3_l, pnt->p3_l, pnt->p3_l, alpha);
-      else {
-        dglColor4f(pnt->p3_r, pnt->p3_g, pnt->p3_b, alpha);
-      }
-
-    } else {
-      dglColor4f(fr, fg, fb, alpha);
-    }
-
-    /*
-    // Finally, specify a vertex
-    float z = std::max(0,std::min(1.0,1.0-(1.0/(pnt->p3_z+Z_bias))));
-    dglVertex3f (pnt->p3_sx+x_add,pnt->p3_sy+y_add,-z);
-    */
-    dglVertex3f(pnt->p3_vecPreRot.x, pnt->p3_vecPreRot.y, pnt->p3_vecPreRot.z);
-  }
-
-  dglEnd();
-  CHECK_ERROR(11)
-  OpenGL_polys_drawn++;
-  OpenGL_verts_processed += nv;
+  gpu_RenderPolygon(vertices.data(), nv);
 }
 
 // Sets the gamma correction value

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -1784,17 +1784,17 @@ void rend_FillRect(ddgr_color color, int x1, int y1, int x2, int y2) {
 
 // Sets a pixel on the display
 void rend_SetPixel(ddgr_color color, int x, int y) {
-  int r = (color >> 16 & 0xFF);
-  int g = (color >> 8 & 0xFF);
-  int b = (color & 0xFF);
-
   g3_RefreshTransforms(true);
 
-  dglColor3ub(r, g, b);
+  PosColorUVVertex vertex{
+      vector{static_cast<float>(x), static_cast<float>(y), 0},
+      color_array{GR_COLOR_RED(color) / 255.0f, GR_COLOR_GREEN(color) / 255.0f, GR_COLOR_BLUE(color) / 255.0f, 1},
+      tex_array{}
+  };
 
-  dglBegin(GL_POINTS);
-  dglVertex2i(x, y);
-  dglEnd();
+  dglVertexPointer(3, GL_FLOAT, sizeof(PosColorUVVertex), &vertex.pos);
+  dglColorPointer(4, GL_FLOAT, sizeof(PosColorUVVertex), &vertex.color);
+  dglDrawArrays(GL_POINTS, 0, 1);
 }
 
 // Sets a pixel on the display

--- a/renderer/HardwareSetup.cpp
+++ b/renderer/HardwareSetup.cpp
@@ -26,12 +26,6 @@
 // User-specified aspect ratio, stored as w/h
 static float sAspect = 0.0f;
 
-// initialize the 3d system
-void g3_Init(void) { atexit(g3_Close); }
-
-// close down the 3d system
-void g3_Close(void) {}
-
 // allows the user to specify an aspect ratio that overrides the renderer's
 // The parameter is the w/h of the screen pixels
 void g3_SetAspectRatio(float aspect) { sAspect = aspect; }

--- a/renderer/HardwareTransforms.cpp
+++ b/renderer/HardwareTransforms.cpp
@@ -47,13 +47,6 @@ void g3_GetModelViewMatrix(const vector *viewPos, const matrix *viewMatrix, floa
   mvMat[15] = 1.0f;
 }
 
-void g3_TransformVert(float res[4], float pt[4], float a[4][4]) {
-  int y;
-  for (y = 0; y < 4; ++y) {
-    res[y] = (pt[0] * a[0][y]) + (pt[1] * a[1][y]) + (pt[2] * a[2][y]) + (pt[3] * a[3][y]);
-  }
-}
-
 void g3_TransformMult(float res[4][4], float a[4][4], float b[4][4]) {
   float temp[4][4];
 

--- a/renderer/dyna_gl.h
+++ b/renderer/dyna_gl.h
@@ -58,7 +58,6 @@
 #endif
 
 typedef void(GLFUNCCALL *glAlphaFunc_fp)(GLenum func, GLclampf ref);
-typedef void(GLFUNCCALL *glBegin_fp)(GLenum mode);
 typedef void(GLFUNCCALL *glBindTexture_fp)(GLenum target, GLuint texture);
 typedef void(GLFUNCCALL *glBlendFunc_fp)(GLenum sfactor, GLenum dfactor);
 typedef void(GLFUNCCALL *glClear_fp)(GLbitfield mask);
@@ -81,7 +80,6 @@ typedef void(GLFUNCCALL *glDrawPixels_fp)(GLsizei width, GLsizei height, GLenum 
                                           const GLvoid *pixels);
 typedef void(GLFUNCCALL *glEnable_fp)(GLenum cap);
 typedef void(GLFUNCCALL *glEnableClientState_fp)(GLenum array);
-typedef void(GLFUNCCALL *glEnd_fp)(void);
 typedef void(GLFUNCCALL *glFlush_fp)(void);
 typedef void(GLFUNCCALL *glFogf_fp)(GLenum pname, GLfloat param);
 typedef void(GLFUNCCALL *glFogfv_fp)(GLenum pname, const GLfloat *params);
@@ -153,7 +151,6 @@ DYNAEXTERN(wglGetProcAddress_fp, dwglGetProcAddress);
 #endif
 
 DYNAEXTERN(glAlphaFunc_fp, dglAlphaFunc);
-DYNAEXTERN(glBegin_fp, dglBegin);
 DYNAEXTERN(glBindTexture_fp, dglBindTexture);
 DYNAEXTERN(glBlendFunc_fp, dglBlendFunc);
 DYNAEXTERN(glClear_fp, dglClear);
@@ -175,7 +172,6 @@ DYNAEXTERN(glDrawElements_fp, dglDrawElements);
 DYNAEXTERN(glDrawPixels_fp, dglDrawPixels);
 DYNAEXTERN(glEnable_fp, dglEnable);
 DYNAEXTERN(glEnableClientState_fp, dglEnableClientState);
-DYNAEXTERN(glEnd_fp, dglEnd);
 DYNAEXTERN(glFlush_fp, dglFlush);
 DYNAEXTERN(glFogf_fp, dglFogf);
 DYNAEXTERN(glFogfv_fp, dglFogfv);
@@ -264,10 +260,6 @@ module *LoadOpenGLDLL(const char *dllname) {
   if (!dglAlphaFunc)
     goto dll_error;
 
-  dglBegin = (glBegin_fp)mod_GetSymbol(&OpenGLDLLInst, "glBegin", 255);
-  if (!dglBegin)
-    goto dll_error;
-
   dglBindTexture = (glBindTexture_fp)mod_GetSymbol(&OpenGLDLLInst, "glBindTexture", 255);
   if (!dglBindTexture)
     goto dll_error;
@@ -350,10 +342,6 @@ module *LoadOpenGLDLL(const char *dllname) {
 
   dglEnableClientState = (glEnableClientState_fp)mod_GetSymbol(&OpenGLDLLInst, "glEnableClientState", 255);
   if (!dglEnableClientState)
-    goto dll_error;
-
-  dglEnd = (glEnd_fp)mod_GetSymbol(&OpenGLDLLInst, "glEnd", 255);
-  if (!dglEnd)
     goto dll_error;
 
   dglFlush = (glFlush_fp)mod_GetSymbol(&OpenGLDLLInst, "glFlush", 255);
@@ -492,7 +480,6 @@ module *LoadOpenGLDLL(const char *dllname) {
 
   // bk000614 - have to fix globals
   extern glAlphaFunc_fp dglAlphaFunc;
-  extern glBegin_fp dglBegin;
   extern glBindTexture_fp dglBindTexture;
   extern glBlendFunc_fp dglBlendFunc;
   extern glClear_fp dglClear;
@@ -513,7 +500,6 @@ module *LoadOpenGLDLL(const char *dllname) {
   extern glDrawPixels_fp dglDrawPixels;
   extern glEnable_fp dglEnable;
   extern glEnableClientState_fp dglEnableClientState;
-  extern glEnd_fp dglEnd;
   extern glFlush_fp dglFlush;
   extern glFogf_fp dglFogf;
   extern glFogfv_fp dglFogfv;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [x] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
Eliminates `glBegin` and `glEnd` calls, bringing us a step closer to eliminating Immediate-Mode OpenGL. In the process, color calculations are unified into one method (which does still need further simplification) and a bunch of dead code is removed.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
