### PR TITLE
Fix use of DLLOpenCFile with std::filesystem::path making multiplayer crash

### DIFF
--- a/netgames/anarchy/anarchy.cpp
+++ b/netgames/anarchy/anarchy.cpp
@@ -548,7 +548,7 @@ quick_exit:;
 
 void SaveStatsToFile(char *filename) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "wt");
   if (!file) {
     mprintf(0, "Unable to open output file\n");
     return;

--- a/netgames/coop/coop.cpp
+++ b/netgames/coop/coop.cpp
@@ -634,7 +634,7 @@ void DisplayHUDScores(struct tHUDItem *hitem) {
 void SaveStatsToFile(char *filename) {
   /*
   CFILE *file;
-  DLLOpenCFILE(&file,filename,"wt");
+  DLLOpenCFILE(&file,std::filesystem::path(filename),"wt");
   if(!file){
           mprintf(0,"Unable to open output file\n");
           return;

--- a/netgames/ctf/ctf.cpp
+++ b/netgames/ctf/ctf.cpp
@@ -1386,7 +1386,7 @@ quick_exit:;
 
 void SaveStatsToFile(char *filename) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "wt");
   if (!file) {
     DLLmprintf(0, "Unable to open output file\n");
     return;

--- a/netgames/dmfc/dmfcbase.cpp
+++ b/netgames/dmfc/dmfcbase.cpp
@@ -3427,7 +3427,7 @@ bool DMFCBase::InputCommandHandle(char *command_string) {
           tInputCommandNode *node = m_InputCommandRootNode;
 
           CFILE *file;
-          DLLOpenCFILE(&file,"C:\\DMFCHelp.txt","wt");
+          DLLOpenCFILE(&file,std::filesystem::path("C:\\DMFCHelp.txt"),"wt");
 
           if(!file)
                   return false;
@@ -4685,7 +4685,7 @@ MenuItem *DMFCBase::CreateMenuItem(const char *title, char type, uint8_t flags, 
 
 void ParseHostsFile(char *filename, tHostsNode **root) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "rt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "rb");
 
   tHostsNode *curr = *root;
 
@@ -4925,7 +4925,7 @@ void DMFCBase::ParseStartupScript(void) {
     DLLddio_MakePath(path, LocalD3Dir, "netgames", "autoexec.dmfc", NULL);
   }
 
-  DLLOpenCFILE(&file, path, "rt");
+  DLLOpenCFILE(&file, std::filesystem::path(path), "rt");
   if (!file)
     return;
 

--- a/netgames/dmfc/dmfccfg.cpp
+++ b/netgames/dmfc/dmfccfg.cpp
@@ -289,7 +289,7 @@ void CRegistry::Export() {
   tKey *curr, *next;
   curr = next = root;
   CFILE *file;
-  DLLOpenCFILE(&file, name, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(name), "wt");
 
   if (!file)
     return;
@@ -340,7 +340,7 @@ bool CRegistry::Import() {
   CFILE *file;
   char *ptr;
 
-  DLLOpenCFILE(&file, name, "rt");
+  DLLOpenCFILE(&file, std::filesystem::path(name), "rt");
 
   if (!file) {
     mprintf(0, "Unable to import %s\n", name);

--- a/netgames/entropy/EntropyBase.cpp
+++ b/netgames/entropy/EntropyBase.cpp
@@ -1396,7 +1396,7 @@ void OnControlMessage(uint8_t msg, int from_pnum) {
 
 void SaveStatsToFile(char *filename) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "wt");
   if (!file) {
     DLLmprintf(0, "Unable to open output file\n");
     return;

--- a/netgames/hoard/hoard.cpp
+++ b/netgames/hoard/hoard.cpp
@@ -1027,7 +1027,7 @@ quick_exit:;
 
 void SaveStatsToFile(char *filename) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "wt");
   if (!file) {
     DLLmprintf(0, "Unable to open output file\n");
     return;

--- a/netgames/hyperanarchy/hyperanarchy.cpp
+++ b/netgames/hyperanarchy/hyperanarchy.cpp
@@ -905,7 +905,7 @@ void OnClientPlayerDisconnect(int player_num) {
 
 void SaveStatsToFile(char *filename) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "wt");
   if (!file) {
     DLLmprintf(0, "Unable to open output file\n");
     return;

--- a/netgames/monsterball/monsterball.cpp
+++ b/netgames/monsterball/monsterball.cpp
@@ -1432,7 +1432,7 @@ void OnPrintScores(int level) {
 
 void SaveStatsToFile(char *filename) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "wt");
   if (!file) {
     DLLmprintf(0, "Unable to open output file\n");
     return;

--- a/netgames/roboanarchy/roboanarchy.cpp
+++ b/netgames/roboanarchy/roboanarchy.cpp
@@ -543,7 +543,7 @@ quick_exit:;
 
 void SaveStatsToFile(char *filename) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "wt");
   if (!file) {
     mprintf(0, "Unable to open output file\n");
     return;

--- a/netgames/tanarchy/tanarchy.cpp
+++ b/netgames/tanarchy/tanarchy.cpp
@@ -620,7 +620,7 @@ quick_exit:;
 
 void SaveStatsToFile(char *filename) {
   CFILE *file;
-  DLLOpenCFILE(&file, filename, "wt");
+  DLLOpenCFILE(&file, std::filesystem::path(filename), "wt");
   if (!file) {
     DLLmprintf(0, "Unable to open output file\n");
     return;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [x] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Conversion from `char *` to `const std::filesystem::path &` did not go as #486 expected, making the game crash when starting multiplayer, because `filename` provided to `cfopen` was null. This fixes the issue by doing explicit conversions

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

Fixup #486 
