### PR TITLE
macOS: Fix netgames not looking for dylib.

### DIFF
--- a/Descent3/Game2DLL.cpp
+++ b/Descent3/Game2DLL.cpp
@@ -572,6 +572,8 @@ bool InitGameModule(const char *name, module *mod) {
 // Make the dll filename
 #if defined(WIN32)
   snprintf(dll_name, sizeof(dll_name), "%s.dll", name);
+#elif defined(MACOSX)
+  snprintf(dll_name, sizeof(dll_name), "%s.dylib", name);
 #else
   snprintf(dll_name, sizeof(dll_name), "%s.so", name);
 #endif

--- a/Descent3/multi_dll_mgr.cpp
+++ b/Descent3/multi_dll_mgr.cpp
@@ -605,6 +605,8 @@ int LoadMultiDLL(const char *name) {
 // Make the dll filename
 #if defined(WIN32)
   snprintf(dll_name, sizeof(dll_name), "%s.dll", name);
+#elif defined(MACOSX)
+  snprintf(dll_name, sizeof(dll_name), "%s.dylib", name);
 #else
   snprintf(dll_name, sizeof(dll_name), "%s.so", name);
 #endif


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [X] Build and Dependency changes
- [X] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [X] Network changes
  - [ ] Other changes

### Description
Have the net games and net modules on macOS look for the _.dylib_ extension.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
This should replace #522

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [X] I have documented any new or modified functionality.
- [X] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [X] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
