### PR TITLE
Resolve out-of-bounds in PolyCollideObject [ASAN]

### DIFF
--- a/physics/findintersection.cpp
+++ b/physics/findintersection.cpp
@@ -4708,6 +4708,7 @@ int fvi_room(int room_index, int from_portal, int room_obj) {
           // If we hit the face...
           if (face_hit_type) {
             if ((fvi_query_ptr->flags & FQ_RECORD) && (face_info & FPF_RECORD) &&
+                Fvi_num_recorded_faces > 0 &&
                 !(Fvi_recorded_faces[Fvi_num_recorded_faces - 1].face_index == i &&
                   Fvi_recorded_faces[Fvi_num_recorded_faces - 1].room_index == room_index)) {
               ASSERT(Fvi_num_recorded_faces < MAX_RECORDED_FACES);

--- a/physics/newstyle_fi.cpp
+++ b/physics/newstyle_fi.cpp
@@ -362,12 +362,13 @@ bool PolyCollideObject(object *obj) {
   ASSERT(obj >= Objects && obj <= &Objects[Highest_object_index]);
 
 #ifndef NED_PHYSICS
-  if ((Game_mode & GM_MULTI) && !(Netgame.flags & NF_USE_ACC_WEAP) && Objects[fvi_moveobj].type == OBJ_WEAPON &&
+  if ((Game_mode & GM_MULTI) && !(Netgame.flags & NF_USE_ACC_WEAP) &&
+      fvi_moveobj >= 0 && Objects[fvi_moveobj].type == OBJ_WEAPON &&
       obj->type == OBJ_PLAYER)
     f_use_big_sphere = true;
 #endif
 
-  fvi_do_orient = (Objects[fvi_moveobj].type == OBJ_WEAPON);
+  fvi_do_orient = fvi_moveobj >= 0 && Objects[fvi_moveobj].type == OBJ_WEAPON;
 
 #ifndef NED_PHYSICS
   if (f_use_big_sphere) {
@@ -375,7 +376,7 @@ bool PolyCollideObject(object *obj) {
 
     if (addition < MULTI_ADD_SPHERE_MIN) {
       addition = MULTI_ADD_SPHERE_MIN;
-      if (Objects[fvi_moveobj].mtype.phys_info.flags & PF_NEVER_USE_BIG_SPHERE)
+      if (fvi_moveobj >= 0 && Objects[fvi_moveobj].mtype.phys_info.flags & PF_NEVER_USE_BIG_SPHERE)
         addition /= 2;
     } else if (addition > MULTI_ADD_SPHERE_MAX)
       addition = MULTI_ADD_SPHERE_MAX;
@@ -384,7 +385,7 @@ bool PolyCollideObject(object *obj) {
   }
 #endif
 
-  if (fvi_do_orient) {
+  if (fvi_do_orient && fvi_moveobj >= 0) {
     fvi_move_fvec = Objects[fvi_moveobj].orient.fvec;
     fvi_move_uvec = Objects[fvi_moveobj].orient.uvec;
   }


### PR DESCRIPTION
(Observed in Retribution level 7 while interacting with an Old Scratch robot.) *Potentially* might fix issue #530.

```
fvi_moveobj=-1
fvi_moveobj=101
fvi_moveobj=235
fvi_moveobj=374
fvi_moveobj=-378
fvi_moveobj=-378
fvi_moveobj=-374
==59260==ERROR: AddressSanitizer: global-buffer-overflow on address 0x000003c8f058 at pc 0x0000012857fc bp 0x7ffffb094c50 sp 0x7ffffb094c48 READ of size 1 at 0x000003c8f058 thread T0
    f0  PolyCollideObject(object*) $GIT/physics/newstyle_fi.cpp:370
    f1  check_hit_obj(int) $GIT/physics/findintersection.cpp:3483
    f2  fvi_rooms_objs $GIT/physics/findintersection.cpp:4398
    f3  fvi_FindIntersection(fvi_query*, fvi_info*, bool) $GIT/physics/findintersection.cpp:2812
    f4 AquireElectricalTarget(object*) $GIT/Descent3/WeaponFire.cpp:1189
    f5 CreateAndFireWeapon(vector*, vector*, object*, int) $GIT/Descent3/WeaponFire.cpp:1326
    f6 FireWeaponFromObject(object*, int, int, bool, bool) $GIT/Descent3/WeaponFire.cpp:1887
    f7 WBFireBattery(object*, otype_wb_info*, int, int, float) $GIT/Descent3/robotfire.cpp:149
    f8 FireWeaponFromPlayer(object*, int, int, bool, float) $GIT/Descent3/WeaponFire.cpp:3004
    f9 DoFlyingControl(object*) $GIT/Descent3/object.cpp:2450
    f10 ObjDoFrame(object*) $GIT/Descent3/object.cpp:2668
    f11 ObjDoFrameAll() $GIT/Descent3/object.cpp:2988
    f12 GameFrame() $GIT/Descent3/GameLoop.cpp:2980
    f13 GameSequencer() $GIT/Descent3/gamesequence.cpp:1221
    f14 PlayGame() $GIT/Descent3/game.cpp:834
    f15 MainLoop() $GIT/Descent3/descent.cpp:555
    f16 Descent3() $GIT/Descent3/descent.cpp:508
    f17 oeD3LnxApp::run() $GIT/Descent3/sdlmain.cpp:151

0x000003c8f058 is located 52 bytes after global variable 'last_heartbeat' defined in '$GIT/Descent3/multi.cpp:9459:16' (0x3c8f020) of size 4 0x000003c8f058 is located 8 bytes before global variable 'guard variable for MultiSendHeartbeat()::last_heartbeat' defined in '$GIT/Descent3/multi.cpp:9459:16' (0x3c8f060) of size 8
```

## Pull Request Type

- [x] Runtime changes
  - [x] Other changes

### Related Issues

#530

### Checklist

- [ ] I have tested my changes locally and verified that they work as intended.
 >1. clearly we're not doing negative array access anymore
 >2. hard to establish that it addresses the crash during collisions since it happens kinda "randomly" as you play the game
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
