### PR TITLE
CMake: add all headers to target sources

### DIFF
--- a/2dlib/CMakeLists.txt
+++ b/2dlib/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(HEADERS
+  gr.h
+  lib2d.h)
 set(CPPS
   font.cpp
   hardsurf.cpp
@@ -9,7 +12,7 @@ set(CPPS
   viewport.cpp
 )
 
-add_library(2dlib STATIC ${CPPS})
+add_library(2dlib STATIC ${HEADERS} ${CPPS})
 target_link_libraries(2dlib PRIVATE
   cfile
   mem

--- a/AudioEncode/CMakeLists.txt
+++ b/AudioEncode/CMakeLists.txt
@@ -1,10 +1,14 @@
+set(HEADERS
+  adecode.h
+  aencode.h
+  audio_encode.h)
 set(CPPS
   adecode.cpp
   aencode.cpp
   encoder.cpp
 )
 
-add_library(AudioEncode STATIC ${CPPS})
+add_library(AudioEncode STATIC ${HEADERS} ${CPPS})
 target_link_libraries(AudioEncode PRIVATE
   libacm
 )

--- a/Descent3/CMakeLists.txt
+++ b/Descent3/CMakeLists.txt
@@ -1,7 +1,28 @@
 set(HEADERS
-  aiambient.h
   AIGoal.h
   AIMain.h
+  BOA.h
+  Briefing.h
+  BriefingParse.h
+  ConfigItem.h
+  CtlCfgElem.h
+  D3ForceFeedback.h
+  DeathInfo.h
+  DllWrappers.h
+  Inventory.h
+  LoadLevel.h
+  Mission.h
+  NewPyroGauges.h
+  ObjScript.h
+  PilotPicsAPI.h
+  SmallViews.h
+  TelCom.h
+  TelComAutoMap.h
+  TelComCargo.h
+  TelComEffects.h
+  TelComEfxStructs.h
+  TelComGoals.h
+  aiambient.h
   aipath.h
   aistruct.h
   aistruct_external.h
@@ -11,31 +32,25 @@ set(HEADERS
   attach.h
   audiotaunts.h
   bnode.h
-  BOA.h
-  Briefing.h
-  BriefingParse.h
   bsp.h
   buddymenu.h
   cinematics.h
   cockpit.h
   config.h
-  ConfigItem.h
   controls.h
   credits.h
-  CtlCfgElem.h
   ctlconfig.h
   ctlconfigtxt.h
-  D3ForceFeedback.h
+  d3movie.h
+  d3music.h
   d3serial.h
   damage.h
   damage_external.h
-  DeathInfo.h
   deathinfo_external.h
   debuggraph.h
   descent.h
   difficulty.h
   difficulty_external.h
-  DllWrappers.h
   door.h
   doorway.h
   fireball.h
@@ -56,23 +71,19 @@ set(HEADERS
   hotspotmap.h
   hud.h
   init.h
-  Inventory.h
   levelgoal.h
   levelgoal_external.h
   lighting.h
   lightmap_info.h
   list.h
-  LoadLevel.h
   localization.h
   marker.h
   matcen.h
   matcen_external.h
   menu.h
-  Mission.h
   mission_download.h
   mmItem.h
   multi.h
-  multisafe.h
   multi_client.h
   multi_dll_mgr.h
   multi_external.h
@@ -80,7 +91,7 @@ set(HEADERS
   multi_server.h
   multi_ui.h
   multi_world_state.h
-  NewPyroGauges.h
+  multisafe.h
   newui.h
   newui_core.h
   object.h
@@ -88,12 +99,10 @@ set(HEADERS
   object_lighting.h
   objinfo.h
   objinit.h
-  ObjScript.h
   osiris_dll.h
   osiris_predefs.h
   osiris_share.h
   pilot.h
-  PilotPicsAPI.h
   pilot_class.h
   player.h
   player_external.h
@@ -113,7 +122,6 @@ set(HEADERS
   screens.h
   ship.h
   slew.h
-  SmallViews.h
   soar.h
   soar_helpers.h
   sounds.h
@@ -122,12 +130,6 @@ set(HEADERS
   splinter.h
   stringtable.h
   subtitles.h
-  TelCom.h
-  TelComAutoMap.h
-  TelComCargo.h
-  TelComEffects.h
-  TelComEfxStructs.h
-  TelComGoals.h
   terrain.h
   trigger.h
   vclip.h

--- a/bitmap/CMakeLists.txt
+++ b/bitmap/CMakeLists.txt
@@ -1,8 +1,8 @@
-set(HEADERS iff.h)
+set(HEADERS
+  NewBitmap.h
+  iff.h)
 set(CPPS
   NewBitmap.cpp
-  NewBitmap.h
-
   bitmain.cpp
   bumpmap.cpp
   iff.cpp

--- a/cfile/CMakeLists.txt
+++ b/cfile/CMakeLists.txt
@@ -1,10 +1,14 @@
+set(HEADERS
+  cfile.h
+  hogfile.h
+  inffile.h)
 set(CPPS
   cfile.cpp
   hogfile.cpp
   inffile.cpp
 )
 
-add_library(cfile STATIC ${CPPS})
+add_library(cfile STATIC ${HEADERS} ${CPPS})
 target_link_libraries(cfile PRIVATE
   ddio
   mem

--- a/ddebug/CMakeLists.txt
+++ b/ddebug/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(HEADERS
+  debug.h
+  debugbreak.h
+  mono.h)
 set(CPPS
   debug.cpp
   $<$<PLATFORM_ID:Darwin,Linux>:
@@ -10,7 +14,7 @@ set(CPPS
   >
 )
 
-add_library(ddebug STATIC ${CPPS})
+add_library(ddebug STATIC ${HEADERS} ${CPPS})
 add_dependencies(ddebug get_git_hash)
 target_include_directories(ddebug PUBLIC
   $<BUILD_INTERFACE:

--- a/ddio/CMakeLists.txt
+++ b/ddio/CMakeLists.txt
@@ -1,3 +1,9 @@
+set(HEADERS
+  chrono_timer.h
+  ddio.h
+  ddio_common.h
+  ddio_lnx.h
+  ddio_win.h)
 set(CPPS
   chrono_timer.cpp
   ddio.cpp
@@ -17,7 +23,7 @@ set(CPPS
     winfile.cpp
   >
 )
-add_library(ddio STATIC ${CPPS})
+add_library(ddio STATIC ${HEADERS} ${CPPS})
 target_link_libraries(ddio PRIVATE
   SDL2::SDL2
   ddebug

--- a/fix/CMakeLists.txt
+++ b/fix/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(HEADERS)
+set(HEADERS
+  fix.h)
 set(CPPS
   fix.cpp)
 

--- a/grtext/CMakeLists.txt
+++ b/grtext/CMakeLists.txt
@@ -1,10 +1,13 @@
+set(HEADERS
+  grtext.h
+  grtextlib.h)
 set(CPPS
   grfont.cpp
   grtext.cpp
   textaux.cpp
 )
 
-add_library(grtext STATIC ${CPPS})
+add_library(grtext STATIC ${HEADERS} ${CPPS})
 target_link_libraries(grtext PRIVATE
   ddio
   mem

--- a/libmve/CMakeLists.txt
+++ b/libmve/CMakeLists.txt
@@ -1,3 +1,9 @@
+set(HEADERS
+  decoders.h
+  movie_sound.h
+  mve_audio.h
+  mvelib.h
+  sound_interface.h)
 set(CPPS
   decoder8.cpp
   decoder16.cpp
@@ -7,7 +13,7 @@ set(CPPS
   mveplay.cpp
 )
 
-add_library(libmve STATIC ${CPPS})
+add_library(libmve STATIC ${HEADERS} ${CPPS})
 target_link_libraries(libmve PRIVATE
   ddio
   SDL2::SDL2

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(HEADERS
+  linux_fix.h
+  lnxapp.h
+  lnxcontroller.h
+  registry.h)
 set(CPPS
   lnxcon.cpp
   lnxcon_raw.cpp
@@ -8,7 +13,7 @@ set(CPPS
   registry.cpp
 )
 
-add_library(linux STATIC ${CPPS})
+add_library(linux STATIC ${HEADERS} ${CPPS})
 target_link_libraries(linux PRIVATE
   cfile
 )

--- a/md5/CMakeLists.txt
+++ b/md5/CMakeLists.txt
@@ -2,9 +2,7 @@ set(HEADERS md5.h)
 set(CPPS
   md5.cpp)
 
-set(PLATFORMCPPS)
-
-add_library(md5 STATIC ${HEADERS} ${CPPS} ${PLATFORMCPPS})
+add_library(md5 STATIC ${HEADERS} ${CPPS})
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/mem/CMakeLists.txt
+++ b/mem/CMakeLists.txt
@@ -1,8 +1,7 @@
-set(CPPS
-  mem.cpp
-)
+set(HEADERS mem.h)
+set(CPPS mem.cpp)
 
-add_library(mem STATIC ${CPPS})
+add_library(mem STATIC ${HEADERS} ${CPPS})
 target_compile_definitions(mem PUBLIC
   $<$<BOOL:${ENABLE_MEM_RTL}>:MEM_USE_RTL>
 )

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,3 +1,10 @@
+set(HEADERS
+  log.h
+  logfile.h
+  pserror.h
+  psglob.h
+  psrand.h
+  pstring.h)
 set(CPPS
   error.cpp
   logfile.cpp
@@ -7,7 +14,7 @@ set(CPPS
   pstring.cpp
 )
 
-add_library(misc STATIC ${CPPS})
+add_library(misc STATIC ${HEADERS} ${CPPS})
 target_link_libraries(misc PRIVATE
   ddebug
   SDL2::SDL2

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -1,9 +1,11 @@
+set(HEADERS 
+  polymodel.h)
 set(CPPS
   newstyle.cpp
   polymodel.cpp
 )
 
-add_library(model STATIC ${CPPS})
+add_library(model STATIC ${HEADERS} ${CPPS})
 target_link_libraries(model PRIVATE
   cfile
   mem

--- a/music/CMakeLists.txt
+++ b/music/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(HEADERS)
+set(HEADERS
+  music.h
+  musiclib.h)
 set(CPPS
   omflex.cpp
   sequencer.cpp

--- a/netcon/lanclient/CMakeLists.txt
+++ b/netcon/lanclient/CMakeLists.txt
@@ -1,6 +1,9 @@
+set(HEADERS
+  lanclient.h
+  lanstrings.h)
 set(CPPS lanclient.cpp)
 
-add_library(Direct_TCP_IP MODULE ${CPPS})
+add_library(Direct_TCP_IP MODULE ${HEADERS} ${CPPS})
 set_target_properties(Direct_TCP_IP PROPERTIES PREFIX "")
 set_target_properties(Direct_TCP_IP PROPERTIES CXX_VISIBILITY_PRESET "hidden")
 set_target_properties(Direct_TCP_IP PROPERTIES OUTPUT_NAME "Direct TCP~IP")

--- a/netcon/mtclient/CMakeLists.txt
+++ b/netcon/mtclient/CMakeLists.txt
@@ -1,3 +1,10 @@
+set(HEADERS
+  chat_api.h
+  mt_net.h
+  mtclient.h
+  mtgametrack.h
+  mtpilottrack.h
+  mtstrings.h)
 set(CPPS
   chat_api.cpp
   mt_net.cpp
@@ -6,7 +13,7 @@ set(CPPS
   mtpilottracker.cpp
 )
 
-add_library(Parallax_Online MODULE ${CPPS})
+add_library(Parallax_Online MODULE ${HEADERS} ${CPPS})
 set_target_properties(Parallax_Online PROPERTIES PREFIX "")
 set_target_properties(Parallax_Online PROPERTIES CXX_VISIBILITY_PRESET "hidden")
 set_target_properties(Parallax_Online PROPERTIES OUTPUT_NAME "Parallax Online")

--- a/netgames/coop/CMakeLists.txt
+++ b/netgames/coop/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(HEADERS coop.h)
+set(HEADERS
+  coop.h
+  coopstr.h)
 set(CPPS coop.cpp)
 
 set(NETGAME_MODULE coop)

--- a/physics/CMakeLists.txt
+++ b/physics/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(HEADERS
+  collide.h
+  findintersection.h
+  physics.h)
 set(CPPS
   collide.cpp
   findintersection.cpp
@@ -5,7 +9,7 @@ set(CPPS
   physics.cpp
 )
 
-add_library(physics STATIC ${CPPS})
+add_library(physics STATIC ${HEADERS} ${CPPS})
 target_link_libraries(physics PRIVATE
   ddio
   mem

--- a/rtperformance/CMakeLists.txt
+++ b/rtperformance/CMakeLists.txt
@@ -1,7 +1,9 @@
+set(HEADERS
+  rtperformance.h)
 set(CPPS
   rtperformance.cpp)
 
-add_library(rtperformance STATIC ${CPPS})
+add_library(rtperformance STATIC ${HEADERS} ${CPPS})
 target_link_libraries(rtperformance PRIVATE
   ddio
 )

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(CMAKE_FOLDER "scripts")
 
+set(HEADERS
+  AIGame3_External.h
+  linux_lib.h
+  osiris_common.h
+  osiris_import.h
+  osiris_vector.h)
 set(CPPS
   $<$<PLATFORM_ID:Darwin,Linux>:
     linux_lib.cpp
@@ -69,7 +75,7 @@ set(SCRIPTS
 #)
 
 foreach(SCRIPT ${SCRIPTS})
-  add_library(${SCRIPT} MODULE ${CPPS} "${SCRIPT}.cpp")
+  add_library(${SCRIPT} MODULE ${CPPS} ${HEADERS} "${SCRIPT}.cpp")
   target_link_libraries(${SCRIPT}
     fix
     misc

--- a/sndlib/CMakeLists.txt
+++ b/sndlib/CMakeLists.txt
@@ -1,3 +1,15 @@
+set(HEADERS
+  auddev.h
+  ddsndgeometry.h
+  ds3dlib.h
+  ds3dlib_internal.h
+  hlsoundlib.h
+  mixer.h
+  sdlsound.h
+  sndrender.h
+  soundload.h
+  ssl_lib.h
+  vmanpset.h)
 set(CPPS
   hlsoundlib.cpp
   sndrender.cpp
@@ -9,7 +21,7 @@ set(CPPS
   sdlsound.cpp
 )
 
-add_library(sndlib STATIC ${CPPS})
+add_library(sndlib STATIC ${HEADERS} ${CPPS})
 target_link_libraries(sndlib PRIVATE
   cfile
   ddio

--- a/stream_audio/CMakeLists.txt
+++ b/stream_audio/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(HEADERS)
+set(HEADERS
+  streamaudio.h)
 set(CPPS
   osfarchive.cpp
   streamaudio.cpp

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -1,3 +1,9 @@
+set(HEADERS
+  UIlib.h
+  ui.h
+  uidraw.h
+  uires.h
+  uisys.h)
 set(CPPS
   UIButton.cpp
   UICombo.cpp
@@ -16,7 +22,7 @@ set(CPPS
   UIWindow.cpp
 )
 
-add_library(ui STATIC ${CPPS})
+add_library(ui STATIC ${HEADERS} ${CPPS})
 target_link_libraries(ui PRIVATE
   ddio
   grtext

--- a/unzip/CMakeLists.txt
+++ b/unzip/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(HEADERS unzip.h)
 set(CPPS unzip.cpp)
 
 add_library(unzip STATIC ${HEADERS} ${CPPS})


### PR DESCRIPTION
This can help with CMake IDE integration and file indexing.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Set every missing header as source of CMake targets. This can improve IDE integration, and is generally a good practice to follow.  

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Mentioned in #502 https://github.com/DescentDevelopers/Descent3/pull/502#discussion_r1697584916

This should probably cover what's left to do out of #411 