### PR TITLE
VECMAT: Silence "unknown pragma" warning on gcc/clang

### DIFF
--- a/lib/vecmat.h
+++ b/lib/vecmat.h
@@ -148,19 +148,12 @@
  * $NoKeywords: $
  */
 
-#ifndef _VECMAT_H
-#define _VECMAT_H
+#ifndef VECMAT_H
+#define VECMAT_H
 
-#include "pstypes.h"
-#include "math.h"
+#include <cmath>
+
 #include "fix.h"
-
-// what does this do?  Why didn't Jason put a comment here?
-// Jason replies: This pragma disables the "possible loss of data" warning that
-// is generated when converting doubles to floats
-// A thousand pardons for the confusion
-
-#pragma warning(disable : 4244)
 
 // All structs, defines and inline functions are located in vecmat_external.h
 // vecmat_external.h is where anything that can be used by DLLs should be.
@@ -253,7 +246,7 @@ void vm_Orthogonalize(matrix *m);
 // Parameters:	m - filled in with the orienation matrix
 //					fvec,uvec,rvec - pointers to vectors that determine the matrix.
 //						One or two of these must be specified, with the other(s) set to NULL.
-void vm_VectorToMatrix(matrix *m, vector *fvec, vector *uvec = NULL, vector *rvec = NULL);
+void vm_VectorToMatrix(matrix *m, vector *fvec, vector *uvec = nullptr, vector *rvec = nullptr);
 
 // Computes a matrix from a vector and and angle of rotation around that vector
 // Parameters:	m - filled in with the computed matrix


### PR DESCRIPTION
There no double to float conversion anymore, so in Windows this pragma is useless.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
