### PR TITLE
Windows crashdumps

### DIFF
--- a/Descent3/CMakeLists.txt
+++ b/Descent3/CMakeLists.txt
@@ -313,8 +313,12 @@ target_link_libraries(Descent3 PRIVATE
   music networking physics renderer rtperformance sndlib ui unzip vecmat md5
   ${PLATFORM_LIBS})
 target_include_directories(Descent3 PRIVATE ${PROJECT_BINARY_DIR}/lib)
+target_link_options(Descent3 PRIVATE $<$<PLATFORM_ID:Windows>:/DEBUG:FULL>)
 add_dependencies(Descent3 get_git_hash Direct_TCP_IP_Hog HogFull NetgamesDir Parallax_Online_Hog)
 install(TARGETS Descent3 RUNTIME BUNDLE DESTINATION .)
+if(MSVC)
+  install(FILES $<TARGET_PDB_FILE:Descent3> DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1059,7 +1059,7 @@ void PreInitD3Systems() {
   debugging = true;
 #endif
 
-  error_Init(debugging, false, PRODUCT_NAME);
+  error_Init(debugging, PRODUCT_NAME);
 
   if (FindArg("-lowmem"))
     Mem_low_memory_mode = true;

--- a/Descent3/sdlmain.cpp
+++ b/Descent3/sdlmain.cpp
@@ -41,6 +41,7 @@
 #include "appdatabase.h"
 #include "args.h"
 #include "init.h"
+#include "debug.h"
 
 #include "osiris_dll.h"
 
@@ -134,7 +135,9 @@ void install_signal_handlers() {
     fprintf(stderr, "SIG: Unable to install SIGTRAP\n");
 }
 #else
-void install_signal_handlers() {}
+void install_signal_handlers() {
+  SetUnhandledExceptionFilter(RecordExceptionInfo);
+}
 #endif
 
 //	---------------------------------------------------------------------------

--- a/ddebug/debug.h
+++ b/ddebug/debug.h
@@ -184,6 +184,6 @@ void ddio_InternalKeyClose();
 // We forward declare PEXCEPTION_POINTERS so that the function
 // prototype doesn't needlessly require windows.h.
 typedef struct _EXCEPTION_POINTERS EXCEPTION_POINTERS, *PEXCEPTION_POINTERS;
-int __cdecl RecordExceptionInfo(PEXCEPTION_POINTERS data, const char *Message);
+long __cdecl RecordExceptionInfo(PEXCEPTION_POINTERS data);
 #endif
 #endif

--- a/ddebug/debug.h
+++ b/ddebug/debug.h
@@ -152,7 +152,7 @@ constexpr const int OSMBOX_OKCANCEL = 5;
 extern bool Debug_break;
 
 // if we are running under a debugger, then pass true
-bool Debug_Init(bool debugger, bool mono_debug);
+bool Debug_Init(bool debugger);
 // Does a messagebox with a stack dump
 // Messagebox shows topstring, then stack dump, then bottomstring
 // Return types are the same as the Windows return values

--- a/ddebug/lnxdebug.cpp
+++ b/ddebug/lnxdebug.cpp
@@ -50,7 +50,7 @@ bool Debug_break = false;
 static char *Debug_DumpInfo();
 
 //	if we are running under a debugger, then pass true
-bool Debug_Init(bool debugger, bool mono_debug) {
+bool Debug_Init(bool debugger) {
 #ifndef RELEASE
   Debug_break = debugger;
 

--- a/ddebug/windebug.cpp
+++ b/ddebug/windebug.cpp
@@ -203,7 +203,7 @@ bool Debug_break = false;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-bool Debug_Init(bool debugger, bool mono_debug) {
+bool Debug_Init(bool debugger) {
   // initialization of debugging consoles.
 
 #ifndef RELEASE

--- a/ddebug/windebug.cpp
+++ b/ddebug/windebug.cpp
@@ -189,21 +189,17 @@
  */
 
 #include <windows.h>
-#include <cstdarg>
-#include <cstdlib>
-#include <cstdint>
+#include <DbgHelp.h>
+#include <cstring>
+#include <filesystem>
 
-#include "d3_version.h"
 #include "debug.h"
 #include "mem.h"
-#include "mono.h"
 #include "pserror.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 
 bool Debug_break = false;
-
-char *Debug_DumpInfo();
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -229,13 +225,7 @@ bool Debug_Init(bool debugger, bool mono_debug) {
 // Messagebox shows topstring, then stack dump, then bottomstring
 // Return types are as the same the Windows return values
 int Debug_ErrorBox(int type, const char *title, const char *topstring, const char *bottomstring) {
-  int answer;
-  char *dumptext = Debug_DumpInfo();
-  // HWND wnd = GetActiveWindow();
-
-  // ShowWindow(wnd, SW_SHOWMINNOACTIVE);
-
-  DWORD flags;
+  DWORD flags = 0;
   if (type == OSMBOX_OK)
     flags = MB_OK;
   else if (type == OSMBOX_YESNO)
@@ -249,40 +239,21 @@ int Debug_ErrorBox(int type, const char *title, const char *topstring, const cha
   else
     debug_break();
 
-  char *tmpbuf = (char *)mem_malloc(
-      strlen(dumptext) + strlen(topstring) + strlen(bottomstring) +
-                      10); // malloc(strlen(dumptext) + strlen(topstring) + strlen(bottomstring) + 10);
-
-  strcpy(tmpbuf, topstring);
-  if (dumptext[0]) {
-    strcat(tmpbuf, "\r\n\r\n");
-    strcat(tmpbuf, dumptext);
-  }
-  if (bottomstring[0]) {
-    strcat(tmpbuf, "\r\n\r\n");
-    strcat(tmpbuf, bottomstring);
-  }
-
-  wsprintf(tmpbuf, "%s\r\n\r\n%s\r\n\r\n%s", topstring, dumptext, bottomstring);
+  char *tmpbuf = (char *)mem_malloc(strlen(topstring) + strlen(bottomstring) + 5);
+  wsprintf(tmpbuf, "%s\r\n\r\n%s", topstring, bottomstring);
 
   ShowCursor(TRUE);
-  answer = MessageBox(NULL, tmpbuf, title, flags | MB_TASKMODAL | MB_SETFOREGROUND); // what's MB_ICONHAND?
+  int answer = MessageBox(nullptr, tmpbuf, title, flags | MB_TASKMODAL | MB_SETFOREGROUND);
   ShowCursor(FALSE);
 
-  // free(tmpbuf);
   mem_free(tmpbuf);
-
-  //	ShowWindow(wnd, SW_SHOWMAXIMIZED);
 
   return answer;
 }
 
 // Return types are the same the Windows return values
 int Debug_MessageBox(int type, const char *title, const char *str) {
-  DWORD flags;
-  int answer;
-  HWND wnd = GetActiveWindow();
-
+  DWORD flags = 0;
   if (type == OSMBOX_OK)
     flags = MB_OK;
   else if (type == OSMBOX_YESNO)
@@ -295,629 +266,15 @@ int Debug_MessageBox(int type, const char *title, const char *str) {
     DebugBreak();
 
   ShowCursor(TRUE);
-  //	ShowWindow(wnd, SW_SHOWMINNOACTIVE);
-  answer = MessageBox(nullptr, str, title, flags | MB_TASKMODAL | MB_SETFOREGROUND);
+  int answer = MessageBox(nullptr, str, title, flags | MB_TASKMODAL | MB_SETFOREGROUND);
   ShowCursor(FALSE);
-  //	ShowWindow(wnd, SW_SHOWMAXIMIZED);
 
   return answer;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-//	This CODE SHOULD ONLY BE USED IN A DEBUGGABLE VERSION.
-
-#ifndef _WIN64
-#define SHOW_CALL_STACK // Uncomment SHOW_CALL_STACK to show the call stack in terminal cases
-// #define DUMPRAM
-#endif // _WIN64
-
-#ifdef SHOW_CALL_STACK
-
-class DumpBuffer {
-public:
-  enum { BUFFER_SIZE = 32000 };
-  DumpBuffer();
-  void Clear();
-  void Printf(const char *format, ...);
-  void SetWindowText(HWND hWnd) const;
-  char buffer[BUFFER_SIZE];
-
-private:
-  char *current;
-};
-
-class PE_Debug {
-public:
-  PE_Debug();
-  ~PE_Debug();
-  void ClearReport();
-  int DumpDebugInfo(DumpBuffer &dumpBuffer, const BYTE *caller, HINSTANCE hInstance);
-  void Display();
-
-private:
-  // Report data
-  enum { MAX_MODULENAME_LEN = 512, VA_MAX_FILENAME_LEN = 256 };
-  char latestModule[MAX_MODULENAME_LEN];
-  char latestFile[VA_MAX_FILENAME_LEN];
-  // File mapping data
-  HANDLE hFile;
-  HANDLE hFileMapping;
-  PIMAGE_DOS_HEADER fileBase;
-  // Pointers to debug information
-  PIMAGE_NT_HEADERS NT_Header;
-  PIMAGE_COFF_SYMBOLS_HEADER COFFDebugInfo;
-  PIMAGE_SYMBOL COFFSymbolTable;
-  int COFFSymbolCount;
-  const char *stringTable;
-
-  void ClearFileCache();
-  void ClearDebugPtrs();
-  void MapFileInMemory(const char *module);
-  void FindDebugInfo();
-  void DumpSymbolInfo(DumpBuffer &dumpBuffer, DWORD relativeAddress);
-  void DumpLineNumber(DumpBuffer &dumpBuffer, DWORD relativeAddress);
-  PIMAGE_COFF_SYMBOLS_HEADER GetDebugHeader();
-  PIMAGE_SECTION_HEADER SectionHeaderFromName(const char *name);
-  const char *GetSymbolName(PIMAGE_SYMBOL sym);
-};
-
-DumpBuffer ::DumpBuffer() { Clear(); }
-
-void DumpBuffer ::Clear() { current = buffer; }
-
-void DumpBuffer ::Printf(const char *format, ...) {
-  // protect against obvious buffer overflow
-  if (current - buffer < BUFFER_SIZE) {
-    va_list argPtr;
-    va_start(argPtr, format);
-    int count = wvsprintf(current, format, argPtr);
-    va_end(argPtr);
-    current += count;
-  }
-}
-
-void DumpBuffer ::SetWindowText(HWND hWnd) const { SendMessage(hWnd, WM_SETTEXT, 0, (LPARAM)buffer); }
-
-///////////////////////////////////////////////////////////////////////////////
-
-// Add an offset to a pointer and cast to a given type; may be
-// implemented as a template function but Visual C++ has some problems.
-#define BasedPtr(type, ptr, ofs) (type)((DWORD)(ptr) + (DWORD)(ofs))
-
-PE_Debug ::PE_Debug() {
-  // Init file mapping cache
-  hFileMapping = 0;
-  hFile = INVALID_HANDLE_VALUE;
-  fileBase = 0;
-  ClearDebugPtrs();
-  ClearReport();
-}
-
-PE_Debug ::~PE_Debug() { ClearFileCache(); }
-
-void PE_Debug ::ClearReport() {
-  latestModule[0] = 0;
-  latestFile[0] = 0;
-}
-
-void PE_Debug ::ClearDebugPtrs() {
-  NT_Header = NULL;
-  COFFDebugInfo = NULL;
-  COFFSymbolTable = NULL;
-  COFFSymbolCount = 0;
-  stringTable = NULL;
-}
-
-void PE_Debug ::ClearFileCache() {
-  if (fileBase) {
-    UnmapViewOfFile(fileBase);
-    fileBase = 0;
-  }
-  if (hFileMapping != 0) {
-    CloseHandle(hFileMapping);
-    hFileMapping = 0;
-  }
-  if (hFile != INVALID_HANDLE_VALUE) {
-    CloseHandle(hFile);
-    hFile = INVALID_HANDLE_VALUE;
-  }
-}
-
-void PE_Debug ::DumpLineNumber(DumpBuffer &dumpBuffer, DWORD relativeAddress) {
-  PIMAGE_LINENUMBER line = BasedPtr(PIMAGE_LINENUMBER, COFFDebugInfo, COFFDebugInfo->LvaToFirstLinenumber);
-  DWORD lineCount = COFFDebugInfo->NumberOfLinenumbers;
-  const DWORD none = (DWORD)-1;
-  DWORD maxAddr = 0;
-  DWORD lineNum = none;
-  for (DWORD i = 0; i < lineCount; i++) {
-    if (line->Linenumber != 0) // A regular line number
-    {
-      // look for line with bigger address <= relativeAddress
-      if (line->Type.VirtualAddress <= relativeAddress && line->Type.VirtualAddress > maxAddr) {
-        maxAddr = line->Type.VirtualAddress;
-        lineNum = line->Linenumber;
-      }
-    }
-    line++;
-  }
-  if (lineNum != none)
-    dumpBuffer.Printf("  line %d\r\n", lineNum);
-  //  else
-  //  dumpBuffer.Printf( "  line <unknown>\r\n" ) ;
-}
-
-const char *PE_Debug ::GetSymbolName(PIMAGE_SYMBOL sym) {
-  const int NAME_MAX_LEN = 64;
-  static char buf[NAME_MAX_LEN];
-  if (sym->N.Name.Short != 0) {
-    strncpy(buf, (const char *)sym->N.ShortName, 8);
-    buf[8] = 0;
-  } else {
-    strncpy(buf, stringTable + sym->N.Name.Long, NAME_MAX_LEN);
-    buf[NAME_MAX_LEN - 1] = 0;
-  }
-  return (buf);
-}
-
-void unmangle(char *dst, const char *src) {
-  // strcpy( dst, src );
-  // return;
-
-  src++;
-  while ((*src) && (*src != ' ') && (*src != '@')) {
-    *dst++ = *src++;
-  }
-  *dst++ = 0;
-}
-
-#ifdef DUMPRAM
-
-struct MemSymbol {
-  int section;
-  int offset;
-  int size;
-  char name[132];
-};
-
-int Num_symbols = 0;
-int Max_symbols = 0;
-MemSymbol *Symbols;
-
-void InitSymbols() {
-  Num_symbols = 0;
-  Max_symbols = 5000;
-  Symbols = (MemSymbol *)mem_malloc(Max_symbols * sizeof(MemSymbol));
-  if (!Symbols) {
-    Max_symbols = 0;
-  }
-}
-
-void Add_Symbol(int section, int offset, const char *name, char *module) {
-  if (Num_symbols >= Max_symbols) {
-    return;
-  }
-
-  MemSymbol *sym = &Symbols[Num_symbols++];
-
-  sym->section = section;
-  sym->offset = offset;
-  sym->size = -1;
-
-  strcpy(sym->name, name);
-  strcat(sym->name, "(");
-  strcat(sym->name, module);
-  strcat(sym->name, ")");
-}
-
-int Sym_compare(const void *arg1, const void *arg2) {
-  MemSymbol *sym1 = (MemSymbol *)arg1;
-  MemSymbol *sym2 = (MemSymbol *)arg2;
-
-  if (sym1->section < sym2->section) {
-    return -1;
-  } else if (sym1->section > sym2->section) {
-    return 1;
-  } else {
-    if (sym1->offset > sym2->offset) {
-      return 1;
-    } else {
-      return -1;
-    }
-  }
-}
-
-int Sym_compare1(const void *arg1, const void *arg2) {
-  MemSymbol *sym1 = (MemSymbol *)arg1;
-  MemSymbol *sym2 = (MemSymbol *)arg2;
-
-  if (sym1->size < sym2->size) {
-    return 1;
-  } else if (sym1->size > sym2->size) {
-    return -1;
-  } else {
-    return 0;
-  }
-}
-
-void DumpSymbols() {
-  int i;
-
-  qsort(Symbols, Num_symbols, sizeof(MemSymbol), Sym_compare);
-
-  for (i = 0; i < Num_symbols; i++) {
-    MemSymbol *sym1 = &Symbols[i];
-    MemSymbol *sym2 = &Symbols[i + 1];
-    if ((i < Num_symbols - 1) && (sym1->section == sym2->section)) {
-      sym1->size = sym2->offset - sym1->offset;
-    } else {
-      sym1->size = -1;
-    }
-  }
-
-  qsort(Symbols, Num_symbols, sizeof(MemSymbol), Sym_compare1);
-
-  FILE *fp = fopen("memory.out", "wt");
-
-  fprintf(fp, "%-60s %8s %8s\n", "Name", "Size", "Total");
-
-  int total_size = 0;
-  for (i = 0; i < Num_symbols; i++) {
-    MemSymbol *sym = &Symbols[i];
-    if (sym->size > 0)
-      total_size += sym->size;
-    fprintf(fp, "%-60s %8d %8d\n", sym->name, sym->size, total_size);
-  }
-
-  fclose(fp);
-
-  mem_free(Symbols);
-  Symbols = NULL;
-  _asm int 3
-}
-#endif
-
-void PE_Debug::DumpSymbolInfo(DumpBuffer &dumpBuffer, DWORD relativeAddress) {
-  // Variables to keep track of function symbols
-  PIMAGE_SYMBOL currentSym = COFFSymbolTable;
-  PIMAGE_SYMBOL fnSymbol = NULL;
-  DWORD maxFnAddress = 0;
-
-#ifdef DUMPRAM
-  InitSymbols();
-#endif
-
-  // Variables to keep track of file symbols
-  PIMAGE_SYMBOL fileSymbol = NULL;
-  PIMAGE_SYMBOL latestFileSymbol = NULL;
-  for (int i = 0; i < COFFSymbolCount; i++) {
-
-    // Look for .text section where relativeAddress belongs to.
-    // Keep track of the filename the .text section belongs to.
-    if (currentSym->StorageClass == IMAGE_SYM_CLASS_FILE) {
-      latestFileSymbol = currentSym;
-    }
-
-    // Borland uses "CODE" instead of the standard ".text" entry
-    // Microsoft uses sections that only _begin_ with .text
-    const char *symName = GetSymbolName(currentSym);
-
-    if (strnicmp(symName, ".text", 5) == 0 || stricmp(symName, "CODE") == 0) {
-      if (currentSym->Value <= relativeAddress) {
-        PIMAGE_AUX_SYMBOL auxSym = (PIMAGE_AUX_SYMBOL)(currentSym + 1);
-        if (currentSym->Value + auxSym->Section.Length >= relativeAddress) {
-          fileSymbol = latestFileSymbol;
-        }
-      }
-    }
-
-    // Look for the function with biggest address <= relativeAddress
-    BOOL isFunction = ISFCN(currentSym->Type); // Type == 0x20, See WINNT.H
-    if (isFunction &&
-        (currentSym->StorageClass == IMAGE_SYM_CLASS_EXTERNAL || currentSym->StorageClass == IMAGE_SYM_CLASS_STATIC)) {
-
-      if (currentSym->Value <= relativeAddress && currentSym->Value > maxFnAddress) {
-        maxFnAddress = currentSym->Value;
-        fnSymbol = currentSym;
-      }
-    }
-
-#ifdef DUMPRAM
-    if (!isFunction && (currentSym->SectionNumber > -1)) {
-      if ((symName[0] == '_' && symName[1] != '$') || (symName[0] == '?')) {
-
-        char pretty_module[1024];
-
-        if (fileSymbol) {
-          const char *auxSym = (const char *)(latestFileSymbol + 1);
-          char tmpFile[VA_MAX_FILENAME_LEN];
-          strcpy(tmpFile, auxSym);
-          strcpy(pretty_module, tmpFile);
-          char *p = pretty_module + strlen(pretty_module) - 1;
-          // Move p to point to first letter of EXE filename
-          while ((*p != '\\') && (*p != '/') && (*p != ':'))
-            p--;
-          p++;
-          if (strlen(p) < 1) {
-            strcpy(pretty_module, "<unknown>");
-          } else {
-            memmove(pretty_module, p, strlen(p) + 1);
-          }
-        } else {
-          strcpy(pretty_module, "");
-        }
-
-        Add_Symbol(currentSym->SectionNumber, currentSym->Value, symName, pretty_module);
-      }
-    }
-#endif
-
-    // Advance counters, skip aux symbols
-    i += currentSym->NumberOfAuxSymbols;
-    currentSym += currentSym->NumberOfAuxSymbols;
-    currentSym++;
-  }
-
-#ifdef DUMPRAM
-  DumpSymbols();
-#endif
-
-  // dump symbolic info if found
-  if (fileSymbol) {
-    const char *auxSym = (const char *)(fileSymbol + 1);
-
-    if (stricmp(latestFile, auxSym)) {
-      strcpy(latestFile, auxSym);
-      // JAS      dumpBuffer.Printf( "  file: %s\r\n", auxSym ) ;
-    }
-  } else {
-    latestFile[0] = 0;
-    // JAS    dumpBuffer.Printf( "  file: unknown\r\n" ) ;
-  }
-
-  if (fnSymbol) {
-    char tmp_name[1024];
-    unmangle(tmp_name, GetSymbolName(fnSymbol));
-    dumpBuffer.Printf("    %s()", tmp_name);
-  } else {
-    dumpBuffer.Printf("    <unknown>");
-  }
-}
-
-PIMAGE_SECTION_HEADER PE_Debug ::SectionHeaderFromName(const char *name) {
-  PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(NT_Header);
-  for (unsigned i = 0; i < NT_Header->FileHeader.NumberOfSections; i++) {
-    if (strnicmp((const char *)section->Name, name, IMAGE_SIZEOF_SHORT_NAME) == 0)
-      return (section);
-    else
-      section++;
-  }
-  return 0;
-}
-
-PIMAGE_COFF_SYMBOLS_HEADER PE_Debug ::GetDebugHeader() {
-  // Some files have a wrong entry in the COFF header, so
-  // first check if the debug info exists at all
-  if (NT_Header->FileHeader.PointerToSymbolTable == 0)
-    return (0);
-  DWORD debugDirRVA = NT_Header->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_DEBUG].VirtualAddress;
-  if (debugDirRVA == 0)
-    return (0);
-
-  // The following values must be calculated differently for MS/Borland files
-  PIMAGE_DEBUG_DIRECTORY debugDir;
-  DWORD size;
-
-  // Borland files have the debug directory at the beginning of a .debug section
-  PIMAGE_SECTION_HEADER debugHeader = SectionHeaderFromName(".debug");
-  if (debugHeader && debugHeader->VirtualAddress == debugDirRVA) {
-    debugDir = (PIMAGE_DEBUG_DIRECTORY)(debugHeader->PointerToRawData + (DWORD)fileBase);
-    size = NT_Header->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_DEBUG].Size * sizeof(IMAGE_DEBUG_DIRECTORY);
-  } else
-  // Microsoft debug directory is in the .rdata section
-  {
-    debugHeader = SectionHeaderFromName(".rdata");
-    if (debugHeader == 0)
-      return (0);
-    size = NT_Header->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_DEBUG].Size;
-    DWORD offsetInto_rdata = debugDirRVA - debugHeader->VirtualAddress;
-    debugDir = BasedPtr(PIMAGE_DEBUG_DIRECTORY, fileBase, debugHeader->PointerToRawData + offsetInto_rdata);
-  }
-
-  // look for COFF debug info
-  DWORD debugFormats = size / sizeof(IMAGE_DEBUG_DIRECTORY);
-  for (DWORD i = 0; i < debugFormats; i++) {
-    if (debugDir->Type == IMAGE_DEBUG_TYPE_COFF)
-      return ((PIMAGE_COFF_SYMBOLS_HEADER)((DWORD)fileBase + debugDir->PointerToRawData));
-    else
-      debugDir++;
-  }
-  return (NULL);
-}
-
-void PE_Debug ::FindDebugInfo() {
-  ClearDebugPtrs();
-  // Put everything into a try/catch in case the file has wrong fields
-  try {
-    // Verify that fileBase is a valid pointer to a DOS header
-    if (fileBase && fileBase->e_magic == IMAGE_DOS_SIGNATURE) {
-      // Get a pointer to the PE header
-      NT_Header = BasedPtr(PIMAGE_NT_HEADERS, fileBase, fileBase->e_lfanew);
-
-      // Verify that NT_Header is a valid pointer to a NT header
-      if (NT_Header && NT_Header->Signature == IMAGE_NT_SIGNATURE) {
-        // Get a pointer to the debug header if any
-        COFFDebugInfo = GetDebugHeader();
-
-        // Get a pointer to the symbol table and retrieve the number of symbols
-        if (NT_Header->FileHeader.PointerToSymbolTable)
-          COFFSymbolTable = BasedPtr(PIMAGE_SYMBOL, fileBase, NT_Header->FileHeader.PointerToSymbolTable);
-        COFFSymbolCount = NT_Header->FileHeader.NumberOfSymbols;
-
-        // The string table starts right after the symbol table
-        stringTable = (const char *)(COFFSymbolTable + COFFSymbolCount);
-      }
-    }
-  } catch (...) {
-    // Header wrong, do nothing
-  }
-}
-
-void PE_Debug ::MapFileInMemory(const char *module) {
-  ClearFileCache();
-  hFile = CreateFile(module, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
-  if (hFile != INVALID_HANDLE_VALUE) {
-    hFileMapping = CreateFileMapping(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
-    if (hFileMapping != 0)
-      fileBase = (PIMAGE_DOS_HEADER)MapViewOfFile(hFileMapping, FILE_MAP_READ, 0, 0, 0);
-  }
-  // NB: open files/mapping are closed later in ClearFileCache
-}
-
-int PE_Debug::DumpDebugInfo(DumpBuffer &dumpBuffer, const BYTE *caller, HINSTANCE hInstance) {
-  // Avoid to open, map and looking for debug header/symbol table
-  // by caching the latest and comparing the actual module with
-  // the latest one.
-  static char module[MAX_MODULENAME_LEN];
-  GetModuleFileName(hInstance, module, MAX_MODULENAME_LEN);
-
-  // New module
-  if (stricmp(latestModule, module)) {
-    strcpy(latestModule, module);
-    // JAS    dumpBuffer.Printf( "Module: %s\r\n", module );
-    MapFileInMemory(module);
-    FindDebugInfo();
-  }
-
-  char pretty_module[1024];
-
-  strcpy(pretty_module, module);
-  char *p = pretty_module + strlen(pretty_module) - 1;
-  // Move p to point to first letter of EXE filename
-  while ((*p != '\\') && (*p != '/') && (*p != ':'))
-    p--;
-  p++;
-  if (strlen(p) < 1) {
-    strcpy(pretty_module, "<unknown>");
-  } else {
-    memmove(pretty_module, p, strlen(p) + 1);
-  }
-
-  if (fileBase) {
-    // Put everything into a try/catch in case the file has wrong fields
-    try {
-      DWORD relativeAddress = caller - (BYTE *)hInstance;
-      // Dump symbolic information and line number if available
-      if (COFFSymbolCount != 0 && COFFSymbolTable != NULL) {
-        DumpSymbolInfo(dumpBuffer, relativeAddress);
-        if (COFFDebugInfo)
-          DumpLineNumber(dumpBuffer, relativeAddress);
-        return 1;
-      } else {
-        // dumpBuffer.Printf( "Call stack is unavailable, because there is\r\nno COFF debugging info in this
-        // module.\r\n" ) ; JAS dumpBuffer.Printf( "  no debug information\r\n" ) ;
-        dumpBuffer.Printf("    %s %08x()\r\n", pretty_module, caller);
-        return 0;
-      }
-    } catch (...) {
-      // Header wrong, do nothing
-      return 0;
-    }
-  } else {
-    dumpBuffer.Printf("    %s %08x()\r\n", pretty_module, caller);
-    // JAS dumpBuffer.Printf( "  module not accessible\r\n" ) ;
-    // JAS dumpBuffer.Printf( "    address: %8X\r\n", caller ) ;
-    return 0;
-  }
-}
-
-void DumpCallsStack(DumpBuffer &dumpBuffer) {
-  const char *separator = "------------------------------------------------------------------\r\n";
-  static PE_Debug PE_debug;
-
-  dumpBuffer.Printf("\r\nCall stack:\r\n");
-  dumpBuffer.Printf(separator);
-
-  // The structure of the stack frames is the following:
-  // EBP -> parent stack frame EBP
-  //        return address for this call ( = caller )
-  // The chain can be navigated iteratively, after the
-  // initial value of EBP is loaded from the register
-  DWORD parentEBP, retval;
-  MEMORY_BASIC_INFORMATION mbi;
-  HINSTANCE hInstance;
-
-  int depth = 0;
-
-  __asm MOV parentEBP, EBP
-
-      do {
-    depth++;
-    if (depth > 16)
-      break;
-
-    if ((parentEBP & 3) || IsBadReadPtr((DWORD *)parentEBP, sizeof(DWORD))) {
-      break;
-    }
-    parentEBP = *(DWORD *)parentEBP;
-
-    BYTE **NextCaller = ((BYTE **)parentEBP + 1);
-
-    if (IsBadReadPtr(NextCaller, sizeof(BYTE *))) {
-      break;
-    }
-
-    BYTE *caller = *NextCaller; // Error sometimes!!!
-
-    // Skip the first EBP as it points to AssertionFailed, which is
-    // uninteresting for the user
-
-    if (depth > 1) {
-
-      // Get the instance handle of the module where caller belongs to
-      retval = VirtualQuery(caller, &mbi, sizeof(mbi));
-
-      // The instance handle is equal to the allocation base in Win32
-      hInstance = (HINSTANCE)mbi.AllocationBase;
-
-      if ((retval == sizeof(mbi)) && hInstance) {
-        if (!PE_debug.DumpDebugInfo(dumpBuffer, caller, hInstance)) {
-          // break;
-        }
-      } else {
-        break; // End of the call chain
-      }
-    }
-  }
-  while (TRUE)
-    ;
-
-  dumpBuffer.Printf(separator);
-  PE_debug.ClearReport(); // Prepare for future calls
-}
-
-// This ought to be local to VerboseAssert, but it
-// causes problems in Visual C++ (in the CRTL init phase)
-static DumpBuffer dumpBuffer;
-
-#endif // SHOW_CALL_STACK
-
-///////////////////////////////////////////////////////////////////////////////
 
 void dump_text_to_clipboard(char *text);
-
-char *Debug_DumpInfo() {
-#ifdef SHOW_CALL_STACK
-  dumpBuffer.Clear();
-  DumpCallsStack(dumpBuffer);
-  dump_text_to_clipboard(dumpBuffer.buffer);
-
-  dumpBuffer.Printf("\r\n[ This info has been copied to the clipboard for pasting to a bug report. ]\r\n");
-
-  return dumpBuffer.buffer;
-#else
-  return ("");
-#endif
-}
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -936,7 +293,7 @@ void DumpTextToClipboard(char *text) {
   }
 
   // Length of string with CRs added
-  int len = strlen(text) + extra + 1;
+  size_t len = strlen(text) + extra + 1;
 
   HGLOBAL h_text = GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, len);
   if (!h_text)
@@ -965,295 +322,44 @@ void DumpTextToClipboard(char *text) {
 
 void dump_text_to_clipboard(char *text) { DumpTextToClipboard(text); }
 
-// Translate the exception code into something human readable.
+///////////////////////////////////////////////////////////////////////////////
 
-static const char *GetExceptionDescription(DWORD ExceptionCode) {
-  struct ExceptionNames {
-    DWORD ExceptionCode;
-    char *ExceptionName;
-  };
+#pragma comment(lib, "DbgHelp.lib")
 
-  ExceptionNames ExceptionMap[] = {
-      {0x40010005, "a Control-C"},
-      {0x40010008, "a Control-Break"},
-      {0x80000002, "a Datatype Misalignment"},
-      {0x80000003, "a Breakpoint"},
-      {0xc0000005, "an Access Violation"},
-      {0xc0000006, "an In Page Error"},
-      {0xc0000017, "a No Memory"},
-      {0xc000001d, "an Illegal Instruction"},
-      {0xc0000025, "a Noncontinuable Exception"},
-      {0xc0000026, "an Invalid Disposition"},
-      {0xc000008c, "a Array Bounds Exceeded"},
-      {0xc000008d, "a Float Denormal Operand"},
-      {0xc000008e, "a Float Divide by Zero"},
-      {0xc000008f, "a Float Inexact Result"},
-      {0xc0000090, "a Float Invalid Operation"},
-      {0xc0000091, "a Float Overflow"},
-      {0xc0000092, "a Float Stack Check"},
-      {0xc0000093, "a Float Underflow"},
-      {0xc0000094, "an Integer Divide by Zero"},
-      {0xc0000095, "an Integer Overflow"},
-      {0xc0000096, "a Privileged Instruction"},
-      {0xc00000fD, "a Stack Overflow"},
-      {0xc0000142, "a DLL Initialization Failed"},
-      {0xe06d7363, "a Microsoft C++ Exception"},
-  };
-
-  for (int i = 0; i < sizeof(ExceptionMap) / sizeof(ExceptionMap[0]); i++)
-    if (ExceptionCode == ExceptionMap[i].ExceptionCode)
-      return ExceptionMap[i].ExceptionName;
-
-  return "Unknown exception type";
-}
-
-static void PrintFileTime(char *sztime, FILETIME ftime) {
-  SYSTEMTIME systime, fixtime;
-  *sztime = NULL;
-
-  if (FileTimeToSystemTime(&ftime, &fixtime)) {
-    if (SystemTimeToTzSpecificLocalTime(NULL, &fixtime, &systime)) {
-      wsprintf(sztime, "%d/%d/%d %02d:%02d:%02d", systime.wMonth, systime.wDay, systime.wYear, systime.wHour,
-               systime.wMinute, systime.wSecond);
-    } else {
-      wsprintf(sztime, "Unknown Time");
-    }
-  }
-}
-
-// Print information about a code module (DLL or EXE) such as its size,
-// location, time stamp, etc.
-
-static void ShowModuleInfo(HANDLE LogFile, HINSTANCE ModuleHandle) {
-  char FmtString[2000];
-  DWORD bytesout;
-  char ModName[_MAX_PATH];
-  __try {
-    if (GetModuleFileName(ModuleHandle, ModName, sizeof(ModName)) > 0) {
-      // If GetModuleFileName returns greater than zero then this must
-      // be a valid code module address. Therefore we can try to walk
-      // our way through its structures to find the link time stamp.
-      IMAGE_DOS_HEADER *DosHeader = (IMAGE_DOS_HEADER *)ModuleHandle;
-      if (IMAGE_DOS_SIGNATURE != DosHeader->e_magic)
-        return;
-      IMAGE_NT_HEADERS *NTHeader = (IMAGE_NT_HEADERS *)((char *)DosHeader + DosHeader->e_lfanew);
-      if (IMAGE_NT_SIGNATURE != NTHeader->Signature)
-        return;
-      // Open the code module file so that we can get its file date
-      // and size.
-      HANDLE ModuleFile =
-          CreateFile(ModName, GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
-      char TimeBuffer[100] = "";
-      DWORD FileSize = 0;
-      if (ModuleFile != INVALID_HANDLE_VALUE) {
-        FileSize = GetFileSize(ModuleFile, 0);
-        FILETIME LastWriteTime;
-        if (GetFileTime(ModuleFile, 0, 0, &LastWriteTime)) {
-          PrintFileTime(TimeBuffer + lstrlen(TimeBuffer), LastWriteTime);
-        }
-        CloseHandle(ModuleFile);
-      }
-
-      wsprintf(FmtString, "%s,\taddr: 0x%08x\tsize:%d\t[%s]\r\n", ModName, ModuleHandle, FileSize,
-               TimeBuffer); // NTHeader->FileHeader.TimeDateStamp,
-      WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-    }
-  }
-  // Handle any exceptions by continuing from this point.
-  __except (EXCEPTION_EXECUTE_HANDLER) {
-  }
-}
-
-// Scan memory looking for code modules (DLLs or EXEs). VirtualQuery is used
-// to find all the blocks of address space that were reserved or committed,
-// and ShowModuleInfo will display module information if they are code
-// modules.
-
-static void RecordModuleList(HANDLE LogFile) {
-  char FmtString[2000];
-  DWORD bytesout;
-  wsprintf(FmtString, "\r\n"
-                      "Modules:\r\n");
-  WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-  SYSTEM_INFO SystemInfo;
-  GetSystemInfo(&SystemInfo);
-  const size_t PageSize = SystemInfo.dwPageSize;
-  // Set NumPages to the number of pages in the 4GByte address space,
-  // while being careful to avoid overflowing ints.
-  const size_t NumPages = 4 * size_t((1024 * 1024 * 1024) / PageSize);
-  size_t pageNum = 0;
-  void *LastAllocationBase = 0;
-  while (pageNum < NumPages) {
-    MEMORY_BASIC_INFORMATION MemInfo;
-    if (VirtualQuery((void *)(pageNum * PageSize), &MemInfo, sizeof(MemInfo))) {
-      if (MemInfo.RegionSize > 0) {
-        // Adjust the page number to skip over this block of memory.
-        pageNum += MemInfo.RegionSize / PageSize;
-        if (MemInfo.State == MEM_COMMIT && MemInfo.AllocationBase > LastAllocationBase) {
-          // Look for new blocks of committed memory, and try
-          // recording their module names - this will fail
-          // gracefully if they aren't code modules.
-          LastAllocationBase = MemInfo.AllocationBase;
-          ShowModuleInfo(LogFile, (HINSTANCE)LastAllocationBase);
-        }
-      } else
-        pageNum += (64 * 1024) / PageSize;
-    } else
-      pageNum += (64 * 1024) / PageSize;
-  }
-}
-
-// Record information about the user's system, such as processor type, amount
-// of memory, etc.
-
-static void RecordSystemInformation(HANDLE LogFile) {
-  char FmtString[2000];
-  DWORD bytesout;
-  FILETIME CurrentTime;
-  GetSystemTimeAsFileTime(&CurrentTime);
-  char TimeBuffer[100];
-
-  PrintFileTime(TimeBuffer, CurrentTime);
-
-  wsprintf(FmtString, "Error occurred at %s.\r\n", TimeBuffer);
-  WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-  char ModuleName[_MAX_PATH];
-  if (GetModuleFileName(0, ModuleName, sizeof(ModuleName)) <= 0)
-    lstrcpy(ModuleName, "Unknown");
-
-  wsprintf(FmtString, "Module: %s.\r\n", ModuleName);
-  WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-
-  MEMORYSTATUS ms;
-  ms.dwLength = sizeof(ms);
-  GlobalMemoryStatus(&ms);
-  // Print out the amount of physical memory, rounded up.
-  wsprintf(FmtString, "System Memory Status:\r\n");
-  WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-  wsprintf(FmtString, "Percent of memory in use: %d\r\n", ms.dwMemoryLoad);
-  WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-  wsprintf(FmtString, "Bytes of physical memory : %d\r\n", ms.dwTotalPhys);
-  WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-  wsprintf(FmtString, "Free physical memory bytes  : %d\r\n", ms.dwAvailPhys);
-  WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-  wsprintf(FmtString, "Available virtual memory : %d\r\n\r\n", ms.dwAvailPageFile);
-  WriteFile(LogFile, FmtString, lstrlen(FmtString), &bytesout, 0);
-}
-/*
-extern bool Debug_break;
-extern char *Debug_DumpInfo();
-*/
-#define FORMAT_REG                                                                                                     \
-  "Registers:\r\nEAX=%08x CS=%04x EIP=%08x EFLGS=%08x\r\nEBX=%08x SS=%04x ESP=%08x EBP=%08x\r\nECX=%08x DS=%04x "      \
-  "ESI=%08x FS=%04x\r\nEDX=%08x ES=%04x EDI=%08x GS=%04x\r\n"
-#define FORMAT_SEP "\r\n--------------------------------------------------------------------------------\r\n"
-#define FORMATCRLF "\r\n"
-
-const int NumCodeBytes = 16;   // Number of code bytes to record.
-const int MaxStackDump = 2048; // Maximum number of DWORDS in stack dumps.
-const int StackColumns = 8;    // Number of columns in stack dump.
-
-int __cdecl RecordExceptionInfo(PEXCEPTION_POINTERS data, const char *Message) {
-  static int BeenHere;
+long __cdecl RecordExceptionInfo(PEXCEPTION_POINTERS data) {
+  static bool BeenHere = false;
   if (BeenHere) // Going recursive! That must mean this routine crashed!
     return EXCEPTION_CONTINUE_SEARCH;
   BeenHere = true;
 
-#ifndef _WIN64
-  PEXCEPTION_RECORD Exception = data->ExceptionRecord;
-  PCONTEXT Context = data->ContextRecord;
-  const char *desc = GetExceptionDescription(Exception->ExceptionCode);
+  SetMessageBoxTitle("Unexpected error");
 
-  // An Int3()
-  if (0x80000003 == Exception->ExceptionCode) {
-    BeenHere = false;
-    return EXCEPTION_CONTINUE_SEARCH;
+  std::error_code ec;
+  const std::filesystem::path dumFilePath = std::filesystem::temp_directory_path(ec) / "d3-crash.dmp";
+  if (ec) {
+    OutrageMessageBox("Could not find temporary directory to write crash dump file into: %s", ec.message().c_str());
+    exit(1);
   }
 
-  char topmsg[500];
-  char tmpmsg[1000];
-  char bottommsg[1000] = "";
-  char callstack[1000] = "";
-
-  wsprintf(topmsg, "Execution in %s was stopped by %s", Message, desc);
-
-  wsprintf(bottommsg, FORMAT_REG, Context->Eax, Context->SegCs, Context->Eip, Context->EFlags, Context->Ebx,
-           Context->SegSs, Context->Esp, Context->Ebp, Context->Ecx, Context->SegDs, Context->Esi, Context->SegFs,
-           Context->Edx, Context->SegEs, Context->Edi, Context->SegGs);
-
-  HANDLE LogFile =
-      CreateFile("error.log", GENERIC_WRITE, 0, 0, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH, 0);
-  if (LogFile != INVALID_HANDLE_VALUE) {
-
-    char *p = Debug_DumpInfo();
-    lstrcpy(callstack, p);
-
-    DWORD NumBytes;
-    SetFilePointer(LogFile, 0, 0, FILE_END);
-
-    WriteFile(LogFile, topmsg, lstrlen(topmsg), &NumBytes, 0);
-    WriteFile(LogFile, FORMATCRLF, lstrlen(FORMATCRLF), &NumBytes, 0);
-
-    char Username[100];
-    DWORD unamelen = 99;
-    char Machinename[200];
-    DWORD cnamelen = 199;
-    GetUserName(Username, &unamelen);
-    GetComputerName(Machinename, &cnamelen);
-    wsprintf(callstack, "Username: %s\r\nMachineName: %s\r\n", Username, Machinename);
-    WriteFile(LogFile, callstack, lstrlen(callstack), &NumBytes, 0);
-
-#if (defined(RELEASE) && (!defined(DEMO)))
-    wsprintf(callstack, "Descent 3 Release build %s\r\n", D3_GIT_HASH);
-    WriteFile(LogFile, callstack, lstrlen(callstack), &NumBytes, 0);
-#endif
-    RecordSystemInformation(LogFile);
-    RecordModuleList(LogFile);
-
-    WriteFile(LogFile, bottommsg, lstrlen(bottommsg), &NumBytes, 0);
-    WriteFile(LogFile, FORMAT_SEP, lstrlen(FORMAT_SEP), &NumBytes, 0);
-
-    DWORD *pStack = (DWORD *)Context->Esp;
-    DWORD *pStackTop;
-    __asm {
-			mov	eax, fs:[4]
-			mov pStackTop, eax
-    }
-    if (pStackTop > pStack + MaxStackDump) pStackTop = pStack + MaxStackDump;
-    int Count = 0;
-
-    char buffer[1000] = "";
-    const int safetyzone = 50;
-    char *nearend = buffer + sizeof(buffer) - safetyzone;
-    char *output = buffer;
-    while (pStack + 1 <= pStackTop) {
-      if ((Count % StackColumns) == 0)
-        output += wsprintf(output, "%08x: ", pStack);
-      char *Suffix = " ";
-      if ((++Count % StackColumns) == 0 || pStack + 2 > pStackTop)
-        Suffix = "\r\n";
-      output += wsprintf(output, "%08x%s", *pStack, Suffix);
-      pStack++;
-      // Check for when the buffer is almost full, and flush it to disk.
-      if (output > nearend) {
-        wsprintf(tmpmsg, "%s", buffer);
-        WriteFile(LogFile, tmpmsg, lstrlen(tmpmsg), &NumBytes, 0);
-        buffer[0] = 0;
-        output = buffer;
-      }
-    }
-    CloseHandle(LogFile);
+  HANDLE hDumpFile = CreateFile(dumFilePath.u8string().c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, 0);
+  if (hDumpFile == INVALID_HANDLE_VALUE) {
+    OutrageMessageBox("Could not create crash dump file, error code: %x", GetLastError());
+    exit(1);
   }
 
-  if ((!Debug_break) && (!no_debug_dialog))
-    Debug_ErrorBox(OSMBOX_OK, "Error", topmsg, bottommsg);
-#endif // _WIN64
+  MINIDUMP_EXCEPTION_INFORMATION exceptInfo;
+  exceptInfo.ThreadId = GetCurrentThreadId();
+  exceptInfo.ExceptionPointers = data;
+  exceptInfo.ClientPointers = TRUE;
 
-  if (no_debug_dialog)
-    exit(0);
+  if (MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpNormal, &exceptInfo, nullptr, nullptr)) {
+    OutrageMessageBox("Crash dump file written to: %s\nYou can attach it to a bug report.", dumFilePath.u8string().c_str());
+  } else {
+    OutrageMessageBox("Could not write crash dump file, error code: %x", GetLastError());
+    exit(1);
+  }
+
   BeenHere = false;
-  if (Debug_break)
-    return EXCEPTION_CONTINUE_SEARCH;
-  else
-    return EXCEPTION_EXECUTE_HANDLER;
+
+  return Debug_break ? EXCEPTION_CONTINUE_SEARCH : EXCEPTION_EXECUTE_HANDLER;
 }

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -576,8 +576,13 @@ target_link_libraries(Descent3Editor PRIVATE
   fix grtext manage mem misc model module stream_audio
   music networking physics renderer rtperformance sndlib ui unzip vecmat md5
   ${PLATFORM_LIBS})
+target_link_options(Descent3Editor PRIVATE $<$<PLATFORM_ID:Windows>:/DEBUG:FULL>)
 
 add_dependencies(Descent3Editor get_git_hash)
 
 # FIXME: enable installation again when the editor is stable/usable
 # install(TARGETS Descent3Editor RUNTIME)
+# if(MSVC)
+#   install(FILES $<TARGET_PDB_FILE:Descent3Editor> DESTINATION ${CMAKE_INSTALL_BINDIR})
+# endif()
+

--- a/misc/error.cpp
+++ b/misc/error.cpp
@@ -77,8 +77,6 @@
 
 #define MAX_MSG_LEN 2000
 
-void Default_dbgbrk_callback();
-
 //	Debug break chain handlers
 void (*DebugBreak_callback_stop)() = NULL;
 void (*DebugBreak_callback_resume)() = NULL;
@@ -97,8 +95,8 @@ void error_Spew();
 //////////////////////////////////////////////////////////////////////////////
 
 //	initializes error handler.
-bool error_Init(bool debugger, bool mono_debug, const char *app_title) {
-  Debug_Init(debugger, mono_debug);
+bool error_Init(bool debugger, const char *app_title) {
+  Debug_Init(debugger);
 
   Error_initialized = true;
   Exit_message[0] = 0;
@@ -113,8 +111,6 @@ bool error_Init(bool debugger, bool mono_debug, const char *app_title) {
 
   return true;
 }
-
-int no_debug_dialog = 0;
 
 //	exits the application and prints out a standard error message
 void Error(const char *fmt, ...) {
@@ -139,12 +135,9 @@ void Error(const char *fmt, ...) {
 
   if (Debug_break)
     answer = Debug_ErrorBox(OSMBOX_ABORTRETRYIGNORE, Exit_title_str, Exit_message, "Press RETRY to debug.");
-  else if (!no_debug_dialog)
+  else
     answer = Debug_ErrorBox(OSMBOX_OKCANCEL, Exit_title_str, Exit_message,
                             "Press OK to exit, CANCEL to ignore this error and continue.");
-
-  if (no_debug_dialog)
-    answer = IDOK;
 
   switch (answer) {
   case IDRETRY:
@@ -225,7 +218,7 @@ void AssertionFailed(const char *expstr, const char *file, int line) {
 
 //	error message output function
 void error_Spew() {
-  if (Exit_message[0] && !no_debug_dialog)
+  if (Exit_message[0])
     Debug_MessageBox(OSMBOX_OK, Exit_title_str, Exit_message);
 }
 

--- a/misc/pserror.h
+++ b/misc/pserror.h
@@ -152,10 +152,8 @@
 #include "debug.h"
 #include "mono.h"
 
-extern int no_debug_dialog;
-
 //	initializes error handler.
-bool error_Init(bool debugger, bool mono_debug, const char *app_title);
+bool error_Init(bool debugger, const char *app_title);
 //	exits the application and prints out a standard error message
 void Error(const char *fmt, ...);
 //	prints out an assertion error


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Since the move to x64 Windows builds the code to manually parse callstacks in the event of unhandled exceptions wasn't used anymore. Maybe that code could have been ported to x64, I dunno. But nowadays we can just easily create a crashdump file aka MiniDump and share that for analysis.

For this to be remotely useful I also enabled the creation of debug symbols (PDB files) for all build configurations and install them, so they are available in the GitHub workflow artifacts. These shouldn't end up in the official install for the game though. For official releases it would be good to have these attached to the release on GitHub.

So when a problem comes up we can look up the version number we now already have in the executable and is recorded in the crashdump, download the matching debug symbols and analys the crash.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
For proper releases of the game it would be nice to have the debug symbols on a symbol server, so they can be fetched automatically when analyzing a crashdump. GitHub doesn't seem to have a solution for this.