### PR TITLE
fix path creation in gamesave.cpp

### DIFF
--- a/Descent3/gamesave.cpp
+++ b/Descent3/gamesave.cpp
@@ -399,8 +399,10 @@ void SaveGameDialog() {
   // create savegame directory if it didn't exist before.
   std::error_code ec;
   if (!std::filesystem::create_directories(savegame_dir, ec)) {
-    DoMessageBox(TXT_ERROR, TXT_ERRCREATEDIR, MSGBOX_OK);
-    return;
+    if (ec != 0) {
+      DoMessageBox(TXT_ERROR, TXT_ERRCREATEDIR, MSGBOX_OK);
+      return;
+    }
   }
 
   // open window

--- a/Descent3/gamesave.cpp
+++ b/Descent3/gamesave.cpp
@@ -399,7 +399,7 @@ void SaveGameDialog() {
   // create savegame directory if it didn't exist before.
   std::error_code ec;
   if (!std::filesystem::create_directories(savegame_dir, ec)) {
-    if (!ec) {
+    if (ec) {
       DoMessageBox(TXT_ERROR, TXT_ERRCREATEDIR, MSGBOX_OK);
       return;
     }

--- a/Descent3/gamesave.cpp
+++ b/Descent3/gamesave.cpp
@@ -399,7 +399,7 @@ void SaveGameDialog() {
   // create savegame directory if it didn't exist before.
   std::error_code ec;
   if (!std::filesystem::create_directories(savegame_dir, ec)) {
-    if (ec != 0) {
+    if (!ec) {
       DoMessageBox(TXT_ERROR, TXT_ERRCREATEDIR, MSGBOX_OK);
       return;
     }


### PR DESCRIPTION
std::filesystem::create_directories returns false but no error code if the path already exists. Hence no longer saving was possible as soon as the path exists. Added check for the error code (ec) to be non-zero for the error message

