### PR TITLE
Disable shipping the editor because it is not currently usable

### DIFF
--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -578,4 +578,6 @@ target_link_libraries(Descent3Editor PRIVATE
   ${PLATFORM_LIBS})
 
 add_dependencies(Descent3Editor get_git_hash)
-install(TARGETS Descent3Editor RUNTIME)
+
+# FIXME: enable installation again when the editor is stable/usable
+# install(TARGETS Descent3Editor RUNTIME)


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Don't install the editor anymore, so it is not in the build artifacts. Editor was broken when first build, but now totally unusable since the SDL2 Windows migration

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

#506 item for 1.5 release process