### PR TITLE
Improve render perf for MSVC Debug configuration

### DIFF
--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -119,7 +119,9 @@ struct Renderer {
             typename = std::enable_if_t<std::is_same_v<typename std::iterator_traits<VertexIter>::value_type, PosColorUVVertex>>>
   size_t addVertexData(VertexIter begin, VertexIter end, PosColorUVVertex_tag = {}) {
     std::array<PosColorUV2Vertex, MAX_POINTS_IN_POLY> converted;
-    std::transform(begin, end, converted.begin(), [](auto const& vtx) {
+    ASSERT(std::distance(begin, end) <= converted.size());
+    // note: funny &* here is to convert the iterators into plain pointers, so MSVC's Debug STL doesn't slow this down
+    std::transform(&*begin, &*end, &*converted.begin(), [](auto const& vtx) {
       return PosColorUV2Vertex{vtx.pos, vtx.color, vtx.uv, {}};
     });
     return shader_.addVertexData(converted.cbegin(), converted.cend());

--- a/renderer/ShaderProgram.h
+++ b/renderer/ShaderProgram.h
@@ -129,7 +129,7 @@ struct OrphaningVertexBuffer : VertexBuffer<V> {
 
     auto start = nextVertex_;
     V* mapped = reinterpret_cast<V*>(dglMapBufferRange(GL_ARRAY_BUFFER, start * sizeof(V), dist * sizeof(V), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT));
-    std::copy(begin, end, mapped);
+    std::copy(&*begin, &*end, mapped); // note: funny &* here is to convert the iterator into a plain pointer, so MSVC's Debug STL doesn't slow this down
     dglUnmapBuffer(GL_ARRAY_BUFFER);
 
     nextVertex_ += dist;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [x] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
MSVC's STL performs extensive bounds and validity checking on iterators in Debug builds. This is desirable for correctness, but causes significant slowdowns in the current renderer's implementation due to the amount of vertex copies and transformations it performs. Until we can fully convert the renderer into more of a 'static data' model where the game does not need to ship thousands of vertices to the GPU each frame, the MSVC Debug build realistically needs to skip the per-iteration checks for its vertex iterators. This is, I think, a happy compromise between full checks and just using bare data pointers: The iterators are still used and checked once each at the start of any operation, but the memory accesses are done via pointers which should be very fast.

### Related Issues
#543, #545 

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
