### PR TITLE
Fixes for Windows build

### DIFF
--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -1635,20 +1635,15 @@ bool DoMissionBriefing(int level) {
   return ret;
 }
 extern bool FirstGame;
-bool Skip_next_movie = false;
+
 //	---------------------------------------------------------------------------
 //	 play movie
 void DoMissionMovie(const char *movie) {
-  char temppath[_MAX_PATH];
   if (PROGRAM(windowed)) {
     mprintf(0, "Skipping movie...can't do in windowed mode!\n");
     return;
   }
-  // Don't play this movie the first time through. This is a horrible hack.
-  if (Skip_next_movie) {
-    Skip_next_movie = false;
-    return;
-  }
+
 #ifdef D3_FAST
   return;
 #endif
@@ -1657,8 +1652,8 @@ void DoMissionMovie(const char *movie) {
     ddio_MakePath(mpath, LocalD3Dir, "movies", movie, NULL);
     PlayMovie(mpath);
   }
-  // PlayMovie(movie);
 }
+
 ///////////////////////////////////////////////////////////////////////////////
 //	Script Management for Missions and Levels
 ///////////////////////////////////////////////////////////////////////////////

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1117,9 +1117,6 @@ void PreInitD3Systems() {
 #endif
 }
 
-/*
-        Save game variables to the registry
-*/
 void SaveGameSettings() {
   char tempbuffer[TEMPBUFFERSIZE];
   int tempint;

--- a/Descent3/init.h
+++ b/Descent3/init.h
@@ -98,4 +98,9 @@ void RestartD3();
 
 void InitMessage(const char *c, float progress = -1);
 
+/**
+ * Save game variables to the registry
+ */
+void SaveGameSettings();
+
 #endif

--- a/Descent3/menu.cpp
+++ b/Descent3/menu.cpp
@@ -658,12 +658,12 @@
 #include "menu.h"
 #include "mmItem.h"
 #include "game.h"
-#include "gamesequence.h"
 #include "Mission.h"
 #include "multi_ui.h"
 #include "ctlconfig.h"
 #include "config.h"
 #include "gamesave.h"
+#include "gamesequence.h"
 #include "demofile.h"
 #include "pilot.h"
 #include "LoadLevel.h"
@@ -671,6 +671,8 @@
 #include "mem.h"
 #include "args.h"
 #include "cinematics.h"
+#include "multi_dll_mgr.h"
+#include "newui_core.h"
 
 #ifdef _WIN32
 #define USE_DIRECTPLAY
@@ -681,9 +683,6 @@
 #else
 bool Directplay_lobby_launched_game = false;
 #endif
-#include "multi_dll_mgr.h"
-#include "d3music.h"
-#include "newui_core.h"
 
 #define IDV_QUIT 0xff
 //	Menu Item Defines
@@ -702,8 +701,7 @@ bool MenuLoadLevel(void);
 #endif
 // for command line joining of games
 bool Auto_connected = false;
-// externed from init.cpp
-extern void SaveGameSettings();
+
 //	runs command line options.
 bool ProcessCommandLine();
 // new game selection
@@ -715,7 +713,6 @@ extern bool Demo_looping;
 bool FirstGame = false;
 
 int MainMenu() {
-  extern void ShowStaticScreen(char *bitmap_filename, bool timed = false, float delay_time = 0.0f);
   mmInterface main_menu;
   bool exit_game = false;
   bool exit_menu = false;
@@ -1127,15 +1124,16 @@ static inline int generate_mission_listbox(newuiListBox *lb, int n_maxfiles, cha
   }
   return c;
 }
-extern bool Skip_next_movie;
+
 #define OEM_TRAINING_FILE "training.mn3"
 #define OEM_MISSION_FILE "d3oem.mn3"
+
 bool MenuNewGame() {
   newuiTiledWindow menu;
   newuiSheet *select_sheet;
   newuiListBox *msn_lb;
-  char **filelist = NULL;
-  int n_missions, i, res; //,k
+  char **filelist = nullptr;
+  int n_missions, i, res;
   bool found = false;
   bool do_menu = true, load_mission = false, retval = true;
 #ifdef DEMO
@@ -1150,17 +1148,9 @@ bool MenuNewGame() {
     return false;
   }
 #else
-#ifdef RELEASE
   if ((!FindArg("-mission")) && (!FirstGame) && (-1 == Current_pilot.find_mission_data(TRAINING_MISSION_NAME))) {
 
     FirstGame = true;
-
-    char moviepath[_MAX_PATH];
-    ddio_MakePath(moviepath, LocalD3Dir, "movies", "level1.mve", nullptr);
-    if (cfexist(moviepath)) {
-      PlayMovie(moviepath);
-    }
-    Skip_next_movie = true;
 
     if (LoadMission("training.mn3")) {
       CurrentPilotUpdateMissionStatus(true);
@@ -1190,7 +1180,7 @@ bool MenuNewGame() {
       return false;
     }
   }
-#endif
+
   // create menu.
   menu.Create(TXT_MENUNEWGAME, 0, 0, 448, 384);
 
@@ -1333,7 +1323,7 @@ redo_newgame_menu:
           goto redo_newgame_menu;
         } else {
           Current_mission.cur_level = start_level;
-          // pull out the ship permssions and use them
+          // pull out the ship permissions and use them
           Players[0].ship_permissions = GetPilotShipPermissions(&Current_pilot, Current_mission.name);
         }
       }

--- a/Descent3/mmItem.h
+++ b/Descent3/mmItem.h
@@ -68,9 +68,12 @@
  */
 #ifndef MMITEM_H
 #define MMITEM_H
+
+#include "cinematics.h"
+#include "gamefont.h"
 #include "newui.h"
 #include "psclass.h"
-#include "gamefont.h"
+
 #if ((!defined(OEM)) && (!defined(DEMO)))
 #define MOVIE_MENU
 #endif
@@ -176,7 +179,7 @@ protected:
   virtual void OnSelect();
 };
 //	Main Menu Interface Object
