### PR TITLE
Revert "macOS: Make sure the netcon modules end with dylib."

### DIFF
--- a/netcon/lanclient/CMakeLists.txt
+++ b/netcon/lanclient/CMakeLists.txt
@@ -11,9 +11,6 @@ target_link_libraries(Direct_TCP_IP PRIVATE
   ui
   $<$<PLATFORM_ID:Windows>:ws2_32>
 )
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set_target_properties(Direct_TCP_IP PROPERTIES SUFFIX ".dylib")
-endif()
 
 add_custom_target(Direct_TCP_IP_Hog
   COMMAND $<TARGET_FILE:HogMaker>

--- a/netcon/mtclient/CMakeLists.txt
+++ b/netcon/mtclient/CMakeLists.txt
@@ -17,9 +17,6 @@ target_link_libraries(Parallax_Online PRIVATE
   ui
   $<$<PLATFORM_ID:Windows>:ws2_32>
 )
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set_target_properties(Parallax_Online PROPERTIES SUFFIX ".dylib")
-endif()
 
 add_custom_target(Parallax_Online_Hog
   COMMAND $<TARGET_FILE:HogMaker>


### PR DESCRIPTION
Reverts DescentDevelopers/Descent3#515
`LoadMultiDLL` doesn't currently look for _.dylib_.