### PR TITLE
Repair non-sensical scorch iterations

### DIFF
--- a/Descent3/scorch.cpp
+++ b/Descent3/scorch.cpp
@@ -151,7 +151,7 @@ void DeleteScorch(int index) {
 
   // Look through all the scorches to see if there are other scorches on the same face
   for (int i = Scorch_start; i >= 0; ) {
-    auto sp = &Scorches[Scorch_start];
+    const auto sp = &Scorches[i];
 
     if ((sp->roomface == roomface) && (i != index)) // Found another scorch
       return;
@@ -161,11 +161,8 @@ void DeleteScorch(int index) {
       break;
 
     // Increment & wrap
-    if (++i == MAX_SCORCHES) {
+    if (++i == MAX_SCORCHES)
       i = 0;
-      sp = Scorches;
-    } else
-      sp++;
   }
 
   // If we're here, there are no other scorches on the face, so clear the flag
@@ -195,7 +192,7 @@ void AddScorch(int roomnum, int facenum, vector *pos, int texture_handle, float 
   // Count the number of scorches on this face, and bail if already at max
   int count = 0;
   for (int i = Scorch_start; i >= 0; ) {
-    auto sp = &Scorches[Scorch_start];
+    const auto sp = &Scorches[i];
     float size = (float)sp->size / 16.0;
 
     // Increment count, and stop drawing if hit limit
@@ -210,11 +207,8 @@ void AddScorch(int roomnum, int facenum, vector *pos, int texture_handle, float 
       break;
 
     // Increment & wrap
-    if (++i == MAX_SCORCHES) {
+    if (++i == MAX_SCORCHES)
       i = 0;
-      sp = Scorches;
-    } else
-      sp++;
   }
 
   // Check for scorch going off the edge of the face, and bail if does
@@ -250,7 +244,7 @@ void AddScorch(int roomnum, int facenum, vector *pos, int texture_handle, float 
     Scorch_start = 0;
 
   // Get a pointer to our struct
-  auto sp = &Scorches[Scorch_end];
+  const auto sp = &Scorches[Scorch_end];
 
   // Fill in the data
   sp->roomface = roomface;
@@ -325,7 +319,7 @@ void DrawScorches(int roomnum, int facenum) {
 
   // Loop through all the scorches, and draw the ones for this face
   for (int i = Scorch_start; i >= 0; ) {
-    auto sp = &Scorches[Scorch_start];
+    const auto sp = &Scorches[i];
 
     if (sp->roomface == roomface) { // Found one!
       vector right, up;
@@ -379,11 +373,8 @@ void DrawScorches(int roomnum, int facenum) {
       break;
 
     // Increment & wrap
-    if (++i == MAX_SCORCHES) {
+    if (++i == MAX_SCORCHES)
       i = 0;
-      sp = Scorches;
-    } else
-      sp++;
   }
 
   // Reset rendering states


### PR DESCRIPTION
## Pull Request Type

- [x] Runtime changes
  - [x] Render changes

### Description

Gazing at my own code/modification, I find it is embarrasingly wrong. Since ``sp`` is re-initialized at every loop iteration, setting it to (the locally-constant) ``Scorch_start`` is incorrect. Make ``sp`` really mirror ``i`` at all times; this way, it also will not be necessary anymore to update ``sp`` within the loop.

Fixes: 20ed30eef804a5a251920cd8484043ef7ea48e78

### Checklist

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
