### PR TITLE
Fix audio distortions on MVE playback with pipewire backend

### DIFF
--- a/libmve/movie_sound.cpp
+++ b/libmve/movie_sound.cpp
@@ -16,21 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <functional>
 #include "movie_sound.h"
 
 namespace D3 {
 
-MovieSoundDevice::MovieSoundDevice(int sample_rate, uint16_t sample_size, uint8_t channels, uint32_t buf_size,
-                                   bool is_compressed) {
-  SDL_AudioFormat format = (sample_size == 2) ? AUDIO_S16LSB : AUDIO_U8;
-  SDL_AudioSpec spec;
+MovieSoundDevice::MovieSoundDevice(int sample_rate, uint16_t sample_size, uint8_t channels, bool is_compressed) {
+  SDL_AudioSpec spec{};
   spec.freq = sample_rate;
-  spec.format = format;
+  spec.format = (sample_size == 2) ? AUDIO_S16LSB : AUDIO_U8;
   spec.channels = channels;
-  spec.size = buf_size;
-  spec.callback = nullptr;
-  spec.userdata = this;
 
   m_device_id = SDL_OpenAudioDevice(nullptr, 0, &spec, nullptr, 0);
   m_is_compressed = is_compressed;

--- a/libmve/movie_sound.h
+++ b/libmve/movie_sound.h
@@ -37,11 +37,10 @@ public:
    * @param sample_rate sample rate in Hz (22050, 44100...)
    * @param sample_size sample size (8, 16)
    * @param channels count of channels (1 for mono, 2 for stereo)
-   * @param buf_size buffer size for SDL audio device
    * @param is_compressed mark stream as compressed (on streaming will be used decompression functions)
    */
-  MovieSoundDevice(int sample_rate, uint16_t sample_size, uint8_t channels, uint32_t buf_size, bool is_compressed);
-  ~MovieSoundDevice();
+  MovieSoundDevice(int sample_rate, uint16_t sample_size, uint8_t channels, bool is_compressed);
+  ~MovieSoundDevice() override;
 
   /**
    * Check if sound device is properly initialized

--- a/libmve/mveplay.cpp
+++ b/libmve/mveplay.cpp
@@ -184,7 +184,7 @@ static int create_audiobuf_handler(unsigned char major, unsigned char minor, uns
     is_compressed = true;
   }
 
-  snd_ds = std::make_unique<D3::MovieSoundDevice>(sample_rate, sample_size, channels, 4096, is_compressed);
+  snd_ds = std::make_unique<D3::MovieSoundDevice>(sample_rate, sample_size, channels, is_compressed);
 #endif
 
   return 1;

--- a/libmve/sound_interface.h
+++ b/libmve/sound_interface.h
@@ -29,6 +29,8 @@ protected:
   bool m_is_compressed = false;
 
 public:
+  virtual ~ISoundDevice() = default;
+
   /// Play stream
   virtual void Play() {};
   /// Stop stream


### PR DESCRIPTION
Don't define fixed buffer length for audio device, SDL2 calculates desired length itself. Minor cleanups and fixes to virtual class and constructor.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [x] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #551.
### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