-struct tCinematic;
+
 class mmInterface : public UIWindow {
   int m_nmenu_items;                 // number of menu items available.
   mmItem m_menuitems[N_MMENU_ITEMS]; // main menu items

--- a/ddebug/debug.h
+++ b/ddebug/debug.h
@@ -180,10 +180,11 @@ void ddio_InternalKeyClose();
 #else
 #define debug_break()
 #endif
+
 #if defined(WIN32)
-// We forward declare PEXCEPTION_POINTERS so that the function
-// prototype doesn't needlessly require windows.h.
-typedef struct _EXCEPTION_POINTERS EXCEPTION_POINTERS, *PEXCEPTION_POINTERS;
-long __cdecl RecordExceptionInfo(PEXCEPTION_POINTERS data);
+
+#include <windows.h>
+
+long WINAPI RecordExceptionInfo(PEXCEPTION_POINTERS data);
 #endif
 #endif

--- a/ddebug/windebug.cpp
+++ b/ddebug/windebug.cpp
@@ -325,8 +325,7 @@ void dump_text_to_clipboard(char *text) { DumpTextToClipboard(text); }
 ///////////////////////////////////////////////////////////////////////////////
 
 #pragma comment(lib, "DbgHelp.lib")
-
-long __cdecl RecordExceptionInfo(PEXCEPTION_POINTERS data) {
+long WINAPI RecordExceptionInfo(PEXCEPTION_POINTERS data) {
   static bool BeenHere = false;
   if (BeenHere) // Going recursive! That must mean this routine crashed!
     return EXCEPTION_CONTINUE_SEARCH;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

This PR fixes two errors:

1. Fixes build compilation on Windows x86 (while we don't support it, but project can still buildable).
2. Fixes runtime error on starting new game with new pilot.

During start of new game with new pilot (never played) game tries to inject to play `level1.mve` cutscene before training mission right in the middle of update UI frame. At same time, if game previously found `mainmenu.mve`, it will be looped in main menu screen. Since buffers for MVE playback already allocated for `mainmenu.mve`, trying to start another movie will lead to crash.

Removed movie injection from playing, now new pilot will see this sequence:

New game -> Training mission -> level1.mve cutscene -> Level 1

Removed `RELEASE` `#ifdef`'s on this part of code as this definitely masked issue until we caught it in preparation of release build.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
