### PR TITLE
Use standard temporary directory instead of custom/cache

### DIFF
--- a/Descent3/D3ForceFeedback.cpp
+++ b/Descent3/D3ForceFeedback.cpp
@@ -97,6 +97,7 @@
 #include "weapon.h"
 #include "ddio.h"
 #include "psrand.h"
+#include "descent.h"
 
 extern float Gametime;
 
@@ -647,7 +648,7 @@ void ForceEffectsInit(void) {
   char path[_MAX_PATH];
 
   if (cfexist("D3Force.ifr")) {
-    ddio_MakePath(path, LocalD3Dir, "custom", "cache", "D3Force.ifr", NULL);
+    ddio_MakePath(path, Descent3_temp_directory, "D3Force.ifr", NULL);
     cf_CopyFile(path, "D3Force.ifr", 0);
     prj = ddio_ForceLoadProject(IGNORE_TABLE(path), kJoy1);
   } else {

--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -3133,7 +3133,6 @@ int Osiris_ExtractScriptsFromHog(int library_handle, bool is_mission_hog) {
 
   if (!OSIRIS_Extracted_script_dir) {
     strcpy(tempdir, Descent3_temp_directory);
-    // ddio_MakePath(tempdir,LocalD3Dir,"custom","cache",NULL);	//TODO: make real path here
     OSIRIS_Extracted_script_dir = mem_strdup(tempdir);
     if (!OSIRIS_Extracted_script_dir)
       Error("Out of memory");

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1387,7 +1387,6 @@ void LoadGameSettings() {
   if (Katmai && !FindArg("-nosparkles")) {
     Render_powerup_sparkles = true;
   }
-
 }
 
 struct tTempFileInfo {
@@ -1414,17 +1413,17 @@ void InitIOSystems(bool editor) {
     memset(exec_path, 0, sizeof(exec_path));
     // Populate exec_path with the executable path
     if (!ddio_GetBinaryPath(exec_path, sizeof(exec_path))) {
-    Error("Failed to get executable path\n");
+      Error("Failed to get executable path\n");
     } else {
-       std::filesystem::path executablePath(exec_path);
-       std::string baseDirectoryString = executablePath.parent_path().string();
-       strncpy(Base_directory, baseDirectoryString.c_str(), sizeof(Base_directory) - 1);
-       Base_directory[sizeof(Base_directory) - 1] = '\0';
-       mprintf(0, "Using working directory of %s\n", Base_directory);
-      }
-    } else {
-       ddio_GetWorkingDir(Base_directory, sizeof(Base_directory));
-      }
+      std::filesystem::path executablePath(exec_path);
+      std::string baseDirectoryString = executablePath.parent_path().string();
+      strncpy(Base_directory, baseDirectoryString.c_str(), sizeof(Base_directory) - 1);
+      Base_directory[sizeof(Base_directory) - 1] = '\0';
+      mprintf(0, "Using working directory of %s\n", Base_directory);
+    }
+  } else {
+    ddio_GetWorkingDir(Base_directory, sizeof(Base_directory));
+  }
 
   ddio_SetWorkingDir(Base_directory);
 
@@ -1667,13 +1666,13 @@ void UpdateInitMessage(float amount) {
   if (Init_in_editor)
     return;
   InitMessage(Init_messagebar_text, (amount * Init_messagebar_portion) + Init_messagebar_offset);
-/*
-  mprintf(0, "amt=%.2f, portion=%.2f offs=%.2f, prog=%.2f\n",
-          amount,
-          Init_messagebar_portion,
-          Init_messagebar_offset,
-          (amount*Init_messagebar_portion)+Init_messagebar_offset);
-*/
+  /*
+    mprintf(0, "amt=%.2f, portion=%.2f offs=%.2f, prog=%.2f\n",
+            amount,
+            Init_messagebar_portion,
+            Init_messagebar_offset,
+            (amount*Init_messagebar_portion)+Init_messagebar_offset);
+  */
 }
 
 void InitMessage(const char *c, float progress) {
@@ -1902,7 +1901,6 @@ void InitD3Systems1(bool editor) {
 
   //	Initialize Cinematics system
   InitCinematics();
-
 }
 
 // Initialize rest of stuff
@@ -1988,9 +1986,14 @@ void SetupTempDirectory(void) {
   if (t_arg) {
     strcpy(Descent3_temp_directory, GameArgs[t_arg + 1]);
   } else {
-    ddio_MakePath(Descent3_temp_directory, std::filesystem::temp_directory_path().u8string().c_str(), "Descent3",
-                  "cache", NULL);
     std::error_code ec;
+    std::filesystem::path tempPath = std::filesystem::temp_directory_path(ec);
+    if (ec) {
+      Error("Could not find temporary directory: \"%s\"", ec.message().c_str() );
+      exit(1);
+    }
+    ddio_MakePath(Descent3_temp_directory, tempPath.u8string().c_str(), "Descent3",
+                  "cache", NULL);
     std::filesystem::create_directories(Descent3_temp_directory, ec);
     if (ec) {
       Error("Could not create temporary directory: \"%s\"", Descent3_temp_directory);

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1988,8 +1988,14 @@ void SetupTempDirectory(void) {
   if (t_arg) {
     strcpy(Descent3_temp_directory, GameArgs[t_arg + 1]);
   } else {
-    // initialize it to custom/cache
-    ddio_MakePath(Descent3_temp_directory, Base_directory, "custom", "cache", NULL);
+    ddio_MakePath(Descent3_temp_directory, std::filesystem::temp_directory_path().u8string().c_str(), "Descent3",
+                  "cache", NULL);
+    std::error_code ec;
+    std::filesystem::create_directories(Descent3_temp_directory, ec);
+    if (ec) {
+      Error("Could not create temporary directory: \"%s\"", Descent3_temp_directory);
+      exit(1);
+    }
   }
 
   // verify that temp directory exists

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1994,11 +1994,13 @@ void SetupTempDirectory(void) {
     }
     ddio_MakePath(Descent3_temp_directory, tempPath.u8string().c_str(), "Descent3",
                   "cache", NULL);
-    std::filesystem::create_directories(Descent3_temp_directory, ec);
-    if (ec) {
-      Error("Could not create temporary directory: \"%s\"", Descent3_temp_directory);
-      exit(1);
-    }
+  }
+
+  std::error_code ec;
+  std::filesystem::create_directories(Descent3_temp_directory, ec);
+  if (ec) {
+    Error("Could not create temporary directory: \"%s\"", Descent3_temp_directory);
+    exit(1);
   }
 
   // verify that temp directory exists

--- a/Descent3/multi.cpp
+++ b/Descent3/multi.cpp
@@ -7684,7 +7684,6 @@ void MultiDoFileReq(uint8_t *data) {
     // char filename[_MAX_PATH];
     char filewithpath[_MAX_PATH * 2];
     strcpy(filewithpath, GetFileNameFromPlayerAndID(filewho, filenum));
-    // ddio_MakePath(filewithpath,LocalD3Dir,"custom","cache",filename,NULL);
     if (filewithpath[0] == 0) {
       mprintf(0, "Got a file request for a file that doesn't exist (%s).\n", filewithpath);
       DenyFile(playernum, filenum, NetPlayers[playernum].file_xfer_who);
@@ -7795,7 +7794,6 @@ void MultiDoFileData(uint8_t *data) {
       // char filename[_MAX_PATH];
       char filewithpath[_MAX_PATH * 2];
       strcpy(filewithpath, GetFileNameFromPlayerAndID(playernum, file_id));
-      // ddio_MakePath(filewithpath,LocalD3Dir,"custom","cache",filename,NULL);
 
       cfp = cfopen(filewithpath, "wb");
       if (!cfp) {

--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ The milestone needs testing on all platforms. Please report issues when found.
     - _(Optional)_ All `.pld` files
     - _(Optional)_ The `demo` folder
     - _(Optional)_ The `movies` folder
-6. Create the following folders in `D3-open-source`:
-    - `custom/`
-    - `custom/cache/`
+6. Create the `custom/` folder in `D3-open-source`
 7. Obtain new Descent 3 engine files:
     - If you want to use pre-built binaries, then download one of the artifacts from our latest CI run. You can find a list of CI runs [here](https://github.com/DescentDevelopers/Descent3/actions/workflows/build.yml?query=branch%3Amain).
     - If you want to build the engine files yourself, the follow [these instructions](#building). Once you build the engine files, they’ll be put in `builds/<platform>/Descent3/<build-type>/`. For example, if you’re using Linux and you create a “Release” build, then the files will be located at `builds/linux/Descent3/Release`.

--- a/manage/manage.cpp
+++ b/manage/manage.cpp
@@ -817,7 +817,6 @@ void mng_InitLocalDirectories() {
   std::filesystem::create_directories(dir / "custom", ec);
   std::filesystem::create_directories(dir / "custom" / "graphics", ec);
   std::filesystem::create_directories(dir / "custom" / "sounds", ec);
-  std::filesystem::create_directories(dir / "custom" / "cache", ec);
   std::filesystem::create_directories(dir / "custom" / "settings", ec);
 
   cf_SetSearchPath(LocalCustomGraphicsDir);


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Temp dir will be `/tmp/Descent3/cache` on Unix. Leave `-tempdir` option anyway, in case we want 2 clients to be run on the same host, so they don't try to lock the same file
