### PR TITLE
macOS: Make sure the netcon modules end with dylib.

### DIFF
--- a/netcon/lanclient/CMakeLists.txt
+++ b/netcon/lanclient/CMakeLists.txt
@@ -11,6 +11,9 @@ target_link_libraries(Direct_TCP_IP PRIVATE
   ui
   $<$<PLATFORM_ID:Windows>:ws2_32>
 )
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set_target_properties(Direct_TCP_IP PROPERTIES SUFFIX ".dylib")
+endif()
 
 add_custom_target(Direct_TCP_IP_Hog
   COMMAND $<TARGET_FILE:HogMaker>

--- a/netcon/mtclient/CMakeLists.txt
+++ b/netcon/mtclient/CMakeLists.txt
@@ -17,6 +17,9 @@ target_link_libraries(Parallax_Online PRIVATE
   ui
   $<$<PLATFORM_ID:Windows>:ws2_32>
 )
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set_target_properties(Parallax_Online PROPERTIES SUFFIX ".dylib")
+endif()
 
 add_custom_target(Parallax_Online_Hog
   COMMAND $<TARGET_FILE:HogMaker>


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [X] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
This changes the extension used by the NetCon modules ("Direct TCP~IP" and "Parallax Online") to be `.dylib` on macOS.
### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [X] I have documented any new or modified functionality.
- [X] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [X] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
An alternative would be to delete the .dylib defines in the "d3c.txt" files and just use the .so extension.