### PR TITLE
Resolve 2 UBSAN warnings about uninitialized vars; establish allocation/type check along with it

### DIFF
--- a/2dlib/font.cpp
+++ b/2dlib/font.cpp
@@ -416,7 +416,7 @@ void grFont::load(char *filename, int slot) {
   int bytesize = READ_FONT_INT(ff);
 
   ft->raw_data = (uint8_t *)mem_malloc(bytesize);
-  ft->char_data = (uint8_t **)mem_malloc(num_char * sizeof(uint8_t *));
+  ft->char_data = mem_rmalloc<uint8_t *>(num_char);
 
   READ_FONT_DATA(ff, ft->raw_data, bytesize, 1);
 

--- a/2dlib/font.cpp
+++ b/2dlib/font.cpp
@@ -415,7 +415,7 @@ void grFont::load(char *filename, int slot) {
   //		generate character data pointer table
   int bytesize = READ_FONT_INT(ff);
 
-  ft->raw_data = (uint8_t *)mem_malloc(bytesize);
+  ft->raw_data = mem_rmalloc<uint8_t>(bytesize);
   ft->char_data = mem_rmalloc<uint8_t *>(num_char);
 
   READ_FONT_DATA(ff, ft->raw_data, bytesize, 1);

--- a/Descent3/BOA.cpp
+++ b/Descent3/BOA.cpp
@@ -2243,8 +2243,8 @@ void ComputeAABB(bool f_full) {
 
         int n_new;
 
-        nfaces = (int16_t *)mem_malloc(sizeof(int16_t) * rp->num_faces);
-        used = (bool *)mem_malloc(sizeof(bool) * rp->num_faces);
+        nfaces = mem_rmalloc<int16_t>(rp->num_faces);
+        used = mem_rmalloc<bool>(rp->num_faces);
 
         for (count1 = 0; count1 < rp->num_faces; count1++) {
           used[count1] = false;

--- a/Descent3/BOA.cpp
+++ b/Descent3/BOA.cpp
@@ -2410,7 +2410,7 @@ void ComputeAABB(bool f_full) {
 
         // temporary malloc
         rp->num_bbf_regions = 27 + num_structs_per_room[i] - 1;
-        rp->bbf_list = (int16_t **)mem_malloc(MAX_REGIONS_PER_ROOM * sizeof(int16_t *));
+        rp->bbf_list = mem_rmalloc<int16_t *>(MAX_REGIONS_PER_ROOM);
         for (x = 0; x < MAX_REGIONS_PER_ROOM; x++) {
           rp->bbf_list[x] = mem_rmalloc<int16_t>(rp->num_faces);
         }

--- a/Descent3/BOA.cpp
+++ b/Descent3/BOA.cpp
@@ -2147,7 +2147,7 @@ void ComputeAABB(bool f_full) {
         if (BOA_AABB_ROOM_checksum[i] != 0 && BOA_AABB_ROOM_checksum[i] == computed_room_check[i])
           continue;
 
-        r_struct_list[i] = (int16_t *)mem_malloc(Rooms[i].num_faces * sizeof(int16_t));
+        r_struct_list[i] = mem_rmalloc<int16_t>(Rooms[i].num_faces);
       }
     }
 
@@ -2318,8 +2318,8 @@ void ComputeAABB(bool f_full) {
         //
         //			continue;
 
-        vector *s_max_xyz = (vector *)mem_malloc(num_structs_per_room[i] * sizeof(vector));
-        vector *s_min_xyz = (vector *)mem_malloc(num_structs_per_room[i] * sizeof(vector));
+        vector *s_max_xyz = mem_rmalloc<vector>(num_structs_per_room[i]);
+        vector *s_min_xyz = mem_rmalloc<vector>(num_structs_per_room[i]);
 
         for (count = 0; count < num_structs_per_room[i]; count++) {
 
@@ -2412,12 +2412,12 @@ void ComputeAABB(bool f_full) {
         rp->num_bbf_regions = 27 + num_structs_per_room[i] - 1;
         rp->bbf_list = (int16_t **)mem_malloc(MAX_REGIONS_PER_ROOM * sizeof(int16_t *));
         for (x = 0; x < MAX_REGIONS_PER_ROOM; x++) {
-          rp->bbf_list[x] = (int16_t *)mem_malloc(rp->num_faces * sizeof(int16_t));
+          rp->bbf_list[x] = mem_rmalloc<int16_t>(rp->num_faces);
         }
-        rp->num_bbf = (int16_t *)mem_malloc(MAX_REGIONS_PER_ROOM * sizeof(int16_t));
-        rp->bbf_list_min_xyz = (vector *)mem_malloc(MAX_REGIONS_PER_ROOM * sizeof(vector));
-        rp->bbf_list_max_xyz = (vector *)mem_malloc(MAX_REGIONS_PER_ROOM * sizeof(vector));
-        rp->bbf_list_sector = (uint8_t *)mem_malloc(MAX_REGIONS_PER_ROOM * sizeof(uint8_t));
+        rp->num_bbf = mem_rmalloc<int16_t>(MAX_REGIONS_PER_ROOM);
+        rp->bbf_list_min_xyz = mem_rmalloc<vector>(MAX_REGIONS_PER_ROOM);
+        rp->bbf_list_max_xyz = mem_rmalloc<vector>(MAX_REGIONS_PER_ROOM);
+        rp->bbf_list_sector = mem_rmalloc<uint8_t>(MAX_REGIONS_PER_ROOM);
 
         for (x = 0; x < 27; x++) {
           rp->bbf_list_sector[x] = bbf_lookup[x];

--- a/Descent3/Briefing.cpp
+++ b/Descent3/Briefing.cpp
@@ -305,7 +305,7 @@ bool ParseForHotTags(const char *src, char **dest) {
   int curr_size = length;
   int curr_index = 0;
 
-  dest_ptr = *dest = (char *)mem_malloc(length);
+  dest_ptr = *dest = mem_rmalloc<char>(length);
   if (!dest_ptr)
     return false;
   char replacement[256];

--- a/Descent3/ConfigItem.cpp
+++ b/Descent3/ConfigItem.cpp
@@ -668,9 +668,9 @@ void ConfigItem::Add(int count, ...) {
     // we need count radiobuttons
     // we need count IDs
     m_tiCount = count;
-    m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * m_tiCount);
+    m_tiList = mem_rmalloc<UITextItem *>(m_tiCount);
     m_rbCount = count;
-    m_rbList = (UIRadioButton **)mem_malloc(sizeof(UIRadioButton *) * m_rbCount);
+    m_rbList = mem_rmalloc<UIRadioButton *>(m_rbCount);
     m_iNumIDs = count;
     m_iID = mem_rmalloc<int>(m_iNumIDs);
     // make sure mallocs are ok
@@ -721,7 +721,7 @@ void ConfigItem::Add(int count, ...) {
     // we need 1 slider
     // we need 1 ID
     m_sCount = 1;
-    m_sList = (NewUISlider **)mem_malloc(sizeof(NewUISlider *) * 1);
+    m_sList = mem_rmalloc<NewUISlider *>(1);
     m_iNumIDs = 1;
     m_iID = mem_rmalloc<int>(1);
     // make sure mallocs are ok
@@ -761,9 +761,9 @@ void ConfigItem::Add(int count, ...) {
     // we need 1 button
     // we need 1 ID
     m_bCount = 1;
-    m_bList = (NewUIButton **)mem_malloc(sizeof(NewUIButton *) * 1);
+    m_bList = mem_rmalloc<NewUIButton *>(1);
     m_tiCount = 2;
-    m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * 2);
+    m_tiList = mem_rmalloc<UITextItem *>(2);
     m_iNumIDs = 1;
     m_iID = mem_rmalloc<int>(1);
     // make sure mallocs mallocs are ok
@@ -798,9 +798,9 @@ void ConfigItem::Add(int count, ...) {
     // we need 1 listbox
     // we need 1 ID
     m_lbCount = 1;
-    m_lbList = (NewUIListBox **)mem_malloc(sizeof(NewUIListBox *) * 1);
+    m_lbList = mem_rmalloc<NewUIListBox *>(1);
     m_tiCount = count;
-    m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * m_tiCount);
+    m_tiList = mem_rmalloc<UITextItem *>(m_tiCount);
     m_iNumIDs = 1;
     m_iID = mem_rmalloc<int>(1);
     // make sure mallocs ok
@@ -838,9 +838,9 @@ void ConfigItem::Add(int count, ...) {
     // we need 1 button
     // we need 1 ID
     m_bCount = 1;
-    m_bList = (NewUIButton **)mem_malloc(sizeof(NewUIButton *) * 1);
+    m_bList = mem_rmalloc<NewUIButton *>(1);
     m_tiCount = 2;
-    m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * 2);
+    m_tiList = mem_rmalloc<UITextItem *>(2);
     m_iNumIDs = 1;
     m_iID = mem_rmalloc<int>(1);
     // make sure mallocs mallocs are ok
@@ -875,9 +875,9 @@ void ConfigItem::Add(int count, ...) {
     // we need 1 hotspot
     // we need 1 ID
     m_hsCount = 1;
-    m_hsList = (UIHotspot **)mem_malloc(sizeof(UIHotspot *) * 1);
+    m_hsList = mem_rmalloc<UIHotspot *>(1);
     m_tiCount = 4;
-    m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * 4);
+    m_tiList = mem_rmalloc<UITextItem *>(4);
     m_iNumIDs = 1;
     m_iID = mem_rmalloc<int>(1);
     // make sure mallocs are ok
@@ -919,9 +919,9 @@ void ConfigItem::Add(int count, ...) {
     // we need count radio buttons
     // we need count IDs
     m_tiCount = count;
-    m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * m_tiCount);
+    m_tiList = mem_rmalloc<UITextItem *>(m_tiCount);
     m_rbCount = count;
-    m_rbList = (UIRadioButton **)mem_malloc(sizeof(UIRadioButton *) * m_rbCount);
+    m_rbList = mem_rmalloc<UIRadioButton *>(m_rbCount);
     m_iNumIDs = count;
     m_iID = mem_rmalloc<int>(m_iNumIDs);
     // make sure mallocs are ok

--- a/Descent3/ConfigItem.cpp
+++ b/Descent3/ConfigItem.cpp
@@ -672,7 +672,7 @@ void ConfigItem::Add(int count, ...) {
     m_rbCount = count;
     m_rbList = (UIRadioButton **)mem_malloc(sizeof(UIRadioButton *) * m_rbCount);
     m_iNumIDs = count;
-    m_iID = (int *)mem_malloc(sizeof(int) * m_iNumIDs);
+    m_iID = mem_rmalloc<int>(m_iNumIDs);
     // make sure mallocs are ok
     ASSERT((m_tiList) && (m_rbList) && (m_iID));
     // initialize variables
@@ -723,7 +723,7 @@ void ConfigItem::Add(int count, ...) {
     m_sCount = 1;
     m_sList = (NewUISlider **)mem_malloc(sizeof(NewUISlider *) * 1);
     m_iNumIDs = 1;
-    m_iID = (int *)mem_malloc(sizeof(int) * 1);
+    m_iID = mem_rmalloc<int>(1);
     // make sure mallocs are ok
     ASSERT((m_sList) && (m_iID));
     // get unique ID
@@ -765,7 +765,7 @@ void ConfigItem::Add(int count, ...) {
     m_tiCount = 2;
     m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * 2);
     m_iNumIDs = 1;
-    m_iID = (int *)mem_malloc(sizeof(int) * 1);
+    m_iID = mem_rmalloc<int>(1);
     // make sure mallocs mallocs are ok
     ASSERT((m_tiList) && (m_bList) && (m_iID));
     // adjust the curr x/y for the button
@@ -802,7 +802,7 @@ void ConfigItem::Add(int count, ...) {
     m_tiCount = count;
     m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * m_tiCount);
     m_iNumIDs = 1;
-    m_iID = (int *)mem_malloc(sizeof(int) * 1);
+    m_iID = mem_rmalloc<int>(1);
     // make sure mallocs ok
     ASSERT((m_lbList) && (m_tiList) && (m_iID));
     // adjust the curr x/y for the listbox
@@ -842,7 +842,7 @@ void ConfigItem::Add(int count, ...) {
     m_tiCount = 2;
     m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * 2);
     m_iNumIDs = 1;
-    m_iID = (int *)mem_malloc(sizeof(int) * 1);
+    m_iID = mem_rmalloc<int>(1);
     // make sure mallocs mallocs are ok
     ASSERT((m_tiList) && (m_bList) && (m_iID));
     // adjust the curr x/y for the button
@@ -879,7 +879,7 @@ void ConfigItem::Add(int count, ...) {
     m_tiCount = 4;
     m_tiList = (UITextItem **)mem_malloc(sizeof(UITextItem *) * 4);
     m_iNumIDs = 1;
-    m_iID = (int *)mem_malloc(sizeof(int) * 1);
+    m_iID = mem_rmalloc<int>(1);
     // make sure mallocs are ok
     ASSERT((m_hsList) && (m_tiList) && (m_iID));
     // adjust the curr x/y for the checkbox
@@ -923,7 +923,7 @@ void ConfigItem::Add(int count, ...) {
     m_rbCount = count;
     m_rbList = (UIRadioButton **)mem_malloc(sizeof(UIRadioButton *) * m_rbCount);
     m_iNumIDs = count;
-    m_iID = (int *)mem_malloc(sizeof(int) * m_iNumIDs);
+    m_iID = mem_rmalloc<int>(m_iNumIDs);
     // make sure mallocs are ok
     ASSERT((m_tiList) && (m_rbList) && (m_iID));
     // adjust the curr x/y for the list of radio buttons

--- a/Descent3/Inventory.cpp
+++ b/Descent3/Inventory.cpp
@@ -450,7 +450,7 @@ bool Inventory::AddObject(int object_handle, int flags, const char *description)
   if (Object_info[newnode->oid].description) {
     newnode->description = mem_strdup(Object_info[newnode->oid].description);
   } else {
-    newnode->description = (char *)mem_malloc(sizeof(char));
+    newnode->description = mem_rmalloc<char>();
     newnode->description[0] = 0;
   }
 
@@ -650,7 +650,7 @@ bool Inventory::AddObjectItem(int otype, int oid, int oauxt, int oauxi, int flag
       newnode->description = (char *)mem_malloc(strlen(Object_info[oid].description) + 1);
       strcpy(newnode->description, Object_info[oid].description);
     } else {
-      newnode->description = (char *)mem_malloc(sizeof(char));
+      newnode->description = mem_rmalloc<char>();
       newnode->description[0] = 0;
     }
 

--- a/Descent3/Inventory.cpp
+++ b/Descent3/Inventory.cpp
@@ -581,7 +581,7 @@ bool Inventory::AddCounterMeasure(int id, int aux_type, int aux_id, int flags, c
 
     if (Weapons[id].icon_handle >= 0) {
       newnode->icon_name =
-          (char *)mem_malloc(strlen(GameBitmaps[GameTextures[Weapons[id].icon_handle].bm_handle].name) + 1);
+          mem_rmalloc<char>(strlen(GameBitmaps[GameTextures[Weapons[id].icon_handle].bm_handle].name) + 1);
       strcpy(newnode->icon_name, GameBitmaps[GameTextures[Weapons[id].icon_handle].bm_handle].name);
     } else {
       newnode->icon_name = nullptr;
@@ -647,7 +647,7 @@ bool Inventory::AddObjectItem(int otype, int oid, int oauxt, int oauxi, int flag
     newnode->oid = oauxi;
 
     if (Object_info[oid].description) {
-      newnode->description = (char *)mem_malloc(strlen(Object_info[oid].description) + 1);
+      newnode->description = mem_rmalloc<char>(strlen(Object_info[oid].description) + 1);
       strcpy(newnode->description, Object_info[oid].description);
     } else {
       newnode->description = mem_rmalloc<char>();
@@ -672,7 +672,7 @@ bool Inventory::AddObjectItem(int otype, int oid, int oauxt, int oauxi, int flag
     if (flags & INVAF_LEVELLAST)
       newnode->iflags |= INVAF_LEVELLAST;
 
-    newnode->icon_name = (char *)mem_malloc(strlen(Object_info[oid].icon_name) + 1);
+    newnode->icon_name = mem_rmalloc<char>(strlen(Object_info[oid].icon_name) + 1);
     strcpy(newnode->icon_name, Object_info[oid].icon_name);
 
     if (description) {

--- a/Descent3/LoadLevel.cpp
+++ b/Descent3/LoadLevel.cpp
@@ -3135,7 +3135,7 @@ void ReadRoomAABBChunk(CFILE *fp, int version) {
 
       Rooms[i].num_bbf_regions = cf_ReadShort(fp);
       Rooms[i].num_bbf = mem_rmalloc<int16_t>(Rooms[i].num_bbf_regions);
-      Rooms[i].bbf_list = (int16_t **)mem_malloc(sizeof(int16_t *) * Rooms[i].num_bbf_regions);
+      Rooms[i].bbf_list = mem_rmalloc<int16_t *>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list_min_xyz = mem_rmalloc<vector>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list_max_xyz = mem_rmalloc<vector>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list_sector = (uint8_t *)mem_malloc(sizeof(char) * Rooms[i].num_bbf_regions);

--- a/Descent3/LoadLevel.cpp
+++ b/Descent3/LoadLevel.cpp
@@ -1686,7 +1686,7 @@ int ReadObject(CFILE *ifile, object *objp, int handle, int fileversion) {
 
   // Set the name
   if (tempname[0]) {
-    objp->name = (char *)mem_malloc(strlen(tempname) + 1);
+    objp->name = mem_rmalloc<char>(strlen(tempname) + 1);
     strcpy(objp->name, tempname);
   }
 
@@ -2446,7 +2446,7 @@ int ReadRoom(CFILE *ifile, room *rp, int version) {
     char tempname[ROOM_NAME_LEN + 1];
     cf_ReadString(tempname, sizeof(tempname), ifile);
     if (strlen(tempname)) {
-      rp->name = (char *)mem_malloc(strlen(tempname) + 1);
+      rp->name = mem_rmalloc<char>(strlen(tempname) + 1);
       strcpy(rp->name, tempname);
     }
   }

--- a/Descent3/LoadLevel.cpp
+++ b/Descent3/LoadLevel.cpp
@@ -2661,7 +2661,7 @@ void ReadNewLightmapChunk(CFILE *fp, int version) {
     return;
   }
 
-  uint16_t *lightmap_remap = (uint16_t *)mem_malloc(MAX_LIGHTMAPS * sizeof(uint16_t));
+  uint16_t *lightmap_remap = mem_rmalloc<uint16_t>(MAX_LIGHTMAPS);
 
   nummaps = cf_ReadInt(fp);
 
@@ -2897,7 +2897,7 @@ void ReadGamePathsChunk(CFILE *fp, int version) {
   for (i = 0; i < Num_game_paths; i++) {
     GamePaths[i].used = 1;
     GamePaths[i].name[0] = 0;
-    GamePaths[i].pathnodes = (node *)mem_malloc(MAX_NODES_PER_PATH * sizeof(node));
+    GamePaths[i].pathnodes = mem_rmalloc<node>(MAX_NODES_PER_PATH);
     GamePaths[i].flags = 0;
 
     // Read in the path's info
@@ -4884,7 +4884,7 @@ void WriteLightmapChunk(CFILE *fp) {
   int lightmap_info_count = 0;
   int lightmap_count = 0;
 
-  uint16_t *lightmap_remap = (uint16_t *)mem_malloc(MAX_LIGHTMAPS * sizeof(uint16_t));
+  uint16_t *lightmap_remap = mem_rmalloc<uint16_t>(MAX_LIGHTMAPS);
   uint8_t *lightmap_spoken_for = (uint8_t *)mem_malloc(MAX_LIGHTMAPS);
 
   ASSERT(lightmap_remap);

--- a/Descent3/LoadLevel.cpp
+++ b/Descent3/LoadLevel.cpp
@@ -2568,7 +2568,7 @@ int ReadRoom(CFILE *ifile, room *rp, int version) {
 
       if (size) {
 
-        rp->volume_lights = (uint8_t *)mem_malloc(size);
+        rp->volume_lights = mem_rmalloc<uint8_t>(size);
         ASSERT(rp->volume_lights); // ran out of memory!
       } else
         rp->volume_lights = NULL;
@@ -3138,7 +3138,7 @@ void ReadRoomAABBChunk(CFILE *fp, int version) {
       Rooms[i].bbf_list = mem_rmalloc<int16_t *>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list_min_xyz = mem_rmalloc<vector>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list_max_xyz = mem_rmalloc<vector>(Rooms[i].num_bbf_regions);
-      Rooms[i].bbf_list_sector = (uint8_t *)mem_malloc(sizeof(char) * Rooms[i].num_bbf_regions);
+      Rooms[i].bbf_list_sector = mem_rmalloc<uint8_t>(sizeof(char) * Rooms[i].num_bbf_regions);
 
       for (j = 0; j < Rooms[i].num_bbf_regions; j++) {
         Rooms[i].num_bbf[j] = cf_ReadShort(fp);
@@ -4079,8 +4079,8 @@ int LoadLevel(char *filename, void (*cb_fn)(const char *, int, int)) {
   // share 1 lightmap
 
   if (version >= 34 && !Dedicated_server) {
-    uint8_t *lightmap_spoken_for = (uint8_t *)mem_malloc(MAX_LIGHTMAPS);
-    uint8_t *free_lightmap_info = (uint8_t *)mem_malloc(MAX_LIGHTMAP_INFOS);
+    uint8_t *lightmap_spoken_for = mem_rmalloc<uint8_t>(MAX_LIGHTMAPS);
+    uint8_t *free_lightmap_info = mem_rmalloc<uint8_t>(MAX_LIGHTMAP_INFOS);
     ASSERT(lightmap_spoken_for);
     memset(lightmap_spoken_for, 0, MAX_LIGHTMAPS);
 
@@ -4885,7 +4885,7 @@ void WriteLightmapChunk(CFILE *fp) {
   int lightmap_count = 0;
 
   uint16_t *lightmap_remap = mem_rmalloc<uint16_t>(MAX_LIGHTMAPS);
-  uint8_t *lightmap_spoken_for = (uint8_t *)mem_malloc(MAX_LIGHTMAPS);
+  uint8_t *lightmap_spoken_for = mem_rmalloc<uint8_t>(MAX_LIGHTMAPS);
 
   ASSERT(lightmap_remap);
   ASSERT(lightmap_spoken_for);

--- a/Descent3/LoadLevel.cpp
+++ b/Descent3/LoadLevel.cpp
@@ -2978,7 +2978,7 @@ void ReadBNodeChunk(CFILE *fp, int version) {
       ASSERT(!(i <= Highest_room_index && (Rooms[i].flags & RF_EXTERNAL) && bnlist->num_nodes > 0));
 
       if (bnlist->num_nodes) {
-        bnlist->nodes = (bn_node *)mem_malloc(sizeof(bn_node) * bnlist->num_nodes);
+        bnlist->nodes = mem_rmalloc<bn_node>(bnlist->num_nodes);
         for (j = 0; j < bnlist->num_nodes; j++) {
           bnlist->nodes[j].pos.x = cf_ReadFloat(fp);
           bnlist->nodes[j].pos.y = cf_ReadFloat(fp);
@@ -2986,7 +2986,7 @@ void ReadBNodeChunk(CFILE *fp, int version) {
 
           bnlist->nodes[j].num_edges = cf_ReadShort(fp);
           if (bnlist->nodes[j].num_edges) {
-            bnlist->nodes[j].edges = (bn_edge *)mem_malloc(sizeof(bn_edge) * bnlist->nodes[j].num_edges);
+            bnlist->nodes[j].edges = mem_rmalloc<bn_edge>(bnlist->nodes[j].num_edges);
             for (k = 0; k < bnlist->nodes[j].num_edges; k++) {
               bnlist->nodes[j].edges[k].end_room = cf_ReadShort(fp);
               bnlist->nodes[j].edges[k].end_index = cf_ReadByte(fp);
@@ -3134,15 +3134,15 @@ void ReadRoomAABBChunk(CFILE *fp, int version) {
       Rooms[i].bbf_max_xyz.z = cf_ReadFloat(fp);
 
       Rooms[i].num_bbf_regions = cf_ReadShort(fp);
-      Rooms[i].num_bbf = (int16_t *)mem_malloc(sizeof(int16_t) * Rooms[i].num_bbf_regions);
+      Rooms[i].num_bbf = mem_rmalloc<int16_t>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list = (int16_t **)mem_malloc(sizeof(int16_t *) * Rooms[i].num_bbf_regions);
-      Rooms[i].bbf_list_min_xyz = (vector *)mem_malloc(sizeof(vector) * Rooms[i].num_bbf_regions);
-      Rooms[i].bbf_list_max_xyz = (vector *)mem_malloc(sizeof(vector) * Rooms[i].num_bbf_regions);
+      Rooms[i].bbf_list_min_xyz = mem_rmalloc<vector>(Rooms[i].num_bbf_regions);
+      Rooms[i].bbf_list_max_xyz = mem_rmalloc<vector>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list_sector = (uint8_t *)mem_malloc(sizeof(char) * Rooms[i].num_bbf_regions);
 
       for (j = 0; j < Rooms[i].num_bbf_regions; j++) {
         Rooms[i].num_bbf[j] = cf_ReadShort(fp);
-        Rooms[i].bbf_list[j] = (int16_t *)mem_malloc(sizeof(int16_t) * Rooms[i].num_bbf[j]);
+        Rooms[i].bbf_list[j] = mem_rmalloc<int16_t>(Rooms[i].num_bbf[j]);
       }
 
       for (j = 0; j < Rooms[i].num_bbf_regions; j++) {

--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -2000,7 +2000,7 @@ void QuickStartMission() {
   //	this initializes a mini one level mission with no frills.
   Current_mission.cur_level = 1;
   Current_mission.num_levels = 1;
-  Current_mission.levels = (tLevelNode *)mem_malloc(sizeof(tLevelNode));
+  Current_mission.levels = mem_rmalloc<tLevelNode>();
   memset(Current_mission.levels, 0, sizeof(tLevelNode));
   Current_level = Current_mission.levels;
   if (Editor_quickplay_levelname[0] != '\0')

--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -773,7 +773,7 @@ void ResetMission() {
 #if (defined(OEM) || defined(DEMO))
 bool DemoMission(int mode = 0) {
   tMission *msn = &Current_mission;
-  tLevelNode *lvls = (tLevelNode *)mem_malloc(sizeof(tLevelNode) * 5);
+  tLevelNode *lvls = mem_rmalloc<tLevelNode>(5);
   msn->cur_level = 1;
   msn->num_levels = 1;
   msn->levels = lvls;
@@ -1071,7 +1071,7 @@ bool LoadMission(const char *mssn) {
             strcpy(errtext, TXT_MSN_LVLNUMINVALID);
             goto msnfile_error;
           }
-          lvls = (tLevelNode *)mem_malloc(sizeof(tLevelNode) * value);
+          lvls = mem_rmalloc<tLevelNode>(value);
           memset(lvls, 0, sizeof(tLevelNode) * value);
           numlevels = value;
         }

--- a/Descent3/ObjInit.cpp
+++ b/Descent3/ObjInit.cpp
@@ -624,7 +624,7 @@ void ObjCreateEffectInfo(object *objp) {
   if (objp->effect_info)
     mem_free(objp->effect_info);
 
-  objp->effect_info = (effect_info_s *)mem_malloc(sizeof(effect_info_s));
+  objp->effect_info = mem_rmalloc<effect_info_s>();
   memset(objp->effect_info, 0, sizeof(effect_info_s));
   ASSERT(objp->effect_info);
   objp->effect_info->sound_handle = SOUND_NONE_INDEX;

--- a/Descent3/ObjInit.cpp
+++ b/Descent3/ObjInit.cpp
@@ -652,7 +652,7 @@ void ObjSetRenderPolyobj(object *objp, int model_num, int dying_model_num) {
       objp->attach_children = NULL;
     }
     if ((objp->attach_children == NULL) && pm->n_attach) {
-      objp->attach_children = (int *)mem_malloc(sizeof(int) * pm->n_attach);
+      objp->attach_children = mem_rmalloc<int>(pm->n_attach);
       if (objp->type == OBJ_PLAYER)
         ASSERT(pm->n_attach >= NUM_PLAYER_ATTACH_POINTS);
       for (int i = 0; i < pm->n_attach; i++)
@@ -710,7 +710,7 @@ int ObjInitPlayer(object *objp) {
   // These are always set for a player
   objp->mtype.phys_info.num_bounces = PHYSICS_UNLIMITED_BOUNCE;
   if (objp->dynamic_wb == NULL) {
-    objp->dynamic_wb = (dynamic_wb_info *)mem_malloc(sizeof(dynamic_wb_info) * MAX_WBS_PER_OBJ);
+    objp->dynamic_wb = mem_rmalloc<dynamic_wb_info>(MAX_WBS_PER_OBJ);
   }
   WBClearInfo(objp);
   // Set a few misc things
@@ -820,7 +820,7 @@ int ObjInitGeneric(object *objp, bool reinit) {
       objp->dynamic_wb = NULL;
     }
     if ((objp->dynamic_wb == NULL) && num_wbs) {
-      objp->dynamic_wb = (dynamic_wb_info *)mem_malloc(sizeof(dynamic_wb_info) * num_wbs);
+      objp->dynamic_wb = mem_rmalloc<dynamic_wb_info>(num_wbs);
     }
     // Setup the weapon batteries (must be after polymodel stuff)
     WBClearInfo(objp);

--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -1500,7 +1500,7 @@ bool Osiris_BindScriptsToObject(object *obj) {
       LOG_ERROR.printf("OSIRIS: Unable to load module (%s) to bind to object (%s)", default_module_name, page_name);
     } else {
       // allocate the memory for the object's scripts
-      obj->osiris_script = (tOSIRISScript *)mem_malloc(sizeof(tOSIRISScript));
+      obj->osiris_script = mem_rmalloc<tOSIRISScript>();
       if (!obj->osiris_script) {
         // out of memory
         LOG_ERROR << "OSIRIS: Out of memory trying to bind script";
@@ -1543,12 +1543,12 @@ bool Osiris_BindScriptsToObject(object *obj) {
 #ifdef OSIRISDEBUG
           tRefObj *node;
           if (OSIRIS_loaded_modules[dll_id].RefRoot == NULL) {
-            node = OSIRIS_loaded_modules[dll_id].RefRoot = (tRefObj *)mem_malloc(sizeof(tRefObj));
+            node = OSIRIS_loaded_modules[dll_id].RefRoot = mem_rmalloc<tRefObj>();
           } else {
             node = OSIRIS_loaded_modules[dll_id].RefRoot;
             while (node->next)
               node = node->next;
-            node->next = (tRefObj *)mem_malloc(sizeof(tRefObj));
+            node->next = mem_rmalloc<tRefObj>();
             node = node->next;
           }
           node->objnum = OBJNUM(obj);
@@ -1578,7 +1578,7 @@ bool Osiris_BindScriptsToObject(object *obj) {
         if (gos_id != -1) {
           if (!obj->osiris_script) {
             // we need to allocate memory for a script
-            obj->osiris_script = (tOSIRISScript *)mem_malloc(sizeof(tOSIRISScript));
+            obj->osiris_script = mem_rmalloc<tOSIRISScript>();
             if (!obj->osiris_script) {
               // out of memory
               LOG_ERROR << "OSIRIS: Out of memory trying to bind script";
@@ -1607,12 +1607,12 @@ bool Osiris_BindScriptsToObject(object *obj) {
 #ifdef OSIRISDEBUG
             tRefObj *node;
             if (OSIRIS_loaded_modules[dll_id].RefRoot == NULL) {
-              node = OSIRIS_loaded_modules[dll_id].RefRoot = (tRefObj *)mem_malloc(sizeof(tRefObj));
+              node = OSIRIS_loaded_modules[dll_id].RefRoot = mem_rmalloc<tRefObj>();
             } else {
               node = OSIRIS_loaded_modules[dll_id].RefRoot;
               while (node->next)
                 node = node->next;
-              node->next = (tRefObj *)mem_malloc(sizeof(tRefObj));
+              node->next = mem_rmalloc<tRefObj>();
               node = node->next;
             }
             node->objnum = OBJNUM(obj);
@@ -1635,7 +1635,7 @@ bool Osiris_BindScriptsToObject(object *obj) {
 
             if (!obj->osiris_script) {
               // we need to allocate memory for a script
-              obj->osiris_script = (tOSIRISScript *)mem_malloc(sizeof(tOSIRISScript));
+              obj->osiris_script = mem_rmalloc<tOSIRISScript>();
               if (!obj->osiris_script) {
                 // out of memory
                 LOG_ERROR << "OSIRIS: Out of memory trying to bind script";
@@ -1664,12 +1664,12 @@ bool Osiris_BindScriptsToObject(object *obj) {
 #ifdef OSIRISDEBUG
               tRefObj *node;
               if (OSIRIS_loaded_modules[dll_id].RefRoot == NULL) {
-                node = OSIRIS_loaded_modules[dll_id].RefRoot = (tRefObj *)mem_malloc(sizeof(tRefObj));
+                node = OSIRIS_loaded_modules[dll_id].RefRoot = mem_rmalloc<tRefObj>();
               } else {
                 node = OSIRIS_loaded_modules[dll_id].RefRoot;
                 while (node->next)
                   node = node->next;
-                node->next = (tRefObj *)mem_malloc(sizeof(tRefObj));
+                node->next = mem_rmalloc<tRefObj>();
                 node = node->next;
               }
               node->objnum = OBJNUM(obj);
@@ -1705,7 +1705,7 @@ bool Osiris_BindScriptsToObject(object *obj) {
         if (gos_id != -1) {
           if (!obj->osiris_script) {
             // we need to allocate memory for a script
-            obj->osiris_script = (tOSIRISScript *)mem_malloc(sizeof(tOSIRISScript));
+            obj->osiris_script = mem_rmalloc<tOSIRISScript>();
             if (!obj->osiris_script) {
               // out of memory
               LOG_ERROR << "OSIRIS: Out of memory trying to bind script";
@@ -1734,12 +1734,12 @@ bool Osiris_BindScriptsToObject(object *obj) {
 #ifdef OSIRISDEBUG
             tRefObj *node;
             if (OSIRIS_loaded_modules[dll_id].RefRoot == NULL) {
-              node = OSIRIS_loaded_modules[dll_id].RefRoot = (tRefObj *)mem_malloc(sizeof(tRefObj));
+              node = OSIRIS_loaded_modules[dll_id].RefRoot = mem_rmalloc<tRefObj>();
             } else {
               node = OSIRIS_loaded_modules[dll_id].RefRoot;
               while (node->next)
                 node = node->next;
-              node->next = (tRefObj *)mem_malloc(sizeof(tRefObj));
+              node->next = mem_rmalloc<tRefObj>();
               node = node->next;
             }
             node->objnum = OBJNUM(obj);
@@ -2856,7 +2856,7 @@ void *Osiris_AllocateMemory(tOSIRISMEMCHUNK *mc) {
 
   if (!Osiris_mem_root) {
     // it'll be the first node
-    Osiris_mem_root = (tOSIRISMEMNODE *)mem_malloc(sizeof(tOSIRISMEMNODE));
+    Osiris_mem_root = mem_rmalloc<tOSIRISMEMNODE>();
     if (!Osiris_mem_root)
       return NULL;
 
@@ -2869,7 +2869,7 @@ void *Osiris_AllocateMemory(tOSIRISMEMCHUNK *mc) {
       curr = curr->next;
     }
 
-    curr->next = (tOSIRISMEMNODE *)mem_malloc(sizeof(tOSIRISMEMNODE));
+    curr->next = mem_rmalloc<tOSIRISMEMNODE>();
     if (!curr->next)
       return NULL;
     error_node = &curr->next;
@@ -3042,7 +3042,7 @@ void Osiris_RestoreMemoryChunks(CFILE *file) {
       done = true;
     } else {
       // handle this node
-      memchunk = (tOSIRISMEMNODE *)mem_malloc(sizeof(tOSIRISMEMNODE));
+      memchunk = mem_rmalloc<tOSIRISMEMNODE>();
       if (!memchunk) {
         Error("Out of memory");
       }
@@ -3481,9 +3481,9 @@ void Osiris_RestoreOMMS(CFILE *file) {
   // we have to rebuild the nodes
   while (cf_ReadByte(file)) {
     if (!currhash) {
-      currhash = OMMS_Hash_node_root = (tOMMSHashNode *)mem_malloc(sizeof(tOMMSHashNode));
+      currhash = OMMS_Hash_node_root = mem_rmalloc<tOMMSHashNode>();
     } else {
-      currhash->next = (tOMMSHashNode *)mem_malloc(sizeof(tOMMSHashNode));
+      currhash->next = mem_rmalloc<tOMMSHashNode>();
       currhash = currhash->next;
     }
 
@@ -3511,9 +3511,9 @@ void Osiris_RestoreOMMS(CFILE *file) {
     // now go through all the nodes and right their data
     while (cf_ReadByte(file)) {
       if (!node) {
-        node = currhash->root = (tOMMSNode *)mem_malloc(sizeof(tOMMSNode));
+        node = currhash->root = mem_rmalloc<tOMMSNode>();
       } else {
-        node->next = (tOMMSNode *)mem_malloc(sizeof(tOMMSNode));
+        node->next = mem_rmalloc<tOMMSNode>();
         node = node->next;
       }
 
@@ -3550,7 +3550,7 @@ tOMMSHashNode *Osiris_OMMS_FindHashNode(char *script_name, bool autocreate) {
     if (!autocreate)
       return NULL;
 
-    curr = OMMS_Hash_node_root = (tOMMSHashNode *)mem_malloc(sizeof(tOMMSHashNode));
+    curr = OMMS_Hash_node_root = mem_rmalloc<tOMMSHashNode>();
   } else {
     if (curr->script_name && !stricmp(curr->script_name, script_name)) {
       // the root node matches
@@ -3571,7 +3571,7 @@ tOMMSHashNode *Osiris_OMMS_FindHashNode(char *script_name, bool autocreate) {
     if (!autocreate)
       return NULL;
 
-    curr->next = (tOMMSHashNode *)mem_malloc(sizeof(tOMMSHashNode));
+    curr->next = mem_rmalloc<tOMMSHashNode>();
     curr = curr->next;
   }
 
@@ -3619,7 +3619,7 @@ tOMMSNode *Osiris_OMMS_FindNode(tOMMSHashNode *root, uint32_t uid, bool autocrea
     if (!autocreate)
       return NULL;
 
-    curr = root->root = (tOMMSNode *)mem_malloc(sizeof(tOMMSNode));
+    curr = root->root = mem_rmalloc<tOMMSNode>();
   } else {
     if (curr->unique_id == uid) {
       // the root node matches
@@ -3640,7 +3640,7 @@ tOMMSNode *Osiris_OMMS_FindNode(tOMMSHashNode *root, uint32_t uid, bool autocrea
     if (!autocreate)
       return NULL;
 
-    curr->next = (tOMMSNode *)mem_malloc(sizeof(tOMMSNode));
+    curr->next = mem_rmalloc<tOMMSNode>();
     curr = curr->next;
   }
 

--- a/Descent3/PilotPicsAPI.cpp
+++ b/Descent3/PilotPicsAPI.cpp
@@ -516,8 +516,8 @@ bool PPic_BuildDatabases(void) {
 
   // allocate all the memory we're going to need
   // -------------------------------------------
-  Pilot_id_to_offset = (tPilotPicIdOffset *)mem_malloc(sizeof(tPilotPicIdOffset) * PilotPic_count);
-  Sorted_Pilot_id_to_offset = (uint16_t *)mem_malloc(sizeof(uint16_t) * PilotPic_count);
+  Pilot_id_to_offset = mem_rmalloc<tPilotPicIdOffset>(PilotPic_count);
+  Sorted_Pilot_id_to_offset = mem_rmalloc<uint16_t>(PilotPic_count);
   if (!Pilot_id_to_offset) {
     // out of memory!!!
     LOG_FATAL << "PPIC: Out of memory allocating index database";

--- a/Descent3/TelCom.cpp
+++ b/Descent3/TelCom.cpp
@@ -831,7 +831,7 @@ bool TelComShow(bool ingame, bool ShipSelect) {
   if (hotspotmap.num_of_hotspots) {
     int TelCom_onbmp = bm_AllocLoadFileBitmap(IGNORE_TABLE(TELCOM_DISPLAY_OGF_ON), 0);
     if (TelCom_onbmp != -1) {
-      hotspot_bitmaps = (chunked_bitmap *)mem_malloc(sizeof(chunked_bitmap) * hotspotmap.num_of_hotspots);
+      hotspot_bitmaps = mem_rmalloc<chunked_bitmap>(hotspotmap.num_of_hotspots);
       ASSERT(hotspot_bitmaps);
       CompressTelComOnImage(TelCom_onbmp, hotspot_bitmaps);
       bm_FreeBitmap(TelCom_onbmp);
@@ -1970,7 +1970,7 @@ void TelcomLoadHiLites(const char *filelist[], int monitor, int xoff, int yoff) 
   if (!TelcomHiLiteCount[monitor])
     TelcomHiLites[monitor] = NULL;
 
-  TelcomHiLites[monitor] = (int *)mem_malloc(sizeof(int) * TelcomHiLiteCount[monitor]);
+  TelcomHiLites[monitor] = mem_rmalloc<int>(TelcomHiLiteCount[monitor]);
   if (!TelcomHiLites[monitor]) {
     LOG_DEBUG.printf("Unable to allocate memory for hilights monitor=%d", monitor);
     TelcomHiLiteCount[monitor] = 0;

--- a/Descent3/TelCom.cpp
+++ b/Descent3/TelCom.cpp
@@ -4060,12 +4060,12 @@ void TelCom_AddCustomKeyEvent(int key_id, int event_id) {
   tCustomKeyEventID *curr = Telcom_custom_key_event_root;
 
   if (!curr) {
-    curr = Telcom_custom_key_event_root = (tCustomKeyEventID *)mem_malloc(sizeof(tCustomKeyEventID));
+    curr = Telcom_custom_key_event_root = mem_rmalloc<tCustomKeyEventID>();
   } else {
     while (curr->next) {
       curr = curr->next;
     }
-    curr->next = (tCustomKeyEventID *)mem_malloc(sizeof(tCustomKeyEventID));
+    curr->next = mem_rmalloc<tCustomKeyEventID>();
     curr = curr->next;
   }
 

--- a/Descent3/TelComAutoMap.cpp
+++ b/Descent3/TelComAutoMap.cpp
@@ -207,7 +207,7 @@ void ClassifyAMFaces() {
   int i = 0;
   for (i = 0; i <= Highest_room_index; i++) {
     if (Rooms[i].used) {
-      Small_faces[i] = (uint8_t *)mem_malloc(Rooms[i].num_faces);
+      Small_faces[i] = mem_rmalloc<uint8_t>(Rooms[i].num_faces);
       ASSERT(Small_faces[i]);
 
       memset(Small_faces[i], 0, Rooms[i].num_faces);

--- a/Descent3/TelComAutoMap.cpp
+++ b/Descent3/TelComAutoMap.cpp
@@ -269,7 +269,7 @@ bool TelComAutoMap(tTelComInfo *tcs) {
   bool done = false;
 
   if (!AM_rotated_points) {
-    AM_rotated_points = (g3Point *)mem_malloc(sizeof(g3Point) * MAX_VERTS_PER_ROOM);
+    AM_rotated_points = mem_rmalloc<g3Point>(MAX_VERTS_PER_ROOM);
   }
   AM_tcs = tcs;
   AM_current_marker = -1;

--- a/Descent3/TelComEffects.cpp
+++ b/Descent3/TelComEffects.cpp
@@ -1030,13 +1030,13 @@ bool CreateTextStatic(tceffect *tce, const char *text) {
   if (!text)
     return false;
 
-  tce->text_buffer = (char *)mem_malloc(strlen(text) + 10);
+  tce->text_buffer = mem_rmalloc<char>(strlen(text) + 10);
   if (!tce->text_buffer)
     return false;
 
   tce->alpha = 255;
 
-  char *tempbuffer = (char *)mem_malloc(strlen(text) + 10);
+  char *tempbuffer = mem_rmalloc<char>(strlen(text) + 10);
   if (!tempbuffer)
     return false;
   strcpy(tempbuffer, text);
@@ -1053,11 +1053,11 @@ bool CreateTextFade(tceffect *tce, const char *text) {
   ASSERT(text);
   if (!text || text[0] == '\0')
     return false;
-  tce->text_buffer = (char *)mem_malloc(strlen(text) + 10);
+  tce->text_buffer = mem_rmalloc<char>(strlen(text) + 10);
   if (!tce->text_buffer)
     return false;
 
-  char *tempbuffer = (char *)mem_malloc(strlen(text) + 10);
+  char *tempbuffer = mem_rmalloc<char>(strlen(text) + 10);
   if (!tempbuffer)
     return false;
   strcpy(tempbuffer, text);
@@ -1084,11 +1084,11 @@ bool CreateTextType(tceffect *tce, const char *text) {
   ASSERT(text);
   if (!text || text[0] == '\0')
     return false;
-  tce->text_buffer = (char *)mem_malloc(strlen(text) + 10);
+  tce->text_buffer = mem_rmalloc<char>(strlen(text) + 10);
   if (!tce->text_buffer)
     return false;
 
-  char *tempbuffer = (char *)mem_malloc(strlen(text) + 10);
+  char *tempbuffer = mem_rmalloc<char>(strlen(text) + 10);
   if (!tempbuffer)
     return false;
   strcpy(tempbuffer, text);
@@ -1252,7 +1252,7 @@ bool CreateMovie(tceffect *tce, const char *filename) {
   tce->movieinfo.filename = NULL;
   tce->w = tce->h = 100;
 
-  tce->movieinfo.filename = (char *)mem_malloc(strlen(filename) + 1);
+  tce->movieinfo.filename = mem_rmalloc<char>(strlen(filename) + 1);
   if (!tce->movieinfo.filename)
     return false;
   strcpy(tce->movieinfo.filename, filename);

--- a/Descent3/TelComEffects.cpp
+++ b/Descent3/TelComEffects.cpp
@@ -1202,7 +1202,7 @@ bool CreateBmpStretch(tceffect *tce, const char *filename) {
     int total = w_count * h_count;
     int index;
     tce->bmpinfo.bm_count = total;
-    tce->bmpinfo.bitmaps = (int *)mem_malloc(sizeof(int) * total);
+    tce->bmpinfo.bitmaps = mem_rmalloc<int>(total);
     if (!tce->bmpinfo.bitmaps)
       return false;
 

--- a/Descent3/TelComGoals.cpp
+++ b/Descent3/TelComGoals.cpp
@@ -188,9 +188,9 @@ void TCGoalsBuildLineData(void) {
   //'count' goals are what we have to display
   // allocate memory needed and start filling in
   if (count) {
-    TG_Lines = (tGoalLineInfo *)mem_malloc(sizeof(tGoalLineInfo) * count);
+    TG_Lines = mem_rmalloc<tGoalLineInfo>(count);
     TG_NumLines = count;
-    TG_SortedList = (int *)mem_malloc(sizeof(int) * count);
+    TG_SortedList = mem_rmalloc<int>(count);
     if (!TG_SortedList || !TG_Lines) {
       // out of memory
       Telcom_system.current_status = TS_OFF;

--- a/Descent3/ambient.cpp
+++ b/Descent3/ambient.cpp
@@ -256,7 +256,7 @@ void ReadAmbientData() {
     asp->num_sounds = cf_ReadInt(ifile);
 
     if (asp->num_sounds > 0)
-      asp->sounds = (ase *)mem_malloc(sizeof(*asp->sounds) * asp->num_sounds);
+      asp->sounds = mem_rmalloc<ase>(asp->num_sounds);
     else
       asp->sounds = NULL;
 

--- a/Descent3/audiotaunts.cpp
+++ b/Descent3/audiotaunts.cpp
@@ -368,7 +368,7 @@ bool taunt_ImportWave(const char *wave_filename, const char *outputfilename) {
   uint32_t filelen, nblocks, i;
   int format;
 
-  StaticFileBuffer = (uint8_t *)mem_malloc(FILEBUFFER_LENGTH);
+  StaticFileBuffer = mem_rmalloc<uint8_t>(FILEBUFFER_LENGTH);
   if (!StaticFileBuffer) {
     ret = false;
     LOG_ERROR << "Out of memory";
@@ -710,7 +710,7 @@ char taunt_LoadWaveFile(const char *filename, tWaveFile *wave) {
 
         wave->sample_length = aligned_size;
         wave->np_sample_length = cksize;
-        wave->sample_8bit = (uint8_t *)mem_malloc(aligned_size);
+        wave->sample_8bit = mem_rmalloc<uint8_t>(aligned_size);
 
         cf_ReadBytes((uint8_t *)wave->sample_8bit, cksize, cfptr);
 

--- a/Descent3/audiotaunts.cpp
+++ b/Descent3/audiotaunts.cpp
@@ -756,7 +756,7 @@ char taunt_LoadWaveFile(const char *filename, tWaveFile *wave) {
   if (wave->sample_16bit == NULL) {
     ASSERT(wave->sample_8bit);
 
-    wave->sample_16bit = (int16_t *)mem_malloc(wave->sample_length * sizeof(int16_t));
+    wave->sample_16bit = mem_rmalloc<int16_t>(wave->sample_length);
 
     // NOTE:  Interesting note on sound conversion:  16 bit sounds are signed (0 biase).  8 bit sounds are unsigned
     // (+128 biase).

--- a/Descent3/bnode.cpp
+++ b/Descent3/bnode.cpp
@@ -226,7 +226,7 @@ bool BNode_FindPath(int start_room, int i, int j, float rad) {
   ASSERT(bnlist);
   ASSERT(i >= 0 && i < bnlist->num_nodes && j >= 0 && j < bnlist->num_nodes);
 
-  node_list = (pq_item **)mem_malloc(bnlist->num_nodes * sizeof(pq_item *));
+  node_list = mem_rmalloc<pq_item *>(bnlist->num_nodes);
   memset(node_list, 0, bnlist->num_nodes * sizeof(pq_item *));
 
   PQPath.push(start_node);

--- a/Descent3/bsp.cpp
+++ b/Descent3/bsp.cpp
@@ -171,7 +171,7 @@ bsppolygon *NewPolygon(int roomnum, int facenum, int numverts) {
     return NULL;
   }
 
-  verts = (vector *)mem_malloc(sizeof(vector) * numverts);
+  verts = mem_rmalloc<vector>(numverts);
   ASSERT(verts != NULL);
 
   newpoly->nv = numverts;

--- a/Descent3/bsp.cpp
+++ b/Descent3/bsp.cpp
@@ -135,7 +135,7 @@ int BSPGetMineChecksum() {
 bspnode *NewBSPNode(void) {
   bspnode *node;
 
-  if ((node = (bspnode *)mem_malloc(sizeof(bspnode))) == NULL) {
+  if ((node = mem_rmalloc<bspnode>()) == NULL) {
     return NULL;
   }
 
@@ -164,7 +164,7 @@ bsppolygon *NewPolygon(int roomnum, int facenum, int numverts) {
   bsppolygon *newpoly;
   vector *verts;
 
-  newpoly = (bsppolygon *)mem_malloc(sizeof(bsppolygon));
+  newpoly = mem_rmalloc<bsppolygon>();
 
   if (newpoly == NULL) {
     LOG_ERROR << "NewPolygon: Couldn't allocate polygon";
@@ -396,7 +396,7 @@ int SplitPolygon(bspplane *plane, bsppolygon *testpoly, bsppolygon **frontpoly, 
 
     vertptr2 = polyvert[(i + 1) % numvert];
     t = dists[i] / (dists[i] - dists[i + 1]);
-    newvert[num_new_verts] = (vector *)mem_malloc(sizeof(vector));
+    newvert[num_new_verts] = mem_rmalloc<vector>();
 
     /* Now we must generate the split point. This is simply
      * an equation in the form Origin + t*Direction

--- a/Descent3/controls.h
+++ b/Descent3/controls.h
@@ -213,30 +213,30 @@ const int ctfFORWARD_THRUSTAXIS = 0, ctfFORWARD_THRUSTKEY = 1, ctfREVERSE_THRUST
 struct game_controls {
   //	movement values
   //	these values are from -1.0 to 1.0.-
-  float pitch_thrust;
-  float heading_thrust;
-  float bank_thrust;
-  float vertical_thrust;
-  float sideways_thrust;
-  float forward_thrust;
-  float afterburn_thrust;
+  float pitch_thrust = 0;
+  float heading_thrust = 0;
+  float bank_thrust = 0;
+  float vertical_thrust = 0;
+  float sideways_thrust = 0;
+  float forward_thrust = 0;
+  float afterburn_thrust = 0;
 
   // these values modify thrust
-  bool toggle_slide;
-  bool toggle_bank;
+  bool toggle_slide = false;
+  bool toggle_bank = false;
 
   //	this is for weapon control
-  int fire_primary_down_count;
-  bool fire_primary_down_state;
-  float fire_primary_down_time;
-  int fire_secondary_down_count;
-  bool fire_secondary_down_state;
-  float fire_secondary_down_time;
+  int fire_primary_down_count = 0;
+  bool fire_primary_down_state = false;
+  float fire_primary_down_time = 0;
+  int fire_secondary_down_count = 0;
+  bool fire_secondary_down_state = false;
+  float fire_secondary_down_time = 0;
 
   // The flare
-  int fire_flare_down_count;
-  int rearview_down_count;
-  bool rearview_down_state;
+  int fire_flare_down_count = 0;
+  int rearview_down_count = 0;
+  bool rearview_down_state = false;
 };
 
 //	This value should be set at initialization time.  Use for remote controlling.

--- a/Descent3/credits.cpp
+++ b/Descent3/credits.cpp
@@ -260,7 +260,7 @@ static bool Credits_LoadCredits(const char *filename) {
     // Generate blank lines for the start
     cur_credit->text = NULL;
     cur_credit->type = CLTYPE_BLANK;
-    cur_credit->next = (creditline *)mem_malloc(sizeof(creditline));
+    cur_credit->next = mem_rmalloc<creditline>();
     ASSERT(cur_credit->next);
     cur_credit = cur_credit->next;
     cur_credit->next = NULL;
@@ -286,7 +286,7 @@ static bool Credits_LoadCredits(const char *filename) {
 
     if (Credits_ParseLine(curline, cur_credit)) {
       // Make a new line
-      cur_credit->next = (creditline *)mem_malloc(sizeof(creditline));
+      cur_credit->next = mem_rmalloc<creditline>();
       ASSERT(cur_credit->next);
       cur_credit = cur_credit->next;
       cur_credit->next = NULL;

--- a/Descent3/debuggraph.cpp
+++ b/Descent3/debuggraph.cpp
@@ -480,7 +480,7 @@ void DebugGraph_DisplayOptions(void) {
   bool exit_menu = false;
   tGraphNode *node;
 
-  bool_values = (bool **)mem_malloc(sizeof(bool *) * graph_num_nodes);
+  bool_values = mem_rmalloc<bool *>(graph_num_nodes);
   if (!bool_values)
     return;
 

--- a/Descent3/debuggraph.cpp
+++ b/Descent3/debuggraph.cpp
@@ -132,12 +132,12 @@ tGraphNode *DebugGraph_AddNode(void) {
   tDebugGraphNode *curr = DebugGraphNode_root;
 
   if (!curr) {
-    curr = DebugGraphNode_root = (tDebugGraphNode *)mem_malloc(sizeof(tDebugGraphNode));
+    curr = DebugGraphNode_root = mem_rmalloc<tDebugGraphNode>();
   } else {
     while (curr->next) {
       curr = curr->next;
     }
-    curr->next = (tDebugGraphNode *)mem_malloc(sizeof(tDebugGraphNode));
+    curr->next = mem_rmalloc<tDebugGraphNode>();
     curr = curr->next;
   }
 

--- a/Descent3/dedicated_server.cpp
+++ b/Descent3/dedicated_server.cpp
@@ -884,7 +884,7 @@ void ListenDedicatedSocket(void) {
     PrintDedicatedMessage(TXT_DS_NEWCONNECT, inet_ntoa(conn_addr.sin_addr));
     PrintDedicatedMessage("\n");
     dedicated_socket *new_socket;
-    new_socket = (dedicated_socket *)mem_malloc(sizeof(dedicated_socket));
+    new_socket = mem_rmalloc<dedicated_socket>();
     if (Head_sock)
       Head_sock->prev = new_socket;
     new_socket->next = Head_sock;

--- a/Descent3/demofile.cpp
+++ b/Descent3/demofile.cpp
@@ -785,7 +785,7 @@ int DemoReadHeader() {
 
   if (gs_Xlates)
     mem_free(gs_Xlates);
-  gs_Xlates = (struct gs_tables *)mem_malloc(sizeof(gs_tables));
+  gs_Xlates = mem_rmalloc<gs_tables>();
 
   try {
     LGSXlateTables(Demo_cfp);

--- a/Descent3/demofile.cpp
+++ b/Descent3/demofile.cpp
@@ -1693,7 +1693,7 @@ void DemoReadPersistantHUDMessage() {
   flags = cf_ReadInt(Demo_cfp);
   sound_index = cf_ReadInt(Demo_cfp);
   int msglen = cf_ReadShort(Demo_cfp);
-  fmt = (char *)mem_malloc(msglen);
+  fmt = mem_rmalloc<char>(msglen);
   cf_ReadBytes((uint8_t *)fmt, msglen, Demo_cfp);
   AddPersistentHUDMessage(color, x, y, time, flags, sound_index, fmt);
   mem_free(fmt);

--- a/Descent3/doorway.cpp
+++ b/Descent3/doorway.cpp
@@ -646,7 +646,7 @@ doorway *DoorwayAdd(room *rp, int doornum) {
 
   rp->flags |= RF_DOOR;
 
-  doorway *dp = rp->doorway_data = (doorway *)mem_malloc(sizeof(*rp->doorway_data));
+  auto dp = rp->doorway_data = mem_rmalloc<doorway>();
 
   // Initialize
   dp->doornum = doornum;

--- a/Descent3/game.cpp
+++ b/Descent3/game.cpp
@@ -1123,7 +1123,7 @@ void FramePush(int x1, int y1, int x2, int y2, bool clear) {
     ASSERT(!FrameStackRoot);
 
     // we need to allocate for the root
-    //		curr = FrameStackRoot = FrameStackPtr = (tFrameStackFrame *)mem_malloc(sizeof(tFrameStackFrame));
+    //		curr = FrameStackRoot = FrameStackPtr = mem_rmalloc<tFrameStackFrame>();
     curr = FrameStackRoot = FrameStackPtr = &FrameStack[0];
     if (!curr) {
       Error("Out of memory\n");
@@ -1134,7 +1134,7 @@ void FramePush(int x1, int y1, int x2, int y2, bool clear) {
   } else {
     // add on to the end of the list
     curr->next = FrameStackPtr = &FrameStack[FrameStackDepth];
-    //		curr->next = FrameStackPtr = (tFrameStackFrame *)mem_malloc(sizeof(tFrameStackFrame));
+    //		curr->next = FrameStackPtr = mem_rmalloc<tFrameStackFrame>();
     if (!curr->next) {
       Error("Out of memory\n");
     }

--- a/Descent3/gamesequence.cpp
+++ b/Descent3/gamesequence.cpp
@@ -1334,7 +1334,7 @@ bool SimpleStartLevel(const std::filesystem::path& level_name) {
 
   Current_mission.cur_level = 1;
   Current_mission.num_levels = 1;
-  Current_mission.levels = (tLevelNode *)mem_malloc(sizeof(tLevelNode));
+  Current_mission.levels = mem_rmalloc<tLevelNode>();
   memset(Current_mission.levels, 0, sizeof(tLevelNode));
 
   Current_level = nullptr;

--- a/Descent3/gametexture.cpp
+++ b/Descent3/gametexture.cpp
@@ -416,7 +416,7 @@ int AllocateProceduralForTexture(int handle) {
     w = h = 128;
   }
 
-  GameTextures[handle].procedural = (proc_struct *)mem_malloc(sizeof(proc_struct));
+  GameTextures[handle].procedural = mem_rmalloc<proc_struct>();
   ASSERT(GameTextures[handle].procedural);
 
   GameTextures[handle].procedural->proc1 = NULL;

--- a/Descent3/gametexture.cpp
+++ b/Descent3/gametexture.cpp
@@ -452,7 +452,7 @@ int AllocateProceduralForTexture(int handle) {
 // Allocates the memory needed for static elements for a procedural texture
 void AllocateStaticProceduralsForTexture(int handle, int num_elements) {
   GameTextures[handle].procedural->static_proc_elements =
-      (static_proc_element *)mem_malloc(sizeof(static_proc_element) * num_elements);
+      mem_rmalloc<static_proc_element>(num_elements);
   ASSERT(GameTextures[handle].procedural->static_proc_elements);
 }
 

--- a/Descent3/hotspotmap.cpp
+++ b/Descent3/hotspotmap.cpp
@@ -175,7 +175,7 @@ int CreateHotSpotMap(const char *map, int width, int height, hotspotmap_t *hsmap
   if (!num_hs)
     return -1;
 
-  hsmap->hs = (hotspot *)mem_malloc(sizeof(hotspot) * num_hs);
+  hsmap->hs = mem_rmalloc<hotspot>(num_hs);
   ASSERT(hsmap->hs);
   for (count = 0; count < num_hs; count++) {
     if (whats_there[count] == HOTSPOT_THERE) {
@@ -220,7 +220,7 @@ int CreateHotSpotMap(const char *map, int width, int height, hotspotmap_t *hsmap
       // fill in the struct with the start and end values for each scanline
       hsmap->hs[count].scanlines = sl_count;
       if (sl_count) {
-        hsmap->hs[count].x = (scanline *)mem_malloc(sizeof(scanline) * sl_count);
+        hsmap->hs[count].x = mem_rmalloc<scanline>(sl_count);
         ASSERT(hsmap->hs[count].x);
         memset(hsmap->hs[count].x, 0, sizeof(scanline) * sl_count);
         y = hsmap->hs[count].starting_y;
@@ -268,7 +268,7 @@ void CreateWindowMap(const char *map, int width, int height, windowmap_t *wndmap
   uint8_t alpha;
   bool newline = true;
 
-  wndmap->wm = (window_box *)mem_malloc(sizeof(window_box) * wndmap->num_of_windows);
+  wndmap->wm = mem_rmalloc<window_box>(wndmap->num_of_windows);
   ASSERT(wndmap->wm);
 
   for (int index = 0; index < wndmap->num_of_windows; index++) {
@@ -681,13 +681,13 @@ void menutga_LoadHotSpotMap(int back_bmp, const char *filename, hotspotmap_t *hs
 
   int curr_hs, curr_sl, num_sl;
 
-  hsmap->hs = (hotspot *)mem_malloc(sizeof(hotspot) * hsmap->num_of_hotspots);
+  hsmap->hs = mem_rmalloc<hotspot>(hsmap->num_of_hotspots);
   memset(hsmap->hs, 0, sizeof(hotspot) * hsmap->num_of_hotspots);
   for (curr_hs = 0; curr_hs < hsmap->num_of_hotspots; curr_hs++) {
     hsmap->hs[curr_hs].starting_y = cf_ReadInt(infile);
     num_sl = hsmap->hs[curr_hs].scanlines = cf_ReadInt(infile);
     if (num_sl) {
-      hsmap->hs[curr_hs].x = (scanline *)mem_malloc(sizeof(scanline) * hsmap->hs[curr_hs].scanlines);
+      hsmap->hs[curr_hs].x = mem_rmalloc<scanline>(hsmap->hs[curr_hs].scanlines);
       memset(hsmap->hs[curr_hs].x, 0, sizeof(scanline) * hsmap->hs[curr_hs].scanlines);
       for (curr_sl = 0; curr_sl < hsmap->hs[curr_hs].scanlines; curr_sl++) {
         hsmap->hs[curr_hs].x[curr_sl].start = cf_ReadInt(infile);
@@ -702,7 +702,7 @@ void menutga_LoadHotSpotMap(int back_bmp, const char *filename, hotspotmap_t *hs
   wndmap->num_of_windows = cf_ReadInt(infile);
   LOG_DEBUG.printf("Loading hotspotmap %s Contains: (%d hotspots) (%d Windows)",
                    filename, hsmap->num_of_hotspots, wndmap->num_of_windows);
-  wndmap->wm = (window_box *)mem_malloc(sizeof(window_box) * wndmap->num_of_windows);
+  wndmap->wm = mem_rmalloc<window_box>(wndmap->num_of_windows);
   for (count = 0; count < wndmap->num_of_windows; count++) {
     wndmap->wm[count].x = cf_ReadInt(infile);
     wndmap->wm[count].y = cf_ReadInt(infile);

--- a/Descent3/hotspotmap.cpp
+++ b/Descent3/hotspotmap.cpp
@@ -721,7 +721,7 @@ void menutga_LoadHotSpotMap(int back_bmp, const char *filename, hotspotmap_t *hs
       // left top
       size = ((wndmap->wm[count].l_end_x) - (wndmap->wm[count].l_start_x)) *
              ((wndmap->wm[count].t_bottom_y) - (wndmap->wm[count].t_top_y));
-      wndmap->wm[count].lt = (char *)mem_malloc(size);
+      wndmap->wm[count].lt = mem_rmalloc<char>(size);
       for (index = 0; index < size; index++) {
         wndmap->wm[count].lt[index] = cf_ReadByte(infile);
       }
@@ -729,7 +729,7 @@ void menutga_LoadHotSpotMap(int back_bmp, const char *filename, hotspotmap_t *hs
       // right top
       size = ((wndmap->wm[count].r_end_x) - (wndmap->wm[count].r_start_x)) *
              ((wndmap->wm[count].t_bottom_y) - (wndmap->wm[count].t_top_y));
-      wndmap->wm[count].rt = (char *)mem_malloc(size);
+      wndmap->wm[count].rt = mem_rmalloc<char>(size);
       for (index = 0; index < size; index++) {
         wndmap->wm[count].rt[index] = cf_ReadByte(infile);
       }
@@ -739,14 +739,14 @@ void menutga_LoadHotSpotMap(int back_bmp, const char *filename, hotspotmap_t *hs
       // left bottom
       size = ((wndmap->wm[count].l_end_x) - (wndmap->wm[count].l_start_x)) *
              ((wndmap->wm[count].b_bottom_y) - (wndmap->wm[count].b_top_y));
-      wndmap->wm[count].lb = (char *)mem_malloc(size);
+      wndmap->wm[count].lb = mem_rmalloc<char>(size);
       for (index = 0; index < size; index++) {
         wndmap->wm[count].lb[index] = cf_ReadByte(infile);
       }
       // right bottom
       size = ((wndmap->wm[count].r_end_x) - (wndmap->wm[count].r_start_x)) *
              ((wndmap->wm[count].b_bottom_y) - (wndmap->wm[count].b_top_y));
-      wndmap->wm[count].rb = (char *)mem_malloc(size);
+      wndmap->wm[count].rb = mem_rmalloc<char>(size);
       for (index = 0; index < size; index++) {
         wndmap->wm[count].rb[index] = cf_ReadByte(infile);
       }
@@ -872,7 +872,7 @@ bool menutga_ConvertTGAtoHSM(const char *fpath) {
   }
 
   int size = strlen(filename) + 5;
-  menu_filename = (char *)mem_malloc(size);
+  menu_filename = mem_rmalloc<char>(size);
   strcpy(menu_filename, filename);
   strcat(menu_filename, ".HSM"); // Hot Spot Map
   LOG_DEBUG.printf("HSM=%s", menu_filename);

--- a/Descent3/hud.cpp
+++ b/Descent3/hud.cpp
@@ -840,7 +840,7 @@ void InitHUDItem(int new_item, tHUDItem *item) {
     break;
 
   case HUD_ITEM_CUSTOMTEXT2:  // malloc buffer to be updated later
-    HUD_array[new_item].data.text = (char *)mem_malloc(item->buffer_size);
+    HUD_array[new_item].data.text = mem_rmalloc<char>(item->buffer_size);
     HUD_array[new_item].data.text[0] = 0;
     HUD_array[new_item].buffer_size = item->buffer_size;
     stat = STAT_CUSTOM;
@@ -998,7 +998,7 @@ bool LGSHudState(CFILE *fp) {
       huditem.render_fn = NULL; // use pointer to function void (*fn)(struct tHUDItem *)
       AddHUDItem(&huditem);
 
-      buffer = (char *)mem_malloc(huditem.buffer_size);
+      buffer = mem_rmalloc<char>(huditem.buffer_size);
       cf_ReadString(buffer, huditem.buffer_size, fp);
       UpdateCustomtext2HUDItem(buffer);
       mem_free(buffer);

--- a/Descent3/hudmessage.cpp
+++ b/Descent3/hudmessage.cpp
@@ -1628,7 +1628,7 @@ bool MsgListConsole::Open(const char *title, int x, int y, int w, int h) {
   m_buflen = 2048;
 
 redo_copy:
-  m_buffer = (char *)mem_malloc(m_buflen);
+  m_buffer = mem_rmalloc<char>(m_buflen);
   if (m_buffer) {
     m_buffer[0] = 0;
     m_opened = true;

--- a/Descent3/hudmessage.cpp
+++ b/Descent3/hudmessage.cpp
@@ -1556,7 +1556,7 @@ bool tMsgList::add(const char *msg, uint8_t lvl, uint8_t hr, uint8_t min, uint8_
     m_limit = 64;
 
   if (m_msg == NULL) {
-    m_msg = (char **)mem_malloc(sizeof(char *) * m_limit);
+    m_msg = mem_rmalloc<char *>(m_limit);
     m_nmsg = 0;
   }
 
@@ -1669,7 +1669,7 @@ redo_copy:
   }
 
   ASSERT(c > 0);
-  m_conlines = (char **)mem_malloc(sizeof(char *) * c);
+  m_conlines = mem_rmalloc<char *>(c);
   n_conlines = c;
   memset(m_conlines, 0, sizeof(char *) * c);
 

--- a/Descent3/levelgoal.cpp
+++ b/Descent3/levelgoal.cpp
@@ -288,7 +288,7 @@ bool lgoal::SetName(int handle, char *name) {
   if (m_name)
     mem_free(m_name);
 
-  m_name = (char *)mem_malloc(strlen(name) + 1);
+  m_name = mem_rmalloc<char>(strlen(name) + 1);
   strcpy(m_name, name);
   m_modified = 1;
 
@@ -320,7 +320,7 @@ bool lgoal::SetCompletionMessage(char *message) {
   if (m_completion_message)
     mem_free(m_completion_message);
 
-  m_completion_message = (char *)mem_malloc(strlen(message) + 1);
+  m_completion_message = mem_rmalloc<char>(strlen(message) + 1);
   strcpy(m_completion_message, message);
 
   return true;
@@ -333,7 +333,7 @@ bool lgoal::SetItemName(char *iname) {
   if (m_item_name)
     mem_free(m_item_name);
 
-  m_item_name = (char *)mem_malloc(strlen(iname) + 1);
+  m_item_name = mem_rmalloc<char>(strlen(iname) + 1);
   strcpy(m_item_name, iname);
 
   return true;
@@ -442,7 +442,7 @@ bool lgoal::SetDesc(char *desc) {
   if (m_desc)
     mem_free(m_desc);
 
-  m_desc = (char *)mem_malloc(strlen(desc) + 1);
+  m_desc = mem_rmalloc<char>(strlen(desc) + 1);
   strcpy(m_desc, desc);
 
   return true;

--- a/Descent3/lighting.cpp
+++ b/Descent3/lighting.cpp
@@ -140,7 +140,7 @@ void InitDynamicLighting() {
   Dynamic_lightmap_memory = (uint16_t *)mem_malloc(DYNAMIC_LIGHTMAP_MEMORY);
 
   // Init our records list
-  Dynamic_lightmaps = (dynamic_lightmap *)mem_malloc(sizeof(dynamic_lightmap) * MAX_DYNAMIC_LIGHTMAPS);
+  Dynamic_lightmaps = mem_rmalloc<dynamic_lightmap>(MAX_DYNAMIC_LIGHTMAPS);
   ASSERT(Dynamic_lightmaps);
 
   for (i = 0; i < MAX_DYNAMIC_LIGHTMAPS; i++) {

--- a/Descent3/lightmap_info.cpp
+++ b/Descent3/lightmap_info.cpp
@@ -56,9 +56,9 @@ void InitLightmapInfo(int nummaps) {
     return;
 
   if (nummaps == 0) {
-    LightmapInfo = (lightmap_info *)mem_malloc(MAX_LIGHTMAP_INFOS * sizeof(lightmap_info));
+    LightmapInfo = mem_rmalloc<lightmap_info>(MAX_LIGHTMAP_INFOS);
     ASSERT(LightmapInfo);
-    Free_lmi_list = (uint16_t *)mem_malloc(MAX_LIGHTMAP_INFOS * sizeof(uint16_t));
+    Free_lmi_list = mem_rmalloc<uint16_t>(MAX_LIGHTMAP_INFOS);
     ASSERT(Free_lmi_list);
 
     for (i = 0; i < MAX_LIGHTMAP_INFOS; i++) {

--- a/Descent3/list.cpp
+++ b/Descent3/list.cpp
@@ -24,7 +24,7 @@
 listnode *NewListNode(void) {
   listnode *node;
 
-  node = (listnode *)mem_malloc(sizeof(listnode));
+  node = mem_rmalloc<listnode>();
   if (node == NULL) {
     LOG_FATAL << "Not enough memory for a new listnode!";
     Int3();

--- a/Descent3/loadstate.cpp
+++ b/Descent3/loadstate.cpp
@@ -1125,7 +1125,7 @@ int LGSObjects(CFILE *fp, int version) {
 
       if (f_allocated) {
         // mprintf(0,"Object %d has %d attach points.\n",i,nattach);
-        op->attach_children = (int *)mem_malloc(sizeof(int) * nattach);
+        op->attach_children = mem_rmalloc<int>(nattach);
         for (j = 0; j < nattach; j++)
           gs_ReadInt(fp, op->attach_children[j]);
       }
@@ -1310,8 +1310,8 @@ int LGSObjects(CFILE *fp, int version) {
         int cur = 0;
 
         p_info->multi_turret_info.time = 0;
-        p_info->multi_turret_info.keyframes = (float *)mem_malloc(sizeof(float) * count);
-        p_info->multi_turret_info.last_keyframes = (float *)mem_malloc(sizeof(float) * count);
+        p_info->multi_turret_info.keyframes = mem_rmalloc<float>(count);
+        p_info->multi_turret_info.last_keyframes = mem_rmalloc<float>(count);
         p_info->multi_turret_info.flags = 0;
       }
       // Do Animation stuff
@@ -1548,7 +1548,7 @@ int LGSObjWB(CFILE *fp, object *op) {
   if (!num_wbs)
     return LGS_OK;
 
-  dwba = (dynamic_wb_info *)mem_malloc(sizeof(dynamic_wb_info) * num_wbs);
+  dwba = mem_rmalloc<dynamic_wb_info>(num_wbs);
 
   for (i = 0; i < num_wbs; i++) {
     dynamic_wb_info *dwb = &dwba[i];

--- a/Descent3/loadstate.cpp
+++ b/Descent3/loadstate.cpp
@@ -838,7 +838,7 @@ int LGSObjects(CFILE *fp, int version) {
   int i, j, highest_index;
   int max_terr;
 
-  matrix *objmat = (matrix *)mem_malloc(sizeof(*objmat) * MAX_OBJECTS);
+  auto objmat = mem_rmalloc<matrix>(MAX_OBJECTS);
 
   Osiris_DisableCreateEvents();
   // we must reset some data before continuing.
@@ -992,7 +992,7 @@ int LGSObjects(CFILE *fp, int version) {
     gs_ReadByte(fp, has_lightinfo);
     if (has_lightinfo) {
       if (!op->lighting_info) {
-        op->lighting_info = (light_info *)mem_malloc(sizeof(*op->lighting_info));
+        op->lighting_info = mem_rmalloc<light_info>();
       }
       cf_ReadBytes((uint8_t *)op->lighting_info, sizeof(*op->lighting_info), fp);
     }
@@ -1443,7 +1443,6 @@ done:;
 
 //	loads ai
 int LGSObjAI(CFILE *fp, ai_frame **pai) {
-  ai_frame *ai;
   int16_t size;
   int8_t read_ai;
 
@@ -1457,9 +1456,7 @@ int LGSObjAI(CFILE *fp, ai_frame **pai) {
   if (size != sizeof(ai_frame))
     return LGS_OUTDATEDVER;
 
-  *pai = (ai_frame *)mem_malloc(size);
-  ai = *pai;
-
+  auto ai = *pai = mem_rmalloc<ai_frame>();
   cf_ReadBytes((uint8_t *)ai, size, fp);
 
   return LGS_OK;
@@ -1478,9 +1475,7 @@ int LGSObjEffects(CFILE *fp, object *op) {
     if (size != sizeof(effect_info_s))
       return LGS_OUTDATEDVER;
 
-    op->effect_info = (effect_info_s *)mem_malloc(size);
-    effect_info_s *ei = op->effect_info;
-
+    auto ei = op->effect_info = mem_rmalloc<effect_info_s>();
     cf_ReadBytes((uint8_t *)ei, size, fp);
   }
 

--- a/Descent3/localization.cpp
+++ b/Descent3/localization.cpp
@@ -664,7 +664,7 @@ void GrowString::operator+=(char *str) {
     return;
   if (root.string_data) {
     tbufferinfo *node;
-    node = (tbufferinfo *)mem_malloc(sizeof(tbufferinfo));
+    node = mem_rmalloc<tbufferinfo>();
     if (!node)
       return;
     node->string_data = (char *)mem_malloc(strlen(str) + 2);

--- a/Descent3/localization.cpp
+++ b/Descent3/localization.cpp
@@ -667,7 +667,7 @@ void GrowString::operator+=(char *str) {
     node = mem_rmalloc<tbufferinfo>();
     if (!node)
       return;
-    node->string_data = (char *)mem_malloc(strlen(str) + 2);
+    node->string_data = mem_rmalloc<char>(strlen(str) + 2);
     if (!node->string_data) {
       mem_free(node);
       return;
@@ -677,7 +677,7 @@ void GrowString::operator+=(char *str) {
     node->next = NULL;
     curr = node;
   } else {
-    root.string_data = (char *)mem_malloc(strlen(str) + 1);
+    root.string_data = mem_rmalloc<char>(strlen(str) + 1);
     if (!root.string_data)
       return;
     strcpy(root.string_data, str);

--- a/Descent3/localization.cpp
+++ b/Descent3/localization.cpp
@@ -180,7 +180,7 @@ int LoadStringTables(void) {
   String_table_size = 0;
 
   // malloc our array of char *
-  String_table = (char **)mem_malloc(sizeof(char *) * string_count);
+  String_table = mem_rmalloc<char *>(string_count);
   if (!String_table) {
     Localization_language = old_language;
     return 0;
@@ -324,7 +324,7 @@ try_english:
   char **strtable;
 
   // malloc our array of char *
-  *table = (char **)mem_malloc(sizeof(char *) * scount);
+  *table = mem_rmalloc<char *>(scount);
   if (!*table) {
     if (table)
       *table = NULL;

--- a/Descent3/matcen.cpp
+++ b/Descent3/matcen.cpp
@@ -920,7 +920,7 @@ void matcen::LoadData(CFILE *fp) {
   m_max_alive_children = cf_ReadShort(fp);
   if (m_max_alive_children > 0) {
     m_num_alive = cf_ReadShort(fp);
-    m_alive_list = (int *)mem_malloc(sizeof(int) * m_max_alive_children);
+    m_alive_list = mem_rmalloc<int>(m_max_alive_children);
 
     for (i = 0; i < m_num_alive; i++) {
       m_alive_list[i] = cf_ReadInt(fp);
@@ -1784,7 +1784,7 @@ bool matcen::SetMaxAliveChildren(int max_alive) {
 
     // Allocate the alive children list
     if (max_alive > 0) {
-      temp = (int *)mem_malloc(sizeof(int) * max_alive);
+      temp = mem_rmalloc<int>(max_alive);
     } else {
       temp = NULL;
     }

--- a/Descent3/menu.cpp
+++ b/Descent3/menu.cpp
@@ -1217,7 +1217,7 @@ bool MenuNewGame() {
 #define OEM_MISSION_NAME "Descent 3: Sol Ascent"
 #define OEM_TRAINING_NAME "Pilot Training "
   n_missions = 2;
-  filelist = (char **)mem_malloc(sizeof(char *) * 2);
+  filelist = mem_rmalloc<char *>(2);
   filelist[0] = mem_strdup(OEM_MISSION_FILE);
   ;
   msn_lb->AddItem(OEM_MISSION_NAME);

--- a/Descent3/multi_ui.cpp
+++ b/Descent3/multi_ui.cpp
@@ -725,7 +725,7 @@ void DoMultiAllowed(void) {
   bool objsallowed[MAX_OBJECTS];
   ConfigItem **ship_list = NULL;
   size_t strMax = std::max(strlen(TXT_ALLOW), strlen(TXT_DISALLOW)) + 3;
-  char *str = (char *)mem_malloc(strMax);
+  char *str = mem_rmalloc<char>(strMax);
 
   // Create Text Items and Window
   UITextItem cancel_on_text(TXT_CANCEL, UICOL_HOTSPOT_HI);

--- a/Descent3/newui_core.cpp
+++ b/Descent3/newui_core.cpp
@@ -1203,7 +1203,7 @@ void newuiSheet::Create(UIWindow *menu, const char *title, int n_items, int sx, 
   m_gadgetlimit = n_items;
   m_ngadgets = 0;
   if (n_items) {
-    m_gadgetlist = (newuiSheet::t_gadget_desc *)mem_malloc(n_items * sizeof(newuiSheet::t_gadget_desc));
+    m_gadgetlist = mem_rmalloc<t_gadget_desc>(n_items);
   } else {
     m_gadgetlist = NULL;
   }

--- a/Descent3/object.cpp
+++ b/Descent3/object.cpp
@@ -3338,7 +3338,7 @@ void SetObjectControlType(object *obj, int control_type) {
     int count = 0;
     int i;
 
-    obj->ai_info = (ai_frame *)mem_malloc(sizeof(ai_frame));
+    obj->ai_info = mem_rmalloc<ai_frame>();
     memset(obj->ai_info, 0x00, sizeof(ai_frame)); // DAJ clear the baby
 
     for (i = 0; i < num_wbs; i++) {

--- a/Descent3/object.cpp
+++ b/Descent3/object.cpp
@@ -3352,8 +3352,8 @@ void SetObjectControlType(object *obj, int control_type) {
       int cur = 0;
 
       p_info->multi_turret_info.time = 0;
-      p_info->multi_turret_info.keyframes = (float *)mem_malloc(sizeof(float) * count);
-      p_info->multi_turret_info.last_keyframes = (float *)mem_malloc(sizeof(float) * count);
+      p_info->multi_turret_info.keyframes = mem_rmalloc<float>(count);
+      p_info->multi_turret_info.last_keyframes = mem_rmalloc<float>(count);
       p_info->multi_turret_info.flags = 0;
     }
   }
@@ -3366,10 +3366,10 @@ void SetObjectControlType(object *obj, int control_type) {
 
     if (obj->dynamic_wb == NULL) {
       if (obj->type == OBJ_PLAYER) {
-        obj->dynamic_wb = (dynamic_wb_info *)mem_malloc(sizeof(dynamic_wb_info) * MAX_WBS_PER_OBJ);
+        obj->dynamic_wb = mem_rmalloc<dynamic_wb_info>(MAX_WBS_PER_OBJ);
       } else {
         if (num_wbs)
-          obj->dynamic_wb = (dynamic_wb_info *)mem_malloc(sizeof(dynamic_wb_info) * num_wbs);
+          obj->dynamic_wb = mem_rmalloc<dynamic_wb_info>(num_wbs);
       }
     }
   }

--- a/Descent3/object_lighting.cpp
+++ b/Descent3/object_lighting.cpp
@@ -540,7 +540,7 @@ void SetupObjectLightmapMemory(object *obj) {
 
     obj->lm_object.num_faces[Mnum] = pm->submodel[Mnum].num_faces;
     obj->lm_object.lightmap_faces[Mnum] =
-        (lightmap_object_face *)mem_malloc(obj->lm_object.num_faces[Mnum] * sizeof(lightmap_object_face));
+        mem_rmalloc<lightmap_object_face>(obj->lm_object.num_faces[Mnum]);
     ASSERT(obj->lm_object.lightmap_faces[Mnum]);
 
     for (Fnum = 0; Fnum < pm->submodel[Mnum].num_faces; Fnum++) {

--- a/Descent3/object_lighting.cpp
+++ b/Descent3/object_lighting.cpp
@@ -630,7 +630,7 @@ void ObjSetLocalLighting(object *objp) {
            (objp->type == OBJ_BUILDING));
 
     // allocate a light info for this object
-    objp->lighting_info = (light_info *)mem_malloc(sizeof(*objp->lighting_info));
+    objp->lighting_info = mem_rmalloc<light_info>();
 
     // copy the lighting info from the type for this object
     *objp->lighting_info = Object_info[objp->id].lighting_info;

--- a/Descent3/objinfo.cpp
+++ b/Descent3/objinfo.cpp
@@ -116,7 +116,7 @@ int AllocObjectID(int type, bool f_anim, bool f_weapons, bool f_ai) {
 
       extern void AISetDefault(t_ai_info * ai_info_ptr);
       if (f_ai) {
-        Object_info[i].ai_info = (t_ai_info *)mem_malloc(sizeof(t_ai_info));
+        Object_info[i].ai_info = mem_rmalloc<t_ai_info>();
         memset(Object_info[i].ai_info, 0, sizeof(t_ai_info));
         AISetDefault(Object_info[i].ai_info);
       }

--- a/Descent3/objinfo.cpp
+++ b/Descent3/objinfo.cpp
@@ -122,13 +122,13 @@ int AllocObjectID(int type, bool f_anim, bool f_weapons, bool f_ai) {
       }
       // Make sure the weapon battery info is cleared for a new object
       if (f_weapons) {
-        Object_info[i].static_wb = (otype_wb_info *)mem_malloc(sizeof(otype_wb_info) * MAX_WBS_PER_OBJ);
+        Object_info[i].static_wb = mem_rmalloc<otype_wb_info>(MAX_WBS_PER_OBJ);
         memset(Object_info[i].static_wb, 0, sizeof(otype_wb_info) * MAX_WBS_PER_OBJ);
         WBClearInfo(Object_info[i].static_wb);
       }
 
       if (f_anim) {
-        Object_info[i].anim = (anim_elem *)mem_malloc(sizeof(anim_elem) * NUM_MOVEMENT_CLASSES);
+        Object_info[i].anim = mem_rmalloc<anim_elem>(NUM_MOVEMENT_CLASSES);
         memset(Object_info[i].anim, 0, sizeof(anim_elem) * NUM_MOVEMENT_CLASSES);
         for (j = 0; j < NUM_MOVEMENT_CLASSES; j++)
           for (k = 0; k < NUM_ANIMS_PER_CLASS; k++) {

--- a/Descent3/osiris_predefs.cpp
+++ b/Descent3/osiris_predefs.cpp
@@ -3324,7 +3324,7 @@ int osipf_AIGetNearbyObjs(vector *pos, int init_roomnum, float rad, int *object_
   int i;
   int count = 0;
 
-  s_list = (int16_t *)mem_malloc(sizeof(int16_t) * max_elements);
+  s_list = mem_rmalloc<int16_t>(max_elements);
 
   num_close = fvi_QuickDistObjectList(pos, init_roomnum, rad, s_list, max_elements, f_lightmap_only,
                                       f_only_players_and_ais, f_include_non_collide_objects, f_stop_at_closed_doors);

--- a/Descent3/pilot.cpp
+++ b/Descent3/pilot.cpp
@@ -2359,7 +2359,7 @@ bool PltSelectShip(pilot *Pilot) {
     if (Ships[i].used)
       count++;
   }
-  ship_info.idlist = (int *)mem_malloc(sizeof(int) * count);
+  ship_info.idlist = mem_rmalloc<int>(count);
   if (!ship_info.idlist)
     goto ship_id_err;
 

--- a/Descent3/pilot.cpp
+++ b/Descent3/pilot.cpp
@@ -3165,7 +3165,7 @@ void ShowPilotPicDialog(pilot *Pilot) {
   // Initialize PPicDlgInfo data
   // ---------------------------
   uint16_t *id_list;
-  id_list = (uint16_t *)mem_malloc(num_pilots * sizeof(uint16_t));
+  id_list = mem_rmalloc<uint16_t>(num_pilots);
 
   if (!id_list) {
     // out of memory

--- a/Descent3/pilot_class.cpp
+++ b/Descent3/pilot_class.cpp
@@ -1279,7 +1279,7 @@ void pilot::read_mission_data(CFILE *file, bool skip) {
       mem_free(mission_data);
       mission_data = NULL;
     }
-    mission_data = (tMissionData *)mem_malloc(sizeof(tMissionData) * num_missions_flown);
+    mission_data = mem_rmalloc<tMissionData>(num_missions_flown);
     if (!mission_data) {
       // out of memory
       num_missions_flown = 0;

--- a/Descent3/pilot_class.cpp
+++ b/Descent3/pilot_class.cpp
@@ -899,7 +899,7 @@ void pilot::add_mission_data(tMissionData *mdata) {
 
   LOG_DEBUG.printf("Adding new mission data for (%s)", mdata->mission_name);
 
-  tMissionData *new_data = (tMissionData *)mem_malloc((num_missions_flown + 1) * sizeof(tMissionData));
+  auto new_data = mem_rmalloc<tMissionData>(num_missions_flown + 1);
   if (!new_data) {
     LOG_WARNING << "Out of memory";
     return;

--- a/Descent3/render.cpp
+++ b/Descent3/render.cpp
@@ -3658,7 +3658,7 @@ void ConsolidateMineMirrors() {
       rp->mirror_face = 0;
       continue;
     }
-    rp->mirror_faces_list = (uint16_t *)mem_malloc(num_mirror_faces * sizeof(uint16_t));
+    rp->mirror_faces_list = mem_rmalloc<uint16_t>(num_mirror_faces);
     ASSERT(rp->mirror_faces_list);
     rp->num_mirror_faces = num_mirror_faces;
     // Now go through and fill in our list

--- a/Descent3/room.cpp
+++ b/Descent3/room.cpp
@@ -567,7 +567,7 @@ void InitRoom(room *rp, int nverts, int nfaces, int nportals) {
   ASSERT(rp->verts != NULL);
 
   if (Katmai) {
-    rp->verts4 = (vector4 *)mem_malloc(nverts * sizeof(*rp->verts4));
+    rp->verts4 = mem_rmalloc<vector4>(nverts);
     ASSERT(rp->verts4 != NULL);
   }
 
@@ -667,7 +667,7 @@ void FreeRoom(room *rp) {
   RoomMemFree(rp->portals);
   RoomMemFree(rp->verts);
 
-  if (Katmai)
+  if (Katmai )
     mem_free(rp->verts4);
 
   if (rp->num_bbf_regions) {

--- a/Descent3/room.cpp
+++ b/Descent3/room.cpp
@@ -496,7 +496,7 @@ void RoomMemInit(int nverts, int nfaces, int nfaceverts, int nportals) {
   if (Room_mem_buf)
     mem_free(Room_mem_buf);
 
-  Room_mem_buf = (uint8_t *)mem_malloc(size);
+  Room_mem_buf = mem_rmalloc<uint8_t>(size);
   Room_mem_size = size;
 
   Room_mem_ptr = Room_mem_buf;

--- a/Descent3/special_face.cpp
+++ b/Descent3/special_face.cpp
@@ -56,7 +56,7 @@ int AllocSpecialFace(int type, int num, bool vertnorms, int num_vertnorms) {
 
   memset(&SpecialFaces[n], 0, sizeof(special_face));
 
-  SpecialFaces[n].spec_instance = (specular_instance *)mem_malloc(num * sizeof(specular_instance));
+  SpecialFaces[n].spec_instance = mem_rmalloc<specular_instance>(num);
   ASSERT(SpecialFaces[n].spec_instance);
 
   SpecialFaces[n].type = type;
@@ -65,7 +65,7 @@ int AllocSpecialFace(int type, int num, bool vertnorms, int num_vertnorms) {
   SpecialFaces[n].used = 1;
 
   if (vertnorms) {
-    SpecialFaces[n].vertnorms = (vector *)mem_malloc(num_vertnorms * sizeof(vector));
+    SpecialFaces[n].vertnorms = mem_rmalloc<vector>(num_vertnorms);
     ASSERT(SpecialFaces[n].vertnorms);
     SpecialFaces[n].flags |= SFF_SPEC_SMOOTH;
   }

--- a/Descent3/subtitles.cpp
+++ b/Descent3/subtitles.cpp
@@ -186,7 +186,7 @@ void SubtParseSubtitles(CFILE *file) {
 
     Subtitles[Num_subtitles].first_frame = first_frame;
     Subtitles[Num_subtitles].last_frame = last_frame;
-    Subtitles[Num_subtitles].msg = (char *)mem_malloc(strlen(p) + 1);
+    Subtitles[Num_subtitles].msg = mem_rmalloc<char>(strlen(p) + 1);
     if (!Subtitles[Num_subtitles].msg)
       goto subt_parse_error;
     strcpy(Subtitles[Num_subtitles].msg, p); // be sure to free this later

--- a/Descent3/terrain.cpp
+++ b/Descent3/terrain.cpp
@@ -823,7 +823,7 @@ int LoadPCXTerrain(char *filename) {
 
   total = width * height;
 
-  lando = (uint8_t *)mem_malloc(total);
+  lando = mem_rmalloc<uint8_t>(total);
 
   LOG_DEBUG.printf("Heightmap is %d x %d", width, height);
 

--- a/Descent3/terrain.cpp
+++ b/Descent3/terrain.cpp
@@ -957,7 +957,7 @@ void InitTerrain(void) {
     Terrain_rotate_list = (uint16_t *)mem_malloc(TERRAIN_WIDTH * TERRAIN_DEPTH * sizeof(uint16_t));
     ASSERT(Terrain_rotate_list);
 
-    World_point_buffer = (g3Point *)mem_malloc(TERRAIN_WIDTH * TERRAIN_DEPTH * sizeof(g3Point));
+    World_point_buffer = mem_rmalloc<g3Point>(TERRAIN_WIDTH * TERRAIN_DEPTH);
     ASSERT(World_point_buffer);
 
     // Allocate space for lod delta tree and unique texture IDs
@@ -975,7 +975,7 @@ void InitTerrain(void) {
     w = TERRAIN_WIDTH >> ((MAX_TERRAIN_LOD - 1) - i);
     h = TERRAIN_DEPTH >> ((MAX_TERRAIN_LOD - 1) - i);
 
-    TerrainNormals[i] = (terrain_normals *)mem_malloc(w * h * sizeof(terrain_normals));
+    TerrainNormals[i] = mem_rmalloc<terrain_normals>(w * h);
     memset(TerrainNormals[i], 0, w * h * sizeof(terrain_normals));
   }
 

--- a/Descent3/vclip.cpp
+++ b/Descent3/vclip.cpp
@@ -204,7 +204,7 @@ int AllocVClip() {
   for (i = 0; i < MAX_VCLIPS; i++) {
     if (GameVClips[i].used == 0) {
       memset(&GameVClips[i], 0, sizeof(vclip));
-      GameVClips[i].frames = (int16_t *)mem_malloc(VCLIP_MAX_FRAMES * sizeof(int16_t));
+      GameVClips[i].frames = mem_rmalloc<int16_t>(VCLIP_MAX_FRAMES);
       ASSERT(GameVClips[i].frames);
       GameVClips[i].frame_time = DEFAULT_FRAMETIME;
       GameVClips[i].flags = VCF_NOT_RESIDENT;

--- a/Descent3/viseffect.cpp
+++ b/Descent3/viseffect.cpp
@@ -499,9 +499,9 @@ void InitVisEffects() {
     VisDeadList = (uint16_t *)mem_realloc(VisDeadList, sizeof(uint16_t) * max_vis_effects);
     Vis_free_list = (int16_t *)mem_realloc(Vis_free_list, sizeof(int16_t) * max_vis_effects);
   } else if (VisEffects == NULL) {
-    VisEffects = (vis_effect *)mem_malloc(sizeof(vis_effect) * max_vis_effects);
-    VisDeadList = (uint16_t *)mem_malloc(sizeof(uint16_t) * max_vis_effects);
-    Vis_free_list = (int16_t *)mem_malloc(sizeof(int16_t) * max_vis_effects);
+    VisEffects = mem_rmalloc<vis_effect>(max_vis_effects);
+    VisDeadList = mem_rmalloc<uint16_t>(max_vis_effects);
+    Vis_free_list = mem_rmalloc<int16_t>(max_vis_effects);
   }
   for (int i = 0; i < max_vis_effects; i++) {
     VisEffects[i].type = VIS_NONE;

--- a/bitmap/bitmain.cpp
+++ b/bitmap/bitmain.cpp
@@ -390,7 +390,7 @@ bm_Node *bm_insertNode(bm_T data) {
    ************************************************/
   /* insert bm_Node at beginning of list */
   bucket = bm_hash(data);
-  if ((p = (bm_Node *)mem_malloc(sizeof(bm_Node))) == 0) {
+  if ((p = mem_rmalloc<bm_Node>()) == 0) {
     exit(1);
   }
   p0 = bm_hashTable[bucket];

--- a/bitmap/bitmain.cpp
+++ b/bitmap/bitmain.cpp
@@ -342,7 +342,7 @@ static void bm_DeleteHashTable();
 static int bm_TestName(const char *src);
 
 void bm_InitHashTable() {
-  bm_hashTable = (bm_Node **)mem_malloc(bm_hashTableSize * sizeof(bm_Node *));
+  bm_hashTable = mem_rmalloc<bm_Node *>(bm_hashTableSize);
   for (int a = 0; a < bm_hashTableSize; a++) {
     bm_hashTable[a] = NULL;
   }

--- a/bitmap/tga.cpp
+++ b/bitmap/tga.cpp
@@ -503,7 +503,7 @@ int bm_tga_alloc_file(CFILE *infile, char *name, int format) {
 
     cfseek(infile, savepos, SEEK_SET);
 
-    Tga_file_data = (char *)mem_malloc(numleft);
+    Tga_file_data = mem_rmalloc<char>(numleft);
     ASSERT(Tga_file_data != NULL);
     Fake_pos = 0;
     Bad_tga = 0;
@@ -661,7 +661,7 @@ int bm_page_in_file(int n) {
 
     cfseek(infile, savepos, SEEK_SET);
 
-    Tga_file_data = (char *)mem_malloc(numleft);
+    Tga_file_data = mem_rmalloc<char>(numleft);
     ASSERT(Tga_file_data != NULL);
     Fake_pos = 0;
     Bad_tga = 0;

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -454,7 +454,7 @@ CFILE *open_file_in_directory(const std::filesystem::path &filename, const char 
   cfile = (CFILE *)mem_malloc(sizeof(*cfile));
   if (!cfile)
     Error("Out of memory in open_file_in_directory()");
-  cfile->name = (char *)mem_malloc(sizeof(char) * (strlen(using_filename.u8string().c_str()) + 1));
+  cfile->name = mem_rmalloc<char>((strlen(using_filename.u8string().c_str()) + 1));
   if (!cfile->name)
     Error("Out of memory in open_file_in_directory()");
   strcpy(cfile->name, using_filename.u8string().c_str());

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -282,7 +282,7 @@ CFILE *cf_OpenFileInLibrary(const std::filesystem::path &filename, int libhandle
       return nullptr;
     }
   }
-  CFILE *cfile = (CFILE *)mem_malloc(sizeof(*cfile));
+  auto cfile = mem_rmalloc<CFILE>();
   if (!cfile)
     Error("Out of memory in cf_OpenFileInLibrary()");
   cfile->name = lib->entries[i]->name;
@@ -335,7 +335,7 @@ CFILE *open_file_in_lib(const char *filename) {
           return nullptr;
         }
       }
-      cfile = (CFILE *)mem_malloc(sizeof(*cfile));
+      cfile = mem_rmalloc<CFILE>();
       if (!cfile)
         Error("Out of memory in open_file_in_lib()");
       cfile->name = lib->entries[i]->name;
@@ -451,7 +451,7 @@ CFILE *open_file_in_directory(const std::filesystem::path &filename, const char 
   }
 
   // found the file, open it
-  cfile = (CFILE *)mem_malloc(sizeof(*cfile));
+  cfile = mem_rmalloc<CFILE>();
   if (!cfile)
     Error("Out of memory in open_file_in_directory()");
   cfile->name = mem_rmalloc<char>((strlen(using_filename.u8string().c_str()) + 1));

--- a/ddebug/windebug.cpp
+++ b/ddebug/windebug.cpp
@@ -239,7 +239,7 @@ int Debug_ErrorBox(int type, const char *title, const char *topstring, const cha
   else
     debug_break();
 
-  char *tmpbuf = (char *)mem_malloc(strlen(topstring) + strlen(bottomstring) + 5);
+  char *tmpbuf = mem_rmalloc<char>(strlen(topstring) + strlen(bottomstring) + 5);
   wsprintf(tmpbuf, "%s\r\n\r\n%s", topstring, bottomstring);
 
   ShowCursor(TRUE);

--- a/ddio/lnxfile.cpp
+++ b/ddio/lnxfile.cpp
@@ -333,7 +333,7 @@ void ddio_CleanPath(char *dest, const char *srcPath) {
   // now the fun part, figure out the correct order of the directories
   int *dir_order;
 
-  dir_order = (int *)mem_malloc(sizeof(int) * dirs);
+  dir_order = mem_rmalloc<int>(dirs);
   if (!dir_order) {
     strcpy(dest, srcPath);
     return;

--- a/ddio/lnxfile.cpp
+++ b/ddio/lnxfile.cpp
@@ -315,7 +315,7 @@ void ddio_CleanPath(char *dest, const char *srcPath) {
   }
 
   // allocate the memory needed for the separate strings of each directory
-  directories = (char **)mem_malloc(sizeof(char *) * dirs);
+  directories = mem_rmalloc<char *>(dirs);
   if (!directories) {
     strcpy(dest, srcPath);
     return;

--- a/ddio/winfile.cpp
+++ b/ddio/winfile.cpp
@@ -302,7 +302,7 @@ int ddio_GetFileSysRoots(char **roots, int max_roots) {
   while ((count < max_roots) && (!done)) {
     if (*strptr != 0) {
       strsize = strlen(strptr);
-      string = roots[count] = (char *)mem_malloc(strsize);
+      string = roots[count] = mem_rmalloc<char>(strsize);
       if (!string)
         break;
       // remove the trailing \ from windows
@@ -336,7 +336,7 @@ std::vector<std::filesystem::path> ddio_GetSysRoots() {
   while (!done) {
     if (*strptr != 0) {
       strsize = strlen(strptr);
-      string = (char *)mem_malloc(strsize);
+      string = mem_rmalloc<char>(strsize);
       if (!string)
         break;
       // remove the trailing \ from windows

--- a/ddio/winfile.cpp
+++ b/ddio/winfile.cpp
@@ -412,7 +412,7 @@ void ddio_CleanPath(char *dest, const char *srcPath) {
   // now the fun part, figure out the correct order of the directories
   int *dir_order;
 
-  dir_order = (int *)mem_malloc(sizeof(int) * dirs);
+  dir_order = mem_rmalloc<int>(dirs);
   if (!dir_order) {
     strcpy(dest, srcPath);
     return;

--- a/ddio/winfile.cpp
+++ b/ddio/winfile.cpp
@@ -394,7 +394,7 @@ void ddio_CleanPath(char *dest, const char *srcPath) {
   }
 
   // allocate the memory needed for the separate strings of each directory
-  directories = (char **)mem_malloc(sizeof(char *) * dirs);
+  directories = mem_rmalloc<char *>(dirs);
   if (!directories) {
     strcpy(dest, srcPath);
     return;

--- a/editor/AmbientSoundPattern.cpp
+++ b/editor/AmbientSoundPattern.cpp
@@ -217,7 +217,7 @@ void CAmbientSoundPattern::OnASPNewElement() {
 
   if (new_element.handle != -1) {
 
-    ase *new_sounds = (ase *)mem_malloc(sizeof(*new_sounds) * (asp->num_sounds + 1));
+    auto new_sounds = mem_rmalloc<ase>(asp->num_sounds + 1);
 
     for (int s = 0; s < asp->num_sounds; s++)
       new_sounds[s] = asp->sounds[s];
@@ -252,7 +252,7 @@ void CAmbientSoundPattern::OnASPDeleteElement() {
   if (m_current_element > -1) {
     if (OutrageMessageBox(MBOX_YESNO, "Do you really want to delete sound '%s' from pattern '%s'?",
                           Sounds[asp->sounds[m_current_element].handle].name, asp->name) == IDYES) {
-      new_sounds = (ase *)mem_malloc(sizeof(*new_sounds) * (asp->num_sounds - 1));
+      new_sounds = mem_rmalloc<ase>(asp->num_sounds - 1);
 
       for (int s = 0; s < m_current_element; s++)
         new_sounds[s] = asp->sounds[s];

--- a/editor/BriefEdit.cpp
+++ b/editor/BriefEdit.cpp
@@ -739,7 +739,7 @@ void BEAddTextEffect(TCTEXTDESC *desc, char *text, char *description, int id) {
     mem_free(befx->text);
     befx->text = NULL;
   }
-  befx->text = (char *)mem_malloc(strlen(text) + 1);
+  befx->text = mem_rmalloc<char>(strlen(text) + 1);
   ASSERT(befx->text);
   strcpy(befx->text, text);
 
@@ -1407,7 +1407,7 @@ void CBriefEdit::OnBriefEffectEdit() {
       if (Briefing_screens[scr_index].effects[efx_index].text)
         mem_free(Briefing_screens[scr_index].effects[efx_index].text);
 
-      Briefing_screens[scr_index].effects[efx_index].text = (char *)mem_malloc(dlg.m_Text.GetLength() + 1);
+      Briefing_screens[scr_index].effects[efx_index].text = mem_rmalloc<char>(dlg.m_Text.GetLength() + 1);
       ASSERT(Briefing_screens[scr_index].effects[efx_index].text);
 
       if (Briefing_screens[scr_index].effects[efx_index].text) {
@@ -1651,7 +1651,7 @@ void CBriefEdit::OnBriefEffectText() {
     if (Briefing_screens[c_scr].effects[c_eff].text)
       mem_free(Briefing_screens[c_scr].effects[c_eff].text);
 
-    Briefing_screens[c_scr].effects[c_eff].text = (char *)mem_malloc(dlg.m_Text.GetLength() + 1);
+    Briefing_screens[c_scr].effects[c_eff].text = mem_rmalloc<char>(dlg.m_Text.GetLength() + 1);
     ASSERT(Briefing_screens[c_scr].effects[c_eff].text);
 
     if (Briefing_screens[c_scr].effects[c_eff].text) {

--- a/editor/BriefEdit.cpp
+++ b/editor/BriefEdit.cpp
@@ -1915,7 +1915,7 @@ void CBriefEdit::ParseLayoutScreenFile(char *filename) {
     return;
   }
 
-  layouts = (tLayoutScreen *)mem_malloc(sizeof(tLayoutScreen) * num_layouts);
+  layouts = mem_rmalloc<tLayoutScreen>(num_layouts);
   if (!layouts) {
     mprintf(0, "Out of memory loading layout screens...trying to load %d screens\n", num_layouts);
     num_layouts = 0;

--- a/editor/DallasMainDlg.cpp
+++ b/editor/DallasMainDlg.cpp
@@ -3525,7 +3525,7 @@ int CDallasMainDlg::GetLowestUnusedScriptID(void) {
   max_size = GetChildCount(TVI_ROOT);
   if (max_size == 0)
     return (lowest_id);
-  list = (int *)mem_malloc(sizeof(int) * max_size);
+  list = mem_rmalloc<int>(max_size);
   if (list == NULL)
     return (m_NextScriptID);
 
@@ -7502,7 +7502,7 @@ int CDallasMainDlg::AddNodeToScriptOwnerGroup(int pos, HTREEITEM script_node) {
 
   // Add this node to the appropriate event section list
   if (event_section->num_script_nodes == 0)
-    event_section->script_node_list = (HTREEITEM *)mem_malloc(sizeof(HTREEITEM) * 1);
+    event_section->script_node_list = mem_rmalloc<HTREEITEM>(1);
   else
     event_section->script_node_list = (HTREEITEM *)mem_realloc(
         event_section->script_node_list, sizeof(HTREEITEM) * (event_section->num_script_nodes + 1));
@@ -7552,7 +7552,7 @@ int CDallasMainDlg::AddNodeToScriptGroupingList(HTREEITEM script_node) {
 
   // Since owner does not exist, create a new Script Group entry
   if (m_NumScriptGroups == 0)
-    m_ScriptGroupingList = (tScriptOwnerGroup *)mem_malloc(sizeof(tScriptOwnerGroup) * 1);
+    m_ScriptGroupingList = mem_rmalloc<tScriptOwnerGroup>(1);
   else
     m_ScriptGroupingList =
         (tScriptOwnerGroup *)mem_realloc(m_ScriptGroupingList, sizeof(tScriptOwnerGroup) * (m_NumScriptGroups + 1));

--- a/editor/DallasMainDlg.cpp
+++ b/editor/DallasMainDlg.cpp
@@ -9442,7 +9442,7 @@ int CDallasMainDlg::ParseCustomScriptFile(char *filename, bool show_errors /*=TR
       ClearCustomScriptStorage();
       m_MaxNumCustomScriptLines = CountCustomScriptLines(infile);
       if (m_MaxNumCustomScriptLines > 0) {
-        m_CustomScriptLines = (char **)mem_malloc(sizeof(char *) * m_MaxNumCustomScriptLines);
+        m_CustomScriptLines = mem_rmalloc<char *>(m_MaxNumCustomScriptLines);
         if (m_CustomScriptLines == NULL) {
           MessageBox("ERROR: Ran out of memory allocating custom script block", "Custom Script Parse Error",
                      MB_OK | MB_ICONEXCLAMATION);

--- a/editor/DallasMainDlg.cpp
+++ b/editor/DallasMainDlg.cpp
@@ -4980,7 +4980,7 @@ int CDallasMainDlg::AddDoorToList(char *name) {
     return FALSE;
 
   int pos = m_DoorListSize;
-  m_DoorList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_DoorList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_DoorList[pos] == NULL) {
     MessageBox("Out of memory in AddDoorToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5018,7 +5018,7 @@ int CDallasMainDlg::AddObjectToList(char *name) {
     return FALSE;
 
   int pos = m_ObjectListSize;
-  m_ObjectList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_ObjectList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_ObjectList[pos] == NULL) {
     MessageBox("Out of memory in AddObjectToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5056,7 +5056,7 @@ int CDallasMainDlg::AddRoomToList(char *name) {
     return FALSE;
 
   int pos = m_RoomListSize;
-  m_RoomList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_RoomList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_RoomList[pos] == NULL) {
     MessageBox("Out of memory in AddRoomToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5094,7 +5094,7 @@ int CDallasMainDlg::AddTriggerToList(char *name) {
     return FALSE;
 
   int pos = m_TriggerListSize;
-  m_TriggerList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_TriggerList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_TriggerList[pos] == NULL) {
     MessageBox("Out of memory in AddTriggerToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5132,7 +5132,7 @@ int CDallasMainDlg::AddSoundToList(char *name) {
     return FALSE;
 
   int pos = m_SoundListSize;
-  m_SoundList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_SoundList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_SoundList[pos] == NULL) {
     MessageBox("Out of memory in AddSoundToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5170,7 +5170,7 @@ int CDallasMainDlg::AddTextureToList(char *name) {
     return FALSE;
 
   int pos = m_TextureListSize;
-  m_TextureList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_TextureList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_TextureList[pos] == NULL) {
     MessageBox("Out of memory in AddTextureToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5208,7 +5208,7 @@ int CDallasMainDlg::AddSpecnameToList(char *name) {
     return FALSE;
 
   int pos = m_SpecnameListSize;
-  m_SpecnameList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_SpecnameList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_SpecnameList[pos] == NULL) {
     MessageBox("Out of memory in AddSpecnameToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5246,7 +5246,7 @@ int CDallasMainDlg::AddPathToList(char *name) {
     return FALSE;
 
   int pos = m_PathListSize;
-  m_PathList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_PathList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_PathList[pos] == NULL) {
     MessageBox("Out of memory in AddPathToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5284,7 +5284,7 @@ int CDallasMainDlg::AddMatcenToList(char *name) {
     return FALSE;
 
   int pos = m_MatcenListSize;
-  m_MatcenList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_MatcenList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_MatcenList[pos] == NULL) {
     MessageBox("Out of memory in AddMatcenToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5322,7 +5322,7 @@ int CDallasMainDlg::AddGoalToList(char *name) {
     return FALSE;
 
   int pos = m_GoalListSize;
-  m_GoalList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_GoalList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_GoalList[pos] == NULL) {
     MessageBox("Out of memory in AddGoalToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5360,7 +5360,7 @@ int CDallasMainDlg::AddStrmAudioToList(char *name) {
     return FALSE;
 
   int pos = m_StrmAudioListSize;
-  m_StrmAudioList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_StrmAudioList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_StrmAudioList[pos] == NULL) {
     MessageBox("Out of memory in AddStrmAudioToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5398,7 +5398,7 @@ int CDallasMainDlg::AddMessageNameToList(char *name) {
     return FALSE;
 
   int pos = m_MessageNameListSize;
-  m_MessageNameList[pos] = (char *)mem_malloc(strlen(name) + 1);
+  m_MessageNameList[pos] = mem_rmalloc<char>(strlen(name) + 1);
   if (m_MessageNameList[pos] == NULL) {
     MessageBox("Out of memory in AddMessageNameToList()!", "Error!", MB_OK | MB_ICONEXCLAMATION);
     return FALSE;
@@ -5512,7 +5512,7 @@ int CDallasMainDlg::AddUserTypeValue(char *utype_name, char *value_name) {
   // Store the new value at the current position
   tEnumValueEntry *value_entry = &entry->values[j];
   value_entry->value = new_value;
-  value_entry->name = (char *)mem_malloc(strlen(value_name) + 1);
+  value_entry->name = mem_rmalloc<char>(strlen(value_name) + 1);
   if (value_entry->name == NULL) {
     MessageBox("ERROR: Out of mem in AddUserTypeValue()!", "Error!");
     return (-1);
@@ -5582,7 +5582,7 @@ int CDallasMainDlg::ChangeValueName(char *utype_name, char *old_name, char *new_
       mem_free(value_entry->name);
 
       // Add the new name
-      value_entry->name = (char *)mem_malloc(strlen(new_name) + 1);
+      value_entry->name = mem_rmalloc<char>(strlen(new_name) + 1);
       if (value_entry->name == NULL) {
         MessageBox("ERROR: Out of mem in ChangeValueName()!", "Error!");
         return FALSE;
@@ -6185,7 +6185,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
           done = 1;
         else if (m_NumFunctionCategories < MAX_CATEGORIES) {
           if (GetFunctionCategoryID(line) == INVALID_CATEGORY) { // don't add duplicate categories
-            m_FunctionCategories[m_NumFunctionCategories] = (char *)mem_malloc(strlen(line) + 1);
+            m_FunctionCategories[m_NumFunctionCategories] = mem_rmalloc<char>(strlen(line) + 1);
             if (m_FunctionCategories[m_NumFunctionCategories] == NULL) {
               FunctionFileParseError(NO_MEM_ERR, linenum, filename);
               cfclose(ifile);
@@ -6222,7 +6222,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
         enum_entry = NULL;
       } else {
         enum_entry = &m_EnumDatabase[m_NumEnums++];
-        enum_entry->name = (char *)mem_malloc(strlen(enum_name) + 1);
+        enum_entry->name = mem_rmalloc<char>(strlen(enum_name) + 1);
         if (enum_entry->name == NULL) {
           FunctionFileParseError(NO_MEM_ERR, linenum, filename);
           cfclose(ifile);
@@ -6240,7 +6240,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
         // Add the default (-1:None) value
         tEnumValueEntry *value_entry;
         value_entry = &enum_entry->values[enum_entry->num_values++];
-        value_entry->name = (char *)mem_malloc(strlen(USERTYPE_NONE) + 1);
+        value_entry->name = mem_rmalloc<char>(strlen(USERTYPE_NONE) + 1);
         if (value_entry->name == NULL) {
           FunctionFileParseError(NO_MEM_ERR, linenum, filename);
           cfclose(ifile);
@@ -6266,7 +6266,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
         enum_entry = NULL;
       } else {
         enum_entry = &m_EnumDatabase[m_NumEnums++];
-        enum_entry->name = (char *)mem_malloc(strlen(enum_name) + 1);
+        enum_entry->name = mem_rmalloc<char>(strlen(enum_name) + 1);
         if (enum_entry->name == NULL) {
           FunctionFileParseError(NO_MEM_ERR, linenum, filename);
           cfclose(ifile);
@@ -6313,7 +6313,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
             value_entry = NULL;
           } else {
             value_entry = &enum_entry->values[enum_entry->num_values++];
-            value_entry->name = (char *)mem_malloc(strlen(enum_value_name) + 1);
+            value_entry->name = mem_rmalloc<char>(strlen(enum_value_name) + 1);
             if (value_entry->name == NULL) {
               FunctionFileParseError(NO_MEM_ERR, linenum, filename);
               cfclose(ifile);
@@ -6345,7 +6345,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
         flag_entry = NULL;
       } else {
         flag_entry = &m_FlagDatabase[m_NumFlags++];
-        flag_entry->name = (char *)mem_malloc(strlen(flag_name) + 1);
+        flag_entry->name = mem_rmalloc<char>(strlen(flag_name) + 1);
         if (flag_entry->name == NULL) {
           FunctionFileParseError(NO_MEM_ERR, linenum, filename);
           cfclose(ifile);
@@ -6390,7 +6390,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
             value_entry = NULL;
           } else {
             value_entry = &flag_entry->values[flag_entry->num_values++];
-            value_entry->name = (char *)mem_malloc(strlen(flag_value_name) + 1);
+            value_entry->name = mem_rmalloc<char>(strlen(flag_value_name) + 1);
             if (value_entry->name == NULL) {
               FunctionFileParseError(NO_MEM_ERR, linenum, filename);
               cfclose(ifile);
@@ -6439,7 +6439,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
       RemoveTrailingWhitespace(linebuf);
       line = SkipInitialWhitespace(linebuf);
 
-      action->desc = (char *)mem_malloc(strlen(line) + 1);
+      action->desc = mem_rmalloc<char>(strlen(line) + 1);
       if (action->desc == NULL) {
         FunctionFileParseError(NO_MEM_ERR, linenum, filename);
         cfclose(ifile);
@@ -6455,7 +6455,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
       RemoveTrailingWhitespace(linebuf);
       line = SkipInitialWhitespace(linebuf);
 
-      action->func = (char *)mem_malloc(strlen(line) + 1);
+      action->func = mem_rmalloc<char>(strlen(line) + 1);
       if (action->func == NULL) {
         FunctionFileParseError(NO_MEM_ERR, linenum, filename);
         cfclose(ifile);
@@ -6487,7 +6487,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
       if (!done)
         FunctionFileParseError(UEOF_ERR, linenum, filename);
 
-      action->help = (char *)mem_malloc(strlen(helpbuf) + 1);
+      action->help = mem_rmalloc<char>(strlen(helpbuf) + 1);
       if (action->help == NULL) {
         FunctionFileParseError(NO_MEM_ERR, linenum, filename);
         cfclose(ifile);
@@ -6528,7 +6528,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
       RemoveTrailingWhitespace(linebuf);
       line = SkipInitialWhitespace(linebuf);
 
-      query->desc = (char *)mem_malloc(strlen(line) + 1);
+      query->desc = mem_rmalloc<char>(strlen(line) + 1);
       if (query->desc == NULL) {
         FunctionFileParseError(NO_MEM_ERR, linenum, filename);
         cfclose(ifile);
@@ -6544,7 +6544,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
       RemoveTrailingWhitespace(linebuf);
       line = SkipInitialWhitespace(linebuf);
 
-      query->func = (char *)mem_malloc(strlen(line) + 1);
+      query->func = mem_rmalloc<char>(strlen(line) + 1);
       if (query->func == NULL) {
         FunctionFileParseError(NO_MEM_ERR, linenum, filename);
         cfclose(ifile);
@@ -6576,7 +6576,7 @@ void CDallasMainDlg::ParseFunctionFile(char *filename, bool show_errors /*=TRUE*
       if (!done)
         FunctionFileParseError(UEOF_ERR, linenum, filename);
 
-      query->help = (char *)mem_malloc(strlen(helpbuf) + 1);
+      query->help = mem_rmalloc<char>(strlen(helpbuf) + 1);
       if (query->help == NULL) {
         FunctionFileParseError(NO_MEM_ERR, linenum, filename);
         cfclose(ifile);
@@ -6772,7 +6772,7 @@ bool CDallasMainDlg::ValidateActionNode(HTREEITEM node, int linenum)
         child_node=m_ScriptTree.GetChildItem(node);
 
         // Make a copy of description (so null chars can be added)
-        desc_copy=(char *)mem_malloc(strlen(desc)+1);
+        desc_copy=mem_rmalloc<char>(strlen(desc)+1);
         if(desc_copy==NULL) {
                 MessageBox("ERROR: Out of memory in ValidateActionNode()!","Out of Memory
 Error!",MB_OK|MB_ICONEXCLAMATION); return FALSE;
@@ -7047,7 +7047,7 @@ bool CDallasMainDlg::ValidateQueryNode(HTREEITEM node, int linenum)
         child_node=m_ScriptTree.GetChildItem(node);
 
         // Make a copy of description (so null chars can be added)
-        desc_copy=(char *)mem_malloc(strlen(desc)+1);
+        desc_copy=mem_rmalloc<char>(strlen(desc)+1);
         if(desc_copy==NULL) {
                 MessageBox("ERROR: Out of memory in ValidateQueryNode()!","Out of Memory
 Error!",MB_OK|MB_ICONEXCLAMATION); return FALSE;
@@ -7137,7 +7137,7 @@ void CDallasMainDlg::FillActionMenu(CMenu *action_menu, int command_offset) {
     // Scan the list, adding Actions that match the current category
     for (k = 0; k < m_NumActions; k++)
       if (m_ActionDatabase[k].category == j) {
-        char *temp_desc = (char *)mem_malloc(strlen(m_ActionDatabase[k].desc) + 1);
+        char *temp_desc = mem_rmalloc<char>(strlen(m_ActionDatabase[k].desc) + 1);
         if (temp_desc == NULL) {
           MessageBox("Out of memory error in FillActionMenu()!", "Memory Error!", MB_OK | MB_ICONEXCLAMATION);
           return;
@@ -7175,7 +7175,7 @@ void CDallasMainDlg::FillQueryMenu(CMenu *query_menu, int command_offset, int va
     // Scan the list, adding queries that match the current category
     for (k = 0; k < m_NumActions; k++)
       if (m_QueryDatabase[k].category == j) {
-        char *temp_desc = (char *)mem_malloc(strlen(m_QueryDatabase[k].desc) + 1);
+        char *temp_desc = mem_rmalloc<char>(strlen(m_QueryDatabase[k].desc) + 1);
         if (temp_desc == NULL) {
           MessageBox("Out of memory error in FillQueryMenu()!", "Memory Error!", MB_OK | MB_ICONEXCLAMATION);
           return;
@@ -7848,7 +7848,7 @@ int CDallasMainDlg::ParseSourceScript(char *filename) {
                 value_entry = NULL;
               } else {
                 value_entry = &enum_entry->values[enum_entry->num_values++];
-                value_entry->name = (char *)mem_malloc(strlen(enum_value_name) + 1);
+                value_entry->name = mem_rmalloc<char>(strlen(enum_value_name) + 1);
                 if (value_entry->name == NULL) {
                   FunctionFileParseError(NO_MEM_ERR, linenum, filename);
                   cfclose(infile);
@@ -9466,7 +9466,7 @@ int CDallasMainDlg::ParseCustomScriptFile(char *filename, bool show_errors /*=TR
 
         // Store this line
         if (m_NumCustomScriptLines < m_MaxNumCustomScriptLines) {
-          m_CustomScriptLines[m_NumCustomScriptLines] = (char *)mem_malloc(strlen(linebuf) + 1);
+          m_CustomScriptLines[m_NumCustomScriptLines] = mem_rmalloc<char>(strlen(linebuf) + 1);
           if (m_CustomScriptLines[m_NumCustomScriptLines] == NULL) {
             MessageBox("ERROR: Ran out of memory parsing custom script block", "Custom Script Parse Error",
                        MB_OK | MB_ICONEXCLAMATION);
@@ -13737,7 +13737,7 @@ void CDallasMainDlg::AddActionParameterNodes(HTREEITEM action_node)
         if(desc==NULL) return;
 
         // Make a copy of description (so null chars can be added)
-        desc_copy=(char *)mem_malloc(strlen(desc)+1);
+        desc_copy=mem_rmalloc<char>(strlen(desc)+1);
         if(desc_copy==NULL) {
                 MessageBox("ERROR: Out of memory adding action parameter node!","Out of Memory
 Error!",MB_OK|MB_ICONEXCLAMATION); return;
@@ -13857,7 +13857,7 @@ void CDallasMainDlg::AddQueryParameterNodes(HTREEITEM query_node)
         if(desc==NULL) return;
 
         // Make a copy of description (so null chars can be added)
-        desc_copy=(char *)mem_malloc(strlen(desc)+1);
+        desc_copy=mem_rmalloc<char>(strlen(desc)+1);
         if(desc_copy==NULL) {
                 MessageBox("ERROR: Out of memory adding query parameter node!","Out of Memory
 Error!",MB_OK|MB_ICONEXCLAMATION); return;

--- a/editor/EPath.cpp
+++ b/editor/EPath.cpp
@@ -101,7 +101,7 @@ int AllocGamePath() {
       GamePaths[i].num_nodes = 0;
       GamePaths[i].flags = 0;
 
-      GamePaths[i].pathnodes = (node *)mem_malloc(MAX_NODES_PER_PATH * sizeof(node));
+      GamePaths[i].pathnodes = mem_rmalloc<node>(MAX_NODES_PER_PATH);
       mprintf(0, "Path %d got some\n", i);
 
       Num_game_paths++;

--- a/editor/Erooms.cpp
+++ b/editor/Erooms.cpp
@@ -1239,7 +1239,7 @@ void FixConcaveFaces(room *rp, int *facelist, int facecount) {
       // Allocate memory for our new faces
       int nfaces = rp->num_faces + num_new_faces;
 
-      newfaces = (face *)mem_malloc(nfaces * sizeof(face));
+      newfaces = mem_rmalloc<face>(nfaces);
       ASSERT(newfaces != NULL);
 
       // Copy all the faces into our new array
@@ -1248,9 +1248,9 @@ void FixConcaveFaces(room *rp, int *facelist, int facecount) {
         if (t != facelist[i]) {
           int nverts = rp->faces[t].num_verts;
 
-          newfaces[t].face_verts = (int16_t *)mem_malloc(nverts * sizeof(int16_t));
+          newfaces[t].face_verts = mem_rmalloc<int16_t>(nverts);
           ASSERT(newfaces[t].face_verts != NULL);
-          newfaces[t].face_uvls = (roomUVL *)mem_malloc(nverts * sizeof(roomUVL));
+          newfaces[t].face_uvls = mem_rmalloc<roomUVL>(nverts);
           ASSERT(newfaces[t].face_uvls != NULL);
 
           newfaces[t].normal = rp->faces[t].normal;
@@ -1268,9 +1268,9 @@ void FixConcaveFaces(room *rp, int *facelist, int facecount) {
         {
           int nverts = 3;
 
-          newfaces[t].face_verts = (int16_t *)mem_malloc(nverts * sizeof(int16_t));
+          newfaces[t].face_verts = mem_rmalloc<int16_t>(nverts);
           ASSERT(newfaces[t].face_verts != NULL);
-          newfaces[t].face_uvls = (roomUVL *)mem_malloc(nverts * sizeof(roomUVL));
+          newfaces[t].face_uvls = mem_rmalloc<roomUVL>(nverts);
           ASSERT(newfaces[t].face_uvls != NULL);
 
           newfaces[t].tmap = rp->faces[t].tmap;

--- a/editor/Erooms.cpp
+++ b/editor/Erooms.cpp
@@ -1343,7 +1343,7 @@ void ReInitRoomFace(face *fp, int nverts) {
 
   fp->face_verts = (int16_t *)mem_malloc(nverts * sizeof(*fp->face_verts));
   ASSERT(fp->face_verts != NULL);
-  fp->face_uvls = (roomUVL *)mem_malloc(nverts * sizeof(*fp->face_uvls));
+  fp->face_uvls = mem_rmalloc<roomUVL>(nverts);
   ASSERT(fp->face_uvls != NULL);
 }
 
@@ -1395,7 +1395,7 @@ int RoomAddVertices(room *rp, int num_new_verts) {
   if (num_new_verts == 0)
     return 0;
 
-  vector *newverts = (vector *)mem_malloc((rp->num_verts + num_new_verts) * sizeof(*newverts));
+  auto newverts = mem_rmalloc<vector>(rp->num_verts + num_new_verts);
 
   ASSERT(newverts != NULL);
 
@@ -1422,7 +1422,7 @@ int RoomAddFaces(room *rp, int num_new_faces) {
   if (num_new_faces == 0)
     return 0;
 
-  face *newfaces = (face *)mem_malloc((rp->num_faces + num_new_faces) * sizeof(*newfaces));
+  auto newfaces = mem_rmalloc<face>(rp->num_faces + num_new_faces);
 
   ASSERT(newfaces != NULL);
 
@@ -1635,7 +1635,7 @@ void DeleteRoomVert(room *rp, int vertnum) {
         fp->face_verts[v]--;
 
   // malloc new list
-  newverts = (vector *)mem_malloc(sizeof(*newverts) * (rp->num_verts - 1));
+  newverts = mem_rmalloc<vector>(rp->num_verts - 1);
   ASSERT(newverts != NULL);
 
   // Copy verts to new list
@@ -1717,7 +1717,7 @@ void DeleteRoomFace(room *rp, int facenum, bool delete_unused_verts) {
   }
 
   // Allocate new face list
-  newfaces = (face *)mem_malloc(sizeof(*newfaces) * (rp->num_faces - 1));
+  newfaces = mem_rmalloc<face>(rp->num_faces - 1);
   ASSERT(newfaces != NULL);
 
   // Copy faces over
@@ -1810,7 +1810,7 @@ void DeleteRoomPortal(room *rp, int portalnum) {
   if (rp->num_portals == 1)
     newportals = NULL;
   else {
-    newportals = (portal *)mem_malloc(sizeof(*newportals) * (rp->num_portals - 1));
+    newportals = mem_rmalloc<portal>(rp->num_portals - 1);
     ASSERT(newportals != NULL);
   }
 
@@ -1956,7 +1956,7 @@ void CopyRoom(room *destp, room *srcp) {
 
   // Copy doorway info
   if (srcp->doorway_data) {
-    destp->doorway_data = (doorway *)mem_malloc(sizeof(*destp->doorway_data));
+    destp->doorway_data = mem_rmalloc<doorway>();
     *destp->doorway_data = *srcp->doorway_data;
   }
 
@@ -1973,9 +1973,7 @@ void CopyRoom(room *destp, room *srcp) {
 // Adds a new portal for this room.  Returns the portal number.
 // Initializes the flags
 int AddPortal(room *rp) {
-  portal *newlist;
-
-  newlist = (portal *)mem_malloc(sizeof(*newlist) * (rp->num_portals + 1));
+  auto newlist = mem_rmalloc<portal>(rp->num_portals + 1);
 
   // Copy from old list to new list, and free old list
   if (rp->num_portals) {

--- a/editor/FilePageAddDlg.cpp
+++ b/editor/FilePageAddDlg.cpp
@@ -411,7 +411,7 @@ bool CFilePageAddDlg::Quit(void) {
       return true;
     }
 
-    int *sel_items = (int *)mem_malloc(sizeof(int) * m_NumberOfSelectedFiles);
+    int *sel_items = mem_rmalloc<int>(m_NumberOfSelectedFiles);
     if (!sel_items) {
       mem_free(m_SelectedFiles);
       m_SelectedFiles = NULL;

--- a/editor/FilePageAddDlg.cpp
+++ b/editor/FilePageAddDlg.cpp
@@ -282,7 +282,7 @@ inline void CFileList::setPath(CString path) {
   if (temp.Right(1) != "\\")
     temp += "\\";
 
-  buffer = (char *)mem_malloc(temp.GetLength() + 1);
+  buffer = mem_rmalloc<char>(temp.GetLength() + 1);
 
   if (!buffer)
     return;

--- a/editor/FilePageAddDlg.cpp
+++ b/editor/FilePageAddDlg.cpp
@@ -404,7 +404,7 @@ bool CFilePageAddDlg::Quit(void) {
     m_SelectedFiles = NULL;
   } else {
 
-    m_SelectedFiles = (char **)mem_malloc(m_NumberOfSelectedFiles * sizeof(char *));
+    m_SelectedFiles = mem_rmalloc<char *>(m_NumberOfSelectedFiles);
     if (!m_SelectedFiles) {
       m_SelectedFiles = NULL;
       m_NumberOfSelectedFiles = 0;

--- a/editor/FilePageDialog.cpp
+++ b/editor/FilePageDialog.cpp
@@ -184,7 +184,7 @@ int CFilePageDialog::CreateIndexMap(int **index_map, int listbox_id) {
 
   int *map;
 
-  map = *index_map = (int *)mem_malloc(sizeof(int) * listbox_count);
+  map = *index_map = mem_rmalloc<int>(listbox_count);
   if (!map)
     return 0;
   n = 0;

--- a/editor/Group.cpp
+++ b/editor/Group.cpp
@@ -236,16 +236,15 @@ void FreeGroup(group *g) {
 //					attachroom, attachface - where group attaches when pasted
 // Returns:		pointer to group
 group *CopyGroup(int nrooms, int *roomnums, int attachroom, int attachface) {
-  group *g;
   int r;
   int room_xlate[MAX_ROOMS];
   int n_objects = 0, n_triggers = 0, n_doors = 0;
 
   // Allocate group & room arrays
-  g = (group *)mem_malloc(sizeof(*g));
+  auto g = mem_rmalloc<group>();
   ASSERT(g != NULL);
   g->nrooms = nrooms;
-  g->rooms = (room *)mem_malloc(sizeof(*g->rooms) * nrooms);
+  g->rooms = mem_rmalloc<room>(nrooms);
   ASSERT(g->rooms != NULL);
 
   // Initialize xlate list
@@ -296,7 +295,7 @@ group *CopyGroup(int nrooms, int *roomnums, int attachroom, int attachface) {
     int objnum = 0;
 
     // Get memory for objects
-    g->objects = (object *)mem_malloc(sizeof(*g->objects) * n_objects);
+    g->objects = mem_rmalloc<object>(n_objects);
 
     // Go through list of rooms & copy the objects
     for (r = 0; r < nrooms; r++) {
@@ -344,7 +343,7 @@ group *CopyGroup(int nrooms, int *roomnums, int attachroom, int attachface) {
     int trignum = 0;
 
     // Get memory for triggers
-    g->triggers = (trigger *)mem_malloc(sizeof(*g->triggers) * n_triggers);
+    g->triggers = mem_rmalloc<trigger>(n_triggers);
 
     for (int t = 0; t < Num_triggers; t++)
       if (room_xlate[Triggers[t].roomnum] != -1) {
@@ -754,7 +753,6 @@ group *LoadGroup(char *filename) {
   CFILE *ifile;
   char tag[4];
   int version, level_version;
-  group *g;
   int i;
 
   ifile = cfopen(filename, "rb");
@@ -794,7 +792,7 @@ group *LoadGroup(char *filename) {
   ReadTextureList(ifile);
 
   // Allocate group
-  g = (group *)mem_malloc(sizeof(*g));
+  auto g = mem_rmalloc<group>();
 
   // Read group info
   g->nrooms = cf_ReadInt(ifile);
@@ -810,7 +808,7 @@ group *LoadGroup(char *filename) {
     g->nobjects = g->ndoors = g->ntriggers = 0;
 
   // Allocate room and vertex arrays
-  g->rooms = (room *)mem_malloc(sizeof(*g->rooms) * g->nrooms);
+  g->rooms = mem_rmalloc<room>(g->nrooms);
 
   // Read rooms
   for (i = 0; i < g->nrooms; i++) {
@@ -825,11 +823,11 @@ group *LoadGroup(char *filename) {
 
     // Allocate objects array
     if (g->nobjects)
-      g->objects = (object *)mem_malloc(sizeof(*g->objects) * g->nobjects);
+      g->objects = mem_rmalloc<object>(g->nobjects);
 
     // Allocate triggers array
     if (g->ntriggers)
-      g->triggers = (trigger *)mem_malloc(sizeof(*g->triggers) * g->ntriggers);
+      g->triggers = mem_rmalloc<trigger>(g->ntriggers);
 
     // Read objects
     for (i = 0; i < g->nobjects; i++)

--- a/editor/MainFrm.cpp
+++ b/editor/MainFrm.cpp
@@ -3456,7 +3456,7 @@ void CMainFrame::OnShowAllCheckedOut() {
   char text_buf[10000], *t;
 
   // Get all locked pages
-  mngs_Pagelock *LockList = (mngs_Pagelock *)mem_malloc(MAX_LOCKLIST_ELEMENTS * sizeof(mngs_Pagelock));
+  mngs_Pagelock *LockList = mem_rmalloc<mngs_Pagelock>(MAX_LOCKLIST_ELEMENTS);
   int n = mng_GetListOfLocks(LockList, MAX_LOCKLIST_ELEMENTS, NULL);
 
   // ASSERT(n >= 1);		//always dummy page?

--- a/editor/MainFrm.cpp
+++ b/editor/MainFrm.cpp
@@ -3171,7 +3171,7 @@ void CMainFrame::OnHotspotTga() {
     return;
   }
 
-  buffer = (char *)mem_malloc(strlen(tga_path.GetBuffer(1)) + 1);
+  buffer = mem_rmalloc<char>(strlen(tga_path.GetBuffer(1)) + 1);
   if (!buffer) {
     Int3(); // find Jeff
     return;

--- a/editor/MegacellDialog.cpp
+++ b/editor/MegacellDialog.cpp
@@ -375,7 +375,7 @@ void CMegacellDialog::OnDeleteMegacell() {
     uint16_t texindices[MAX_MEGACELL_WIDTH * MAX_MEGACELL_HEIGHT];
 
     for (i = 0; i < MAX_MEGACELL_WIDTH * MAX_MEGACELL_HEIGHT; i++) {
-      texnames[i] = (char *)mem_malloc(PAGENAME_LEN);
+      texnames[i] = mem_rmalloc<char>(PAGENAME_LEN);
       ASSERT(texnames[i]);
       if (!can_delete[i])
         continue;

--- a/editor/ObjCScript.cpp
+++ b/editor/ObjCScript.cpp
@@ -239,7 +239,7 @@ char *LoadScript(const char *filename) {
 
   cfclose(file);
 
-  source = (char *)mem_malloc(strlen(temp.GetBuffer(1)) + 1);
+  source = mem_rmalloc<char>(strlen(temp.GetBuffer(1)) + 1);
   if (!source)
     return false;
   strcpy(source, temp.GetBuffer(1));
@@ -604,7 +604,7 @@ char *AddScriptBlockToScript(char *script, const char *newname, const char *type
   sprintf(newhdr, SCRHDR_FORMAT, type_str, newname);
   sprintf(newblk, SCRIPT_FORMAT, newname, newhdr);
 
-  newsrc = (char *)mem_malloc(strlen(script) + strlen(newblk) + 1);
+  newsrc = mem_rmalloc<char>(strlen(script) + strlen(newblk) + 1);
   if (!newsrc) {
     mprintf(1, "Allocation failure in creating new script buffer.\n");
     return NULL;
@@ -668,7 +668,7 @@ char *AddEventBlockToScript(char *script, const char *evtname, const char *scrip
           postblk[postlen] = 0;
           sprintf(evtblk, EVT_STATEMENT, evtname);
 
-          newtxt = (char *)mem_malloc(strlen(preblk) + strlen(postblk) + strlen(evtblk) + 1);
+          newtxt = mem_rmalloc<char>(strlen(preblk) + strlen(postblk) + strlen(evtblk) + 1);
           sprintf(newtxt, "%s%s%s", preblk, evtblk, postblk);
 
           delete[] postblk;

--- a/editor/ObjectDialog.cpp
+++ b/editor/ObjectDialog.cpp
@@ -1160,7 +1160,7 @@ void CObjectDialog::OnObjectSwapButton() {
           int o_index = ObjCreate(Object_info[d_id].type, d_id, room, &pos, &orient, parent);
 
           if (temp_name[0] != '\0') {
-            Objects[o_index].name = (char *)mem_malloc(strlen(temp_name) + 1);
+            Objects[o_index].name = mem_rmalloc<char>(strlen(temp_name) + 1);
             strcpy(Objects[o_index].name, temp_name);
           }
         }

--- a/editor/Read3ds.cpp
+++ b/editor/Read3ds.cpp
@@ -204,8 +204,8 @@ int Read3DSMaxFile(char *filename) {
   Nest_level = 0;
 
   // Alloc space for reading stuff in
-  Reading_room.faces = (reading_face *)mem_malloc(MAX_READING_ROOM_FACES * sizeof(reading_face));
-  Reading_room.verts = (vector *)mem_malloc(MAX_VERTS_PER_ROOM * sizeof(vector));
+  Reading_room.faces = mem_rmalloc<reading_face>(MAX_READING_ROOM_FACES);
+  Reading_room.verts = mem_rmalloc<vector>(MAX_VERTS_PER_ROOM);
 
   Reading_room.num_faces = 0;
   Reading_room.num_verts = 0;

--- a/editor/Read3ds.cpp
+++ b/editor/Read3ds.cpp
@@ -371,7 +371,7 @@ skip_combine:;
     }
 
     ASSERT(rp->name == NULL);
-    rp->name = (char *)mem_malloc(strlen(roomname) + 1);
+    rp->name = mem_rmalloc<char>(strlen(roomname) + 1);
     strcpy(rp->name, roomname);
 
     // Save it out to disk (locally)

--- a/editor/ScriptEditorDlg.cpp
+++ b/editor/ScriptEditorDlg.cpp
@@ -246,7 +246,7 @@ bool CScriptEditorDlg::FindNext(char *w) {
 
   // Make a copy of the script to work with
   char *text;
-  text = (char *)mem_malloc(GetScriptLength());
+  text = mem_rmalloc<char>(GetScriptLength());
   strcpy(text, GetScript());
   max = GetScriptLength();
 

--- a/editor/ScriptLevelInterface.cpp
+++ b/editor/ScriptLevelInterface.cpp
@@ -1249,7 +1249,7 @@ bool CScriptLevelInterface::DeleteLevel() {
 
   if (list_size == 0)
     return false;
-  int *index_map = (int *)mem_malloc(list_size * sizeof(int));
+  int *index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return false;
 
@@ -1394,7 +1394,7 @@ bool CScriptLevelInterface::DeleteScript() {
 
   if (list_size == 0)
     return false;
-  int *index_map = (int *)mem_malloc(list_size * sizeof(int));
+  int *index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return false;
 
@@ -1511,7 +1511,7 @@ bool CScriptLevelInterface::CheckInScripts() {
 
   if (list_size == 0)
     return false;
-  int *index_map = (int *)mem_malloc(list_size * sizeof(int));
+  int *index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return false;
 
@@ -1619,7 +1619,7 @@ bool CScriptLevelInterface::CheckInLevels() {
 
   if (list_size == 0)
     return false;
-  int *index_map = (int *)mem_malloc(list_size * sizeof(int));
+  int *index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return false;
 
@@ -1759,7 +1759,7 @@ bool CScriptLevelInterface::CheckOutScripts() {
 
   if (list_size == 0)
     return false;
-  int *index_map = (int *)mem_malloc(list_size * sizeof(int));
+  int *index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return false;
 
@@ -1871,7 +1871,7 @@ bool CScriptLevelInterface::CheckOutLevels() {
 
   if (list_size == 0)
     return false;
-  int *index_map = (int *)mem_malloc(list_size * sizeof(int));
+  int *index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return false;
 
@@ -2015,7 +2015,7 @@ bool CScriptLevelInterface::UndoCheckOutScripts() {
 
   if (list_size == 0)
     return false;
-  int *index_map = (int *)mem_malloc(list_size * sizeof(int));
+  int *index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return false;
 
@@ -2126,7 +2126,7 @@ bool CScriptLevelInterface::UndoCheckOutLevels() {
 
   if (list_size == 0)
     return false;
-  int *index_map = (int *)mem_malloc(list_size * sizeof(int));
+  int *index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return false;
 

--- a/editor/ScriptMassCompile.cpp
+++ b/editor/ScriptMassCompile.cpp
@@ -145,7 +145,7 @@ void CScriptMassCompile::OnBuild() {
 
   if (list_size == 0)
     return;
-  index_map = (int *)mem_malloc(list_size * sizeof(int));
+  index_map = mem_rmalloc<int>(list_size);
   if (!index_map)
     return;
 

--- a/editor/ScriptStudio.cpp
+++ b/editor/ScriptStudio.cpp
@@ -463,7 +463,7 @@ bool CScriptStudio::FindNext(char *w) {
 
   // Make a copy of the script to work with
   char *text;
-  text = (char *)mem_malloc(m_EditText.GetLength() + 1);
+  text = mem_rmalloc<char>(m_EditText.GetLength() + 1);
   if (!text)
     Int3();
   strcpy(text, (LPCSTR)m_EditText);

--- a/editor/ScriptSyncDialog.cpp
+++ b/editor/ScriptSyncDialog.cpp
@@ -308,7 +308,7 @@ void CScriptSyncDialog::BuildList(void) {
   if (m_NumFiles == 0)
     return;
 
-  m_Files = (tFileInfo *)mem_malloc(sizeof(tFileInfo) * m_NumFiles);
+  m_Files = mem_rmalloc<tFileInfo>(m_NumFiles);
   m_NumFiles = 0;
 
   if (ManageFindFirst(buffer, "*.cpp")) {

--- a/editor/ScriptWizard.cpp
+++ b/editor/ScriptWizard.cpp
@@ -317,7 +317,7 @@ void CScriptWizard::OnEditScript() {
 
     FreeScript(m_ScriptSource);
     studio.GetText(tempstr);
-    m_ScriptSource = (char *)mem_malloc(tempstr.GetLength() + 1);
+    m_ScriptSource = mem_rmalloc<char>(tempstr.GetLength() + 1);
 
     if (m_ScriptSource) {
       strcpy(m_ScriptSource, (LPCSTR)tempstr);

--- a/editor/TableManage.cpp
+++ b/editor/TableManage.cpp
@@ -393,7 +393,7 @@ void GenericPageList::SaveSelected(CEdit *description) {
 
   // Get Copy of new Description text
   description->GetWindowText(new_descrip);
-  new_text = (char *)mem_malloc(strlen(new_descrip.GetBuffer(0)) + 1);
+  new_text = mem_rmalloc<char>(strlen(new_descrip.GetBuffer(0)) + 1);
   ASSERT(new_text); // out of memory!
   sprintf(new_text, "%s", new_descrip.GetBuffer(0));
 

--- a/editor/TerrainDialog.cpp
+++ b/editor/TerrainDialog.cpp
@@ -1750,7 +1750,7 @@ void CTerrainDialog::OnTerrainOcclusion() {
 
   for (int i = 0; i < 256; i++) {
     memset(Terrain_occlusion_map[i], 0, 32);
-    touch_buffer[i] = (uint8_t *)mem_malloc(256);
+    touch_buffer[i] = mem_rmalloc<uint8_t>(256);
     ASSERT(touch_buffer[i]);
     memset(touch_buffer[i], 255, 256);
   }

--- a/editor/TextureGrWnd.cpp
+++ b/editor/TextureGrWnd.cpp
@@ -1548,7 +1548,7 @@ BOOL CTextureGrWnd::OnCommand(WPARAM wParam, LPARAM lParam) {
       }
 
       if (strlen(tempname)) {
-        curobj->name = (char *)mem_malloc(strlen(tempname) + 1);
+        curobj->name = mem_rmalloc<char>(strlen(tempname) + 1);
         strcpy(curobj->name, tempname);
       }
 
@@ -1586,14 +1586,14 @@ BOOL CTextureGrWnd::OnCommand(WPARAM wParam, LPARAM lParam) {
 
         if (!dlg.m_Module.IsEmpty()) {
           char module_name[MAX_MODULENAME_LEN];
-          curobj->custom_default_module_name = (char *)mem_malloc(dlg.m_Module.GetLength() + 1);
+          curobj->custom_default_module_name = mem_rmalloc<char>(dlg.m_Module.GetLength() + 1);
 
           ddio_SplitPath(dlg.m_Module.GetBuffer(0), NULL, module_name, NULL);
           strcpy(curobj->custom_default_module_name, module_name);
         }
 
         if (!dlg.m_Name.IsEmpty()) {
-          curobj->custom_default_script_name = (char *)mem_malloc(dlg.m_Name.GetLength() + 1);
+          curobj->custom_default_script_name = mem_rmalloc<char>(dlg.m_Name.GetLength() + 1);
           strcpy(curobj->custom_default_script_name, dlg.m_Name.GetBuffer(0));
         }
       }

--- a/editor/WorldObjectsDoorDialog.cpp
+++ b/editor/WorldObjectsDoorDialog.cpp
@@ -634,7 +634,7 @@ void CWorldObjectsDoorDialog::OnDeleteDoor() {
 // Returns true if got new name, false if cancelled.
 // the data in buf not changed if cancel is pressed
 bool InputDoorName(char *buf, int len, char *title, char *prompt, CWnd *wnd) {
-  char *tempbuf = (char *)mem_malloc(len);
+  char *tempbuf = mem_rmalloc<char>(len);
 
   strcpy(tempbuf, buf);
 

--- a/editor/WorldObjectsGenericDialog.cpp
+++ b/editor/WorldObjectsGenericDialog.cpp
@@ -612,7 +612,7 @@ bool InputObjectName(char *buf, int len, char *title, char *prompt, CWnd *wnd) {
   if (len > (PAGENAME_LEN - 1))
     len = PAGENAME_LEN - 1;
 
-  char *tempbuf = (char *)mem_malloc(len);
+  char *tempbuf = mem_rmalloc<char>(len);
 
   strncpy(tempbuf, buf, len - 1);
   tempbuf[len - 1] = '\0';

--- a/editor/WorldSoundsDialog.cpp
+++ b/editor/WorldSoundsDialog.cpp
@@ -1102,7 +1102,7 @@ bool InputSoundName(char *buf, int len, char *title, char *prompt, CWnd *wnd) {
   if (len > (PAGENAME_LEN - 1))
     len = PAGENAME_LEN - 1;
 
-  char *tempbuf = (char *)mem_malloc(len);
+  char *tempbuf = mem_rmalloc<char>(len);
 
   strncpy(tempbuf, buf, len - 1);
   tempbuf[len - 1] = '\0';

--- a/editor/WorldTexturesDialog.cpp
+++ b/editor/WorldTexturesDialog.cpp
@@ -1998,7 +1998,7 @@ void CWorldTexturesDialog::OnPingPong() {
 // Returns true if got new name, false if cancelled.
 // the data in buf not changed if cancel is pressed
 bool InputTextureName(char *buf, int len, char *title, char *prompt, CWnd *wnd) {
-  char *tempbuf = (char *)mem_malloc(len);
+  char *tempbuf = mem_rmalloc<char>(len);
 
   strcpy(tempbuf, buf);
 

--- a/editor/WorldWeaponsDialog.cpp
+++ b/editor/WorldWeaponsDialog.cpp
@@ -1579,7 +1579,7 @@ void CWorldWeaponsDialog::OnEditPhysics() {
 // Returns true if got new name, false if cancelled.
 // the data in buf not changed if cancel is pressed
 bool InputWeaponName(char *buf, int len, char *title, char *prompt, CWnd *wnd) {
-  char *tempbuf = (char *)mem_malloc(len);
+  char *tempbuf = mem_rmalloc<char>(len);
 
   strcpy(tempbuf, buf);
 

--- a/editor/ebnode.cpp
+++ b/editor/ebnode.cpp
@@ -712,7 +712,7 @@ int EBNode_AddNode(int roomnum, vector *pnt, bool f_from_editor, bool f_check_fo
   if (new_node != 0)
     nlist->nodes = (bn_node *)mem_realloc(nlist->nodes, sizeof(bn_node) * (nlist->num_nodes));
   else
-    nlist->nodes = (bn_node *)mem_malloc(sizeof(bn_node));
+    nlist->nodes = mem_rmalloc<bn_node>();
 
   nlist->nodes[new_node].edges = NULL;
   nlist->nodes[new_node].num_edges = 0;
@@ -897,7 +897,7 @@ void EBNode_AddEdge(int spnt, int sroom, int epnt, int eroom, bool f_add_reverse
     snlist->nodes[spnt].num_edges++;
 
     if (new_edge == 0) {
-      snlist->nodes[spnt].edges = (bn_edge *)mem_malloc(sizeof(bn_edge));
+      snlist->nodes[spnt].edges = mem_rmalloc<bn_edge>();
     } else {
       snlist->nodes[spnt].edges =
           (bn_edge *)mem_realloc(snlist->nodes[spnt].edges, sizeof(bn_edge) * snlist->nodes[spnt].num_edges);

--- a/editor/editorView.cpp
+++ b/editor/editorView.cpp
@@ -1269,7 +1269,7 @@ try_again:;
   }
 
   if (strlen(tempname)) {
-    Curroomp->name = (char *)mem_malloc(strlen(tempname) + 1);
+    Curroomp->name = mem_rmalloc<char>(strlen(tempname) + 1);
     strcpy(Curroomp->name, tempname);
   }
 

--- a/editor/editor_lighting.cpp
+++ b/editor/editor_lighting.cpp
@@ -1041,7 +1041,7 @@ void DoRadiosityForRooms() {
     Light_surfaces[surface_index].verts = (vector *)mem_malloc(sizeof(vector) * 3);
     ASSERT(Light_surfaces[surface_index].verts != NULL);
 
-    Light_surfaces[surface_index].elements = (rad_element *)mem_malloc(sizeof(rad_element));
+    Light_surfaces[surface_index].elements = mem_rmalloc<rad_element>();
     ASSERT(Light_surfaces[surface_index].elements != NULL);
 
     Light_surfaces[surface_index].elements[0].verts = (vector *)mem_malloc(sizeof(vector) * 3);
@@ -1911,7 +1911,7 @@ void DoRadiosityForTerrain() {
       }
 
       // Do upper left triangle
-      Light_surfaces[i * 2].elements = (rad_element *)mem_malloc(sizeof(rad_element));
+      Light_surfaces[i * 2].elements = mem_rmalloc<rad_element>();
       ASSERT(Light_surfaces[i * 2].elements != NULL);
 
       Light_surfaces[i * 2].elements[0].verts = (vector *)mem_malloc(sizeof(vector) * 3);
@@ -1951,7 +1951,7 @@ void DoRadiosityForTerrain() {
 
       // Now do lower right
 
-      Light_surfaces[i * 2 + 1].elements = (rad_element *)mem_malloc(sizeof(rad_element));
+      Light_surfaces[i * 2 + 1].elements = mem_rmalloc<rad_element>();
       ASSERT(Light_surfaces[i * 2 + 1].elements != NULL);
 
       Light_surfaces[i * 2 + 1].elements[0].verts = (vector *)mem_malloc(sizeof(vector) * 3);
@@ -1996,7 +1996,7 @@ void DoRadiosityForTerrain() {
     Light_surfaces[surf_index].verts = (vector *)mem_malloc(sizeof(vector) * 3);
     ASSERT(Light_surfaces[surf_index].verts != NULL);
 
-    Light_surfaces[surf_index].elements = (rad_element *)mem_malloc(sizeof(rad_element));
+    Light_surfaces[surf_index].elements = mem_rmalloc<rad_element>();
     ASSERT(Light_surfaces[surf_index].elements != NULL);
 
     Light_surfaces[surf_index].elements[0].verts = (vector *)mem_malloc(sizeof(vector) * 3);

--- a/editor/editor_lighting.cpp
+++ b/editor/editor_lighting.cpp
@@ -422,7 +422,7 @@ void SqueezeLightmaps(int external, int target_roomnum) {
   int i, t, k;
   mprintf(0, "Squeezing %s lightmaps, please wait...\n", external ? "external" : "internal");
 
-  Lmi_spoken_for = (uint8_t *)mem_malloc(MAX_LIGHTMAP_INFOS);
+  Lmi_spoken_for = mem_rmalloc<uint8_t>(MAX_LIGHTMAP_INFOS);
   Lightmap_mask = (uint8_t *)mem_malloc(128 * 128);
   Squeeze_lightmap_handle = -1;
 
@@ -2927,7 +2927,7 @@ void ComputeAllRoomLightmapUVs(int external) {
       if (!external && (Rooms[i].flags & RF_EXTERNAL))
         continue;
 
-      RoomsAlreadyCombined[i] = (uint8_t *)mem_malloc(Rooms[i].num_faces);
+      RoomsAlreadyCombined[i] = mem_rmalloc<uint8_t>(Rooms[i].num_faces);
       ASSERT(RoomsAlreadyCombined[i]);
       for (k = 0; k < Rooms[i].num_faces; k++)
         RoomsAlreadyCombined[i][k] = 0;

--- a/editor/editor_lighting.cpp
+++ b/editor/editor_lighting.cpp
@@ -903,7 +903,7 @@ void DoRadiosityForRooms() {
       Rooms[roomnum].volume_lights = (uint8_t *)mem_malloc(vw * vh * vd);
       ASSERT(Rooms[roomnum].volume_lights);
 
-      Volume_elements[roomnum] = (volume_element *)mem_malloc((vw * vh * vd) * sizeof(volume_element));
+      Volume_elements[roomnum] = mem_rmalloc<volume_element>(vw * vh * vd);
       ASSERT(Volume_elements[roomnum]);
 
       // Now go through and find all the valid spectra points
@@ -977,8 +977,8 @@ void DoRadiosityForRooms() {
 
         if (Light_surfaces[surface_index].xresolution * Light_surfaces[surface_index].yresolution) {
           Light_surfaces[surface_index].elements =
-              (rad_element *)mem_malloc(Light_surfaces[surface_index].xresolution *
-                                        Light_surfaces[surface_index].yresolution * sizeof(rad_element));
+               mem_rmalloc<rad_element>(Light_surfaces[surface_index].xresolution *
+                                        Light_surfaces[surface_index].yresolution);
           ASSERT(Light_surfaces[surface_index].elements != NULL);
         } else {
           Light_surfaces[surface_index].elements = NULL;
@@ -1223,8 +1223,8 @@ void DoRadiosityForCurrentRoom(room *rp) {
     }
 
     if (Light_surfaces[surface_index].xresolution * Light_surfaces[surface_index].yresolution) {
-      Light_surfaces[surface_index].elements = (rad_element *)mem_malloc(
-          Light_surfaces[surface_index].xresolution * Light_surfaces[surface_index].yresolution * sizeof(rad_element));
+      Light_surfaces[surface_index].elements = mem_rmalloc<rad_element>(
+          Light_surfaces[surface_index].xresolution * Light_surfaces[surface_index].yresolution);
       ASSERT(Light_surfaces[surface_index].elements != NULL);
     } else {
       Light_surfaces[surface_index].elements = NULL;
@@ -1873,8 +1873,8 @@ void DoRadiosityForTerrain() {
   ClearAllObjectLightmaps(1);
 
   // Allocate memory
-  terrain_sums[0] = (spectra *)mem_malloc(TERRAIN_WIDTH * TERRAIN_DEPTH * sizeof(spectra));
-  terrain_sums[1] = (spectra *)mem_malloc(TERRAIN_WIDTH * TERRAIN_DEPTH * sizeof(spectra));
+  terrain_sums[0] = mem_rmalloc<spectra>(TERRAIN_WIDTH * TERRAIN_DEPTH);
+  terrain_sums[1] = mem_rmalloc<spectra>(TERRAIN_WIDTH * TERRAIN_DEPTH);
   ASSERT(terrain_sums[0] && terrain_sums[1]);
 
   Light_surfaces = mem_rmalloc<rad_surface>(total_surfaces);
@@ -2044,8 +2044,8 @@ void DoRadiosityForTerrain() {
         Light_surfaces[surf_index].verts = mem_rmalloc<vector>(Rooms[i].faces[t].num_verts);
         ASSERT(Light_surfaces[surf_index].verts != NULL);
 
-        Light_surfaces[surf_index].elements = (rad_element *)mem_malloc(
-            Light_surfaces[surf_index].xresolution * Light_surfaces[surf_index].yresolution * sizeof(rad_element));
+        Light_surfaces[surf_index].elements = mem_rmalloc<rad_element>(
+            Light_surfaces[surf_index].xresolution * Light_surfaces[surf_index].yresolution);
         ASSERT(Light_surfaces[surf_index].elements != NULL);
 
         if (Rooms[i].faces[t].portal_num != -1 &&

--- a/editor/editor_lighting.cpp
+++ b/editor/editor_lighting.cpp
@@ -952,7 +952,7 @@ void DoRadiosityForRooms() {
 
   // Allocate enough memory to hold all surfaces
 
-  Light_surfaces = (rad_surface *)mem_malloc(facecount * sizeof(rad_surface));
+  Light_surfaces = mem_rmalloc<rad_surface>(facecount);
   ASSERT(Light_surfaces != NULL);
 
   // Set initial surface properties
@@ -968,7 +968,7 @@ void DoRadiosityForRooms() {
         ComputeSurfaceRes(&Light_surfaces[surface_index], &Rooms[i], t);
 
         if (Rooms[i].faces[t].num_verts) {
-          Light_surfaces[surface_index].verts = (vector *)mem_malloc(Rooms[i].faces[t].num_verts * sizeof(vector));
+          Light_surfaces[surface_index].verts = mem_rmalloc<vector>(Rooms[i].faces[t].num_verts);
           ASSERT(Light_surfaces[surface_index].verts != NULL);
         } else {
           Light_surfaces[surface_index].verts = NULL;
@@ -1205,7 +1205,7 @@ void DoRadiosityForCurrentRoom(room *rp) {
 
   // Allocate enough memory to hold all surfaces
 
-  Light_surfaces = (rad_surface *)mem_malloc(facecount * sizeof(rad_surface));
+  Light_surfaces = mem_rmalloc<rad_surface>(facecount);
   ASSERT(Light_surfaces != NULL);
 
   // Set initial surface properties
@@ -1215,7 +1215,7 @@ void DoRadiosityForCurrentRoom(room *rp) {
     ComputeSurfaceRes(&Light_surfaces[surface_index], rp, t);
 
     if (rp->faces[t].num_verts) {
-      Light_surfaces[surface_index].verts = (vector *)mem_malloc(rp->faces[t].num_verts * sizeof(vector));
+      Light_surfaces[surface_index].verts = mem_rmalloc<vector>(rp->faces[t].num_verts);
       ASSERT(Light_surfaces[surface_index].verts != NULL);
     } else {
       Light_surfaces[surface_index].verts = NULL;
@@ -1877,7 +1877,7 @@ void DoRadiosityForTerrain() {
   terrain_sums[1] = (spectra *)mem_malloc(TERRAIN_WIDTH * TERRAIN_DEPTH * sizeof(spectra));
   ASSERT(terrain_sums[0] && terrain_sums[1]);
 
-  Light_surfaces = (rad_surface *)mem_malloc(total_surfaces * sizeof(rad_surface));
+  Light_surfaces = mem_rmalloc<rad_surface>(total_surfaces);
   ASSERT(Light_surfaces != NULL);
 
   // Setup radiosity surfaces
@@ -2041,7 +2041,7 @@ void DoRadiosityForTerrain() {
 
         ComputeSurfaceRes(&Light_surfaces[surf_index], &Rooms[i], t);
 
-        Light_surfaces[surf_index].verts = (vector *)mem_malloc(Rooms[i].faces[t].num_verts * sizeof(vector));
+        Light_surfaces[surf_index].verts = mem_rmalloc<vector>(Rooms[i].faces[t].num_verts);
         ASSERT(Light_surfaces[surf_index].verts != NULL);
 
         Light_surfaces[surf_index].elements = (rad_element *)mem_malloc(

--- a/editor/editor_lighting.cpp
+++ b/editor/editor_lighting.cpp
@@ -1038,13 +1038,13 @@ void DoRadiosityForRooms() {
 
   // Setup satellites
   for (i = 0; i < Terrain_sky.num_satellites; i++, surface_index++) {
-    Light_surfaces[surface_index].verts = (vector *)mem_malloc(sizeof(vector) * 3);
+    Light_surfaces[surface_index].verts = mem_rmalloc<vector>(3);
     ASSERT(Light_surfaces[surface_index].verts != NULL);
 
     Light_surfaces[surface_index].elements = mem_rmalloc<rad_element>();
     ASSERT(Light_surfaces[surface_index].elements != NULL);
 
-    Light_surfaces[surface_index].elements[0].verts = (vector *)mem_malloc(sizeof(vector) * 3);
+    Light_surfaces[surface_index].elements[0].verts = mem_rmalloc<vector>(3);
     ASSERT(Light_surfaces[surface_index].elements[0].verts);
 
     Light_surfaces[surface_index].surface_type = ST_SATELLITE;
@@ -1558,7 +1558,7 @@ void ClipSurfaceElement(vector *surf_verts, rad_element *ep, vector *clip_verts,
   if (ep->num_verts == 0)
     ep->flags |= EF_IGNORE;
   else {
-    ep->verts = (vector *)mem_malloc(sizeof(vector) * nnv);
+    ep->verts = mem_rmalloc<vector>(nnv);
     ASSERT(ep->verts);
 
     for (i = 0; i < nnv; i++) {
@@ -1914,10 +1914,10 @@ void DoRadiosityForTerrain() {
       Light_surfaces[i * 2].elements = mem_rmalloc<rad_element>();
       ASSERT(Light_surfaces[i * 2].elements != NULL);
 
-      Light_surfaces[i * 2].elements[0].verts = (vector *)mem_malloc(sizeof(vector) * 3);
+      Light_surfaces[i * 2].elements[0].verts = mem_rmalloc<vector>(3);
       ASSERT(Light_surfaces[i * 2].elements[0].verts);
 
-      Light_surfaces[i * 2].verts = (vector *)mem_malloc(sizeof(vector) * 3);
+      Light_surfaces[i * 2].verts = mem_rmalloc<vector>(3);
       ASSERT(Light_surfaces[i * 2].verts != NULL);
 
       Light_surfaces[i * 2].normal = TerrainNormals[MAX_TERRAIN_LOD - 1][seg].normal1;
@@ -1954,10 +1954,10 @@ void DoRadiosityForTerrain() {
       Light_surfaces[i * 2 + 1].elements = mem_rmalloc<rad_element>();
       ASSERT(Light_surfaces[i * 2 + 1].elements != NULL);
 
-      Light_surfaces[i * 2 + 1].elements[0].verts = (vector *)mem_malloc(sizeof(vector) * 3);
+      Light_surfaces[i * 2 + 1].elements[0].verts = mem_rmalloc<vector>(3);
       ASSERT(Light_surfaces[i * 2 + 1].elements[0].verts);
 
-      Light_surfaces[i * 2 + 1].verts = (vector *)mem_malloc(sizeof(vector) * 3);
+      Light_surfaces[i * 2 + 1].verts = mem_rmalloc<vector>(3);
       ASSERT(Light_surfaces[i * 2 + 1].verts != NULL);
 
       Light_surfaces[i * 2 + 1].normal = TerrainNormals[MAX_TERRAIN_LOD - 1][seg].normal2;
@@ -1993,13 +1993,13 @@ void DoRadiosityForTerrain() {
 
   // Setup satellites
   for (i = 0; i < Terrain_sky.num_satellites; i++, surf_index++) {
-    Light_surfaces[surf_index].verts = (vector *)mem_malloc(sizeof(vector) * 3);
+    Light_surfaces[surf_index].verts = mem_rmalloc<vector>(3);
     ASSERT(Light_surfaces[surf_index].verts != NULL);
 
     Light_surfaces[surf_index].elements = mem_rmalloc<rad_element>();
     ASSERT(Light_surfaces[surf_index].elements != NULL);
 
-    Light_surfaces[surf_index].elements[0].verts = (vector *)mem_malloc(sizeof(vector) * 3);
+    Light_surfaces[surf_index].elements[0].verts = mem_rmalloc<vector>(3);
     ASSERT(Light_surfaces[surf_index].elements[0].verts);
 
     Light_surfaces[surf_index].surface_type = ST_SATELLITE;
@@ -3312,7 +3312,7 @@ void SetupSpecularLighting(int external) {
       room *rp = &Rooms[i];
 
       // Calculate vertex normals for this room
-      vector *vertnorms = (vector *)mem_malloc(sizeof(vector) * rp->num_verts);
+      vector *vertnorms = mem_rmalloc<vector>(rp->num_verts);
       ASSERT(vertnorms);
       for (t = 0; t < rp->num_verts; t++) {
         int total = 0;
@@ -3336,7 +3336,7 @@ void SetupSpecularLighting(int external) {
       }
 
       for (t = 0; t < 4; t++) {
-        Room_strongest_value[i][t] = (float *)mem_malloc(sizeof(float) * rp->num_faces);
+        Room_strongest_value[i][t] = mem_rmalloc<float>(rp->num_faces);
         ASSERT(Room_strongest_value[i][t]);
         memset(Room_strongest_value[i][t], 0, sizeof(float) * rp->num_faces);
       }

--- a/editor/editor_object_lighting.cpp
+++ b/editor/editor_object_lighting.cpp
@@ -959,7 +959,7 @@ void CombineObjectLightmapUVs(object *obj, int lmi_type) {
     if (IsNonRenderableSubmodel(pm, i))
       continue;
 
-    ObjectsAlreadyCombined[i] = (uint8_t *)mem_malloc(sm->num_faces);
+    ObjectsAlreadyCombined[i] = mem_rmalloc<uint8_t>(sm->num_faces);
     ASSERT(ObjectsAlreadyCombined[i]);
     for (k = 0; k < sm->num_faces; k++)
       ObjectsAlreadyCombined[i][k] = 0;

--- a/editor/editor_object_lighting.cpp
+++ b/editor/editor_object_lighting.cpp
@@ -321,8 +321,8 @@ int ComputeSurfacesForObjects(int surface_index, int terrain) {
 
           if (Light_surfaces[surface_index].xresolution * Light_surfaces[surface_index].yresolution > 0) {
             Light_surfaces[surface_index].elements =
-                (rad_element *)mem_malloc(Light_surfaces[surface_index].xresolution *
-                                          Light_surfaces[surface_index].yresolution * sizeof(rad_element));
+                mem_rmalloc<rad_element>(Light_surfaces[surface_index].xresolution *
+                                         Light_surfaces[surface_index].yresolution);
             ASSERT(Light_surfaces[surface_index].elements != NULL);
           } else
             Light_surfaces[surface_index].elements = NULL;
@@ -407,8 +407,8 @@ int ComputeSurfacesForObjectsForSingleRoom(int surface_index, int roomnum) {
 
           if (Light_surfaces[surface_index].xresolution * Light_surfaces[surface_index].yresolution > 0) {
             Light_surfaces[surface_index].elements =
-                (rad_element *)mem_malloc(Light_surfaces[surface_index].xresolution *
-                                          Light_surfaces[surface_index].yresolution * sizeof(rad_element));
+                mem_rmalloc<rad_element>(Light_surfaces[surface_index].xresolution *
+                                         Light_surfaces[surface_index].yresolution);
             ASSERT(Light_surfaces[surface_index].elements != NULL);
           } else
             Light_surfaces[surface_index].elements = NULL;

--- a/editor/editor_object_lighting.cpp
+++ b/editor/editor_object_lighting.cpp
@@ -314,7 +314,7 @@ int ComputeSurfacesForObjects(int surface_index, int terrain) {
           ComputeObjectSurfaceRes(&Light_surfaces[surface_index], &Objects[i], t, j);
 
           if (sm->faces[j].nverts > 0) {
-            Light_surfaces[surface_index].verts = (vector *)mem_malloc(sm->faces[j].nverts * sizeof(vector));
+            Light_surfaces[surface_index].verts = mem_rmalloc<vector>(sm->faces[j].nverts);
             ASSERT(Light_surfaces[surface_index].verts != NULL);
           } else
             Light_surfaces[surface_index].verts = NULL;
@@ -400,7 +400,7 @@ int ComputeSurfacesForObjectsForSingleRoom(int surface_index, int roomnum) {
           ComputeObjectSurfaceRes(&Light_surfaces[surface_index], &Objects[i], t, j);
 
           if (sm->faces[j].nverts > 0) {
-            Light_surfaces[surface_index].verts = (vector *)mem_malloc(sm->faces[j].nverts * sizeof(vector));
+            Light_surfaces[surface_index].verts = mem_rmalloc<vector>(sm->faces[j].nverts);
             ASSERT(Light_surfaces[surface_index].verts != NULL);
           } else
             Light_surfaces[surface_index].verts = NULL;

--- a/editor/rad_init.cpp
+++ b/editor/rad_init.cpp
@@ -125,7 +125,7 @@ void InitRadiosityRun() {
 void SetupFormFactors() {
   ASSERT(rad_NumElements > 0);
 
-  rad_FormFactors = (float *)mem_malloc(rad_NumElements * sizeof(float));
+  rad_FormFactors = mem_rmalloc<float>(rad_NumElements);
   ASSERT(rad_FormFactors != NULL);
 }
 

--- a/editor/roomkeypaddialog.cpp
+++ b/editor/roomkeypaddialog.cpp
@@ -437,7 +437,7 @@ void CRoomKeypadDialog::OnLoadRoom() {
   }
 
   ASSERT(Rooms[n].name == NULL);
-  Rooms[n].name = (char *)mem_malloc(strlen(roomname) + 1);
+  Rooms[n].name = mem_rmalloc<char>(strlen(roomname) + 1);
   strcpy(Rooms[n].name, roomname);
 
   D3EditState.current_room = n;

--- a/grtext/grfont.cpp
+++ b/grtext/grfont.cpp
@@ -341,7 +341,7 @@ int grfont_Load(const char *fname) {
   //	Read in kerning data
   if (fnt.flags & FT_KERNED) {
     int n_pairs = (int)READ_FONT_SHORT(ff);
-    fnt.kern_data = (uint8_t *)mem_malloc(sizeof(uint8_t) * 3 * (n_pairs + 1));
+    fnt.kern_data = mem_rmalloc<uint8_t>(sizeof(uint8_t) * 3 * (n_pairs + 1));
     for (i = 0; i < n_pairs; i++) {
       fnt.kern_data[i * 3] = READ_FONT_BYTE(ff);
       fnt.kern_data[i * 3 + 1] = READ_FONT_BYTE(ff);
@@ -361,7 +361,7 @@ int grfont_Load(const char *fname) {
   //		generate character data pointer table
   int bytesize = READ_FONT_INT(ff);
 
-  fnt.raw_data = (uint8_t *)mem_malloc(bytesize);
+  fnt.raw_data = mem_rmalloc<uint8_t>(bytesize);
   fnt.char_data = mem_rmalloc<uint8_t *>(num_char);
 
   READ_FONT_DATA(ff, fnt.raw_data, bytesize, 1);
@@ -486,7 +486,7 @@ bool grfont_LoadTemplate(const char *fname, tFontTemplate *ft) {
 
   //	Read in all widths
   if (ft_flags & FT_PROPORTIONAL) {
-    ft->ch_widths = (uint8_t *)mem_malloc(num_char);
+    ft->ch_widths = mem_rmalloc<uint8_t>(num_char);
     for (i = 0; i < num_char; i++)
       ft->ch_widths[i] = (uint8_t)READ_FONT_SHORT(ff);
   } else {
@@ -495,7 +495,7 @@ bool grfont_LoadTemplate(const char *fname, tFontTemplate *ft) {
 
   if (ft_flags & FT_KERNED) {
     int n_pairs = (int)READ_FONT_SHORT(ff);
-    ft->kern_data = (uint8_t *)mem_malloc(sizeof(uint8_t) * 3 * (n_pairs + 1));
+    ft->kern_data = mem_rmalloc<uint8_t>(sizeof(uint8_t) * 3 * (n_pairs + 1));
     for (i = 0; i < n_pairs; i++) {
       ft->kern_data[i * 3] = READ_FONT_BYTE(ff);
       ft->kern_data[i * 3 + 1] = READ_FONT_BYTE(ff);
@@ -588,7 +588,7 @@ bool grfont_SetTemplate(const char *pathname, const tFontTemplate *ft) {
   //	Read in kerning data
   if (fnt.flags & FT_KERNED) {
     int n_pairs = (int)READ_FONT_SHORT(ffin);
-    fnt.kern_data = (uint8_t *)mem_malloc(sizeof(uint8_t) * 3 * (n_pairs + 1));
+    fnt.kern_data = mem_rmalloc<uint8_t>(sizeof(uint8_t) * 3 * (n_pairs + 1));
     for (i = 0; i < n_pairs; i++) {
       fnt.kern_data[i * 3] = READ_FONT_BYTE(ffin);
       fnt.kern_data[i * 3 + 1] = READ_FONT_BYTE(ffin);
@@ -604,7 +604,7 @@ bool grfont_SetTemplate(const char *pathname, const tFontTemplate *ft) {
   //	Read in pixel data.
   int bytesize = READ_FONT_INT(ffin);
 
-  fnt.raw_data = (uint8_t *)mem_malloc(bytesize);
+  fnt.raw_data = mem_rmalloc<uint8_t>(bytesize);
 
   READ_FONT_DATA(ffin, fnt.raw_data, bytesize, 1);
 

--- a/grtext/grfont.cpp
+++ b/grtext/grfont.cpp
@@ -331,7 +331,7 @@ int grfont_Load(const char *fname) {
 
   //	Read in all widths
   if (fnt.flags & FT_PROPORTIONAL) {
-    fnt.char_widths = (uint8_t *)mem_malloc(sizeof(uint8_t) * num_char);
+    fnt.char_widths = mem_rmalloc<uint8_t>(num_char);
     for (i = 0; i < num_char; i++)
       fnt.char_widths[i] = (uint8_t)READ_FONT_SHORT(ff);
   } else {
@@ -578,7 +578,7 @@ bool grfont_SetTemplate(const char *pathname, const tFontTemplate *ft) {
 
   //	Read in all widths
   if (fnt.flags & FT_PROPORTIONAL) {
-    fnt.char_widths = (uint8_t *)mem_malloc(sizeof(uint8_t) * num_char);
+    fnt.char_widths = mem_rmalloc<uint8_t>(num_char);
     for (i = 0; i < num_char; i++)
       fnt.char_widths[i] = (uint8_t)READ_FONT_SHORT(ffin);
   } else {

--- a/grtext/grfont.cpp
+++ b/grtext/grfont.cpp
@@ -362,7 +362,7 @@ int grfont_Load(const char *fname) {
   int bytesize = READ_FONT_INT(ff);
 
   fnt.raw_data = (uint8_t *)mem_malloc(bytesize);
-  fnt.char_data = (uint8_t **)mem_malloc(num_char * sizeof(uint8_t *));
+  fnt.char_data = mem_rmalloc<uint8_t *>(num_char);
 
   READ_FONT_DATA(ff, fnt.raw_data, bytesize, 1);
 

--- a/grtext/grtext.cpp
+++ b/grtext/grtext.cpp
@@ -461,7 +461,7 @@ void grtext_Puts(int x, int y, const char *str) {
 
   if (grtext_FilterProfanity) {
     // DAJ changed to local to reduce memory thrashing
-    // DAJ		char *lowerstr = (char *)mem_malloc(strlen(str)+1);
+    // DAJ		char *lowerstr = mem_rmalloc<char>(strlen(str)+1);
     char lowerstr[GR_STR_LEN];
 
     int slen = strlen(str);

--- a/legacy/inetfile/Chttpget.cpp
+++ b/legacy/inetfile/Chttpget.cpp
@@ -661,7 +661,7 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
       http_lastaslu->abort = true;
 
     async_dns_lookup *newaslu;
-    newaslu = (async_dns_lookup *)mem_malloc(sizeof(async_dns_lookup));
+    newaslu = mem_rmalloc<async_dns_lookup>();
     memset(&newaslu->ip, 0, sizeof(uint32_t));
     newaslu->host = hostname;
     newaslu->done = false;

--- a/legacy/renderer/Direct3D.cpp
+++ b/legacy/renderer/Direct3D.cpp
@@ -1021,7 +1021,7 @@ int d3d_TextureCacheInit() {
   }
 
   // Allocate room to hold all our surfaces
-  UploadSurfaces = (LPDIRECTDRAWSURFACE4 *)mem_malloc(NUM_TEXTURE_CLASSES * sizeof(LPDIRECTDRAWSURFACE4));
+  UploadSurfaces = mem_rmalloc<LPDIRECTDRAWSURFACE4>(NUM_TEXTURE_CLASSES);
   if (UploadSurfaces == NULL) {
     mprintf(0, "Couldn't allocate memory for UploadSurfaces!\n");
 
@@ -1030,7 +1030,7 @@ int d3d_TextureCacheInit() {
   }
 
   // Allocate room to hold all our 4444 surfaces
-  Upload4444Surfaces = (LPDIRECTDRAWSURFACE4 *)mem_malloc(NUM_TEXTURE_CLASSES * sizeof(LPDIRECTDRAWSURFACE4));
+  Upload4444Surfaces = mem_rmalloc<LPDIRECTDRAWSURFACE4>(NUM_TEXTURE_CLASSES);
   if (Upload4444Surfaces == NULL) {
     mprintf(0, "Couldn't allocate memory for Upload4444Surfaces!\n");
 
@@ -1038,7 +1038,7 @@ int d3d_TextureCacheInit() {
     return 0;
   }
 
-  BitmapTextureSurfaces = (LPDIRECTDRAWSURFACE4 *)mem_malloc(MAX_BITMAPS * sizeof(LPDIRECTDRAWSURFACE4));
+  BitmapTextureSurfaces = mem_rmalloc<LPDIRECTDRAWSURFACE4>(MAX_BITMAPS);
   if (BitmapTextureSurfaces == NULL) {
     mprintf(0, "Couldn't allocate memory for BitmapTextureSurfaces!\n");
 
@@ -1047,7 +1047,7 @@ int d3d_TextureCacheInit() {
   }
 
   // Allocate room to hold all our surfaces
-  LightmapTextureSurfaces = (LPDIRECTDRAWSURFACE4 *)mem_malloc(MAX_LIGHTMAPS * sizeof(LPDIRECTDRAWSURFACE4));
+  LightmapTextureSurfaces = mem_rmalloc<LPDIRECTDRAWSURFACE4>(MAX_LIGHTMAPS);
   if (LightmapTextureSurfaces == NULL) {
     mprintf(0, "Couldn't allocate memory for LightmapTextureSurfaces!\n");
     rend_SetErrorMessage("Couldn't alloc mem for LightmapTextureSurfaces!");
@@ -1055,7 +1055,7 @@ int d3d_TextureCacheInit() {
   }
 
   if (d3d_CanBumpmap) {
-    BumpmapTextureSurfaces = (LPDIRECTDRAWSURFACE4 *)mem_malloc(MAX_BUMPMAPS * sizeof(LPDIRECTDRAWSURFACE4));
+    BumpmapTextureSurfaces = mem_rmalloc<LPDIRECTDRAWSURFACE4>(MAX_BUMPMAPS);
     if (BumpmapTextureSurfaces == NULL) {
       mprintf(0, "Couldn't allocate memory for BumpmapTextureSurfaces!\n");
       rend_SetErrorMessage("Couldn't alloc mem for BumpmapTextureSurfaces!");

--- a/legacy/renderer/opengl.cpp
+++ b/legacy/renderer/opengl.cpp
@@ -281,9 +281,9 @@ int opengl_InitCache() {
   OpenGL_lightmap_remap = (uint16_t *)mem_malloc(MAX_LIGHTMAPS * 2);
   ASSERT(OpenGL_lightmap_remap);
 
-  OpenGL_bitmap_states = (uint8_t *)mem_malloc(MAX_BITMAPS);
+  OpenGL_bitmap_states = mem_rmalloc<uint8_t>(MAX_BITMAPS);
   ASSERT(OpenGL_bitmap_states);
-  OpenGL_lightmap_states = (uint8_t *)mem_malloc(MAX_LIGHTMAPS);
+  OpenGL_lightmap_states = mem_rmalloc<uint8_t>(MAX_LIGHTMAPS);
   ASSERT(OpenGL_lightmap_states);
 
   Cur_texture_object_num = 1;

--- a/lib/win/wincontroller.h
+++ b/lib/win/wincontroller.h
@@ -216,28 +216,28 @@ public:
   void set_controller_deadzone(int ctl, float deadzone);
 
 private:
-  int m_NumControls;               // number of controllers available
-  int m_Suspended;                 // is controller polling suspended?
-  bool m_JoyActive, m_MouseActive; // enables or disables mouse, joystick control
+  int m_NumControls = 0;           // number of controllers available
+  int m_Suspended = 0;             // is controller polling suspended?
+  bool m_JoyActive = false, m_MouseActive = false; // enables or disables mouse, joystick control
 
   struct t_controller {
-    int id;
-    uint16_t flags;
-    uint16_t buttons;
-    unsigned btnmask;
-    float normalizer[CT_NUM_AXES];
-    float sens[CT_NUM_AXES];
-    float sensmod[CT_NUM_AXES];
-    float deadzone;
+    int id = 0;
+    uint16_t flags = 0;
+    uint16_t buttons = 0;
+    unsigned btnmask = 0;
+    float normalizer[CT_NUM_AXES]{};
+    float sens[CT_NUM_AXES]{};
+    float sensmod[CT_NUM_AXES]{};
+    float deadzone = 0;
   } m_ControlList[CT_MAX_CONTROLLERS]; // the control list.
 
   struct ct_element {
-    ct_format format;
-    int8_t ctl[CTLBINDS_PER_FUNC];
-    uint8_t value[CTLBINDS_PER_FUNC];
-    ct_type ctype[CTLBINDS_PER_FUNC];
-    uint8_t flags[2];
-    bool enabled;
+    ct_format format{};
+    int8_t ctl[CTLBINDS_PER_FUNC]{};
+    uint8_t value[CTLBINDS_PER_FUNC]{};
+    ct_type ctype[CTLBINDS_PER_FUNC]{};
+    uint8_t flags[2]{};
+    bool enabled = false;
   } m_ElementList[CT_MAX_ELEMENTS];
 
   bool enum_controllers(char *remote_adr);
@@ -271,27 +271,27 @@ private:
 
 private:
   struct t_msestate {
-    int m_deltaX, m_deltaY, m_deltaZ;
-    int m_absX, m_absY;
-    uint32_t m_buttonMask;
+    int m_deltaX = 0, m_deltaY = 0, m_deltaZ = 0;
+    int m_absX = 0, m_absY = 0;
+    uint32_t m_buttonMask = 0;
   } m_MseState;
 
   struct t_extctlstate {
-    int x, y, z, r, u, v;
-    int pov[JOYPOV_NUM];
-    int last_pov[JOYPOV_NUM];
-    float povstarts[JOYPOV_NUM][JOYPOV_DIR];
-    float povtimes[JOYPOV_NUM][JOYPOV_DIR];
-    uint8_t povpresses[JOYPOV_NUM][JOYPOV_DIR];
-    unsigned buttons;
-    uint8_t btnpresses[CT_MAX_BUTTONS];
-    float btnstarts[CT_MAX_BUTTONS];
-    float btntimes[CT_MAX_BUTTONS];
+    int x = 0, y = 0, z = 0, r = 0, u = 0, v = 0;
+    int pov[JOYPOV_NUM]{};
+    int last_pov[JOYPOV_NUM]{};
+    float povstarts[JOYPOV_NUM][JOYPOV_DIR]{};
+    float povtimes[JOYPOV_NUM][JOYPOV_DIR]{};
+    uint8_t povpresses[JOYPOV_NUM][JOYPOV_DIR]{};
+    unsigned buttons = 0;
+    uint8_t btnpresses[CT_MAX_BUTTONS]{};
+    float btnstarts[CT_MAX_BUTTONS]{};
+    float btntimes[CT_MAX_BUTTONS]{};
   } m_ExtCtlStates[CT_MAX_EXTCTLS];
 
   //	thread info.
-  int64_t m_frame_timer_ms;
-  float m_frame_time;
+  int64_t m_frame_timer_ms = 0;
+  float m_frame_time = 0;
 
   //	note id is id value from controller in control list.
   void extctl_getpos(int id);

--- a/linux/lnxcontroller.h
+++ b/linux/lnxcontroller.h
@@ -105,28 +105,28 @@ public:
   void set_controller_deadzone(int ctl, float deadzone);
 
 private:
-  int m_NumControls;               // number of controllers available
-  int m_Suspended;                 // is controller polling suspended?
-  bool m_JoyActive, m_MouseActive; // enables or disables mouse, joystick control
+  int m_NumControls = 0;           // number of controllers available
+  int m_Suspended = 0;             // is controller polling suspended?
+  bool m_JoyActive = false, m_MouseActive = false; // enables or disables mouse, joystick control
 
   struct t_controller {
-    int id;
-    uint16_t flags;
-    uint16_t buttons;
-    unsigned btnmask;
-    float normalizer[CT_NUM_AXES];
-    float sens[CT_NUM_AXES];
-    float sensmod[CT_NUM_AXES];
-    float deadzone;
+    int id = 0;
+    uint16_t flags = 0;
+    uint16_t buttons = 0;
+    unsigned btnmask = 0;
+    float normalizer[CT_NUM_AXES]{};
+    float sens[CT_NUM_AXES]{};
+    float sensmod[CT_NUM_AXES]{};
+    float deadzone = 0;
   } m_ControlList[CT_MAX_CONTROLLERS]; // the control list.
 
   struct ct_element {
-    ct_format format;
-    int8_t ctl[CTLBINDS_PER_FUNC];
-    uint8_t value[CTLBINDS_PER_FUNC];
-    ct_type ctype[CTLBINDS_PER_FUNC];
-    uint8_t flags[2];
-    bool enabled;
+    ct_format format{};
+    int8_t ctl[CTLBINDS_PER_FUNC]{};
+    uint8_t value[CTLBINDS_PER_FUNC]{};
+    ct_type ctype[CTLBINDS_PER_FUNC]{};
+    uint8_t flags[2]{};
+    bool enabled = false;
   } m_ElementList[CT_MAX_ELEMENTS];
 
   bool enum_controllers();
@@ -159,27 +159,27 @@ private:
 
 private:
   struct t_msestate {
-    int x, y, z;
-    int mx, my;
-    unsigned btnmask;
+    int x = 0, y = 0, z = 0;
+    int mx = 0, my = 0;
+    unsigned btnmask = 0;
   } m_MseState;
 
   struct t_extctlstate {
-    int x, y, z, r, u, v;
-    int pov[JOYPOV_NUM];
-    int last_pov[JOYPOV_NUM];
-    float povstarts[JOYPOV_NUM][JOYPOV_DIR];
-    float povtimes[JOYPOV_NUM][JOYPOV_DIR];
-    uint8_t povpresses[JOYPOV_NUM][JOYPOV_DIR];
-    unsigned buttons;
-    uint8_t btnpresses[CT_MAX_BUTTONS];
-    float btnstarts[CT_MAX_BUTTONS];
-    float btntimes[CT_MAX_BUTTONS];
+    int x = 0, y = 0, z = 0, r = 0, u = 0, v = 0;
+    int pov[JOYPOV_NUM]{};
+    int last_pov[JOYPOV_NUM]{};
+    float povstarts[JOYPOV_NUM][JOYPOV_DIR]{};
+    float povtimes[JOYPOV_NUM][JOYPOV_DIR]{};
+    uint8_t povpresses[JOYPOV_NUM][JOYPOV_DIR]{};
+    unsigned buttons = 0;
+    uint8_t btnpresses[CT_MAX_BUTTONS]{};
+    float btnstarts[CT_MAX_BUTTONS]{};
+    float btntimes[CT_MAX_BUTTONS]{};
   } m_ExtCtlStates[CT_MAX_EXTCTLS];
 
   //	thread info.
-  int64_t m_frame_timer_ms;
-  float m_frame_time;
+  int64_t m_frame_timer_ms = 0;
+  float m_frame_time = 0;
 
   //	note id is id value from controller in control list.
   void extctl_getpos(int id);

--- a/manage/generic.cpp
+++ b/manage/generic.cpp
@@ -1144,7 +1144,7 @@ int mng_ReadNewGenericPage(CFILE *infile, mngs_generic_page *genericpage) {
     cf_ReadString(tempbuf, 1024, infile);
     size_t slen = strlen(tempbuf) + 1;
 
-    genericpage->objinfo_struct.description = (char *)mem_malloc(slen);
+    genericpage->objinfo_struct.description = mem_rmalloc<char>(slen);
     ASSERT(genericpage->objinfo_struct.description);
     strcpy(genericpage->objinfo_struct.description, tempbuf);
   } else

--- a/manage/manage.cpp
+++ b/manage/manage.cpp
@@ -629,9 +629,9 @@ int mng_InitTableFiles() {
 // Loads our tables
 int mng_LoadTableFiles(int show_progress) {
   if (Network_up) {
-    LockList = (mngs_Pagelock *)mem_malloc(MAX_LOCKLIST_ELEMENTS * sizeof(mngs_Pagelock));
+    LockList = mem_rmalloc<mngs_Pagelock>(MAX_LOCKLIST_ELEMENTS);
     Num_locklist = mng_GetListOfLocks(LockList, MAX_LOCKLIST_ELEMENTS, TableUser);
-    OldFiles = (old_file *)mem_malloc(MAX_OLDFILE_ELEMENTS * sizeof(old_file));
+    OldFiles = mem_rmalloc<old_file>(MAX_OLDFILE_ELEMENTS);
     Num_old_files = 0;
     ASSERT(OldFiles);
 #if defined(WIN32)
@@ -2735,7 +2735,7 @@ bool mng_SetAddonTable(char *name) {
 
   strcpy(AddOnDataTables[Num_addon_tables].AddOnTableFilename, name);
   AddOnDataTables[Num_addon_tables].Addon_tracklocks =
-      (mngs_track_lock *)mem_malloc(MAX_ADDON_TRACKLOCKS * sizeof(mngs_track_lock));
+      mem_rmalloc<mngs_track_lock>(MAX_ADDON_TRACKLOCKS);
   AddOnDataTables[Num_addon_tables].Num_addon_tracklocks = 0;
   ASSERT(AddOnDataTables[Num_addon_tables].Addon_tracklocks);
   memset(AddOnDataTables[Num_addon_tables].Addon_tracklocks, 0, MAX_ADDON_TRACKLOCKS * sizeof(mngs_track_lock));

--- a/manage/manage.cpp
+++ b/manage/manage.cpp
@@ -1466,7 +1466,7 @@ void mng_TransferPages() {
     Int3();
     return;
   }
-  mngs_track_lock *local_tracklocks = (mngs_track_lock *)mem_malloc(sizeof(*local_tracklocks) * 5000);
+  auto local_tracklocks = mem_rmalloc<mngs_track_lock>(5000);
   // Do textures
   int done = 0;
   while (!done) {

--- a/manage/manage.cpp
+++ b/manage/manage.cpp
@@ -2059,7 +2059,7 @@ int mng_ReplacePage(char *srcname, char *destname, int handle, int dest_pagetype
     return 0;
   }
   // Allocate memory for copying
-  uint8_t *copybuffer = (uint8_t *)mem_malloc(COPYBUFFER_SIZE);
+  uint8_t *copybuffer = mem_rmalloc<uint8_t>(COPYBUFFER_SIZE);
   if (!copybuffer) {
     LOG_ERROR.printf("Couldn't allocate memory to replace page %s!", srcname);
     cfclose(infile);
@@ -2229,7 +2229,7 @@ int mng_DeletePage(char *name, int dest_pagetype, int local) {
     return 0;
   }
   // Allocate memory for copying
-  uint8_t *copybuffer = (uint8_t *)mem_malloc(COPYBUFFER_SIZE);
+  uint8_t *copybuffer = mem_rmalloc<uint8_t>(COPYBUFFER_SIZE);
   if (!copybuffer) {
     LOG_ERROR << "Couldn't allocate memory to delete page!";
     cfclose(infile);

--- a/manage/pagelock.cpp
+++ b/manage/pagelock.cpp
@@ -661,7 +661,7 @@ int mng_DeleteDuplicatePagelocks() {
   mngs_Pagelock *already_read;
   int num = 0, duplicates = 0, i;
 
-  already_read = (mngs_Pagelock *)mem_malloc(sizeof(mngs_Pagelock) * 8000);
+  already_read = mem_rmalloc<mngs_Pagelock>(8000);
   ASSERT(already_read);
 
   infile = (CFILE *)cfopen(TableLockFilename, "rb");

--- a/manage/texpage.cpp
+++ b/manage/texpage.cpp
@@ -1247,7 +1247,7 @@ int mng_GetGuaranteedTexturePage(char *name, CFILE *infile) {
   if (i != -1)
     return i;
 
-  mngs_texture_page *texpage = (mngs_texture_page *)mem_malloc(sizeof(*texpage));
+  auto texpage = mem_rmalloc<mngs_texture_page>();
 
   // Not in memory.  Load it from the table file.  Start searching from the
   // current spot in the open table file

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -73,6 +73,19 @@
 
 #ifndef MEM_H
 #define MEM_H
+#include <cstdlib>
+#include <type_traits>
+
+template<typename T> static inline T *mem_rmalloc()
+{
+	static_assert(std::is_trivially_constructible_v<T> && std::is_trivially_destructible_v<T>);
+	return static_cast<T *>(std::malloc(sizeof(T)));
+}
+template<typename T> static inline T *mem_rmalloc(std::size_t nelem)
+{
+	static_assert(std::is_trivially_constructible_v<T> && std::is_trivially_destructible_v<T>);
+	return static_cast<T *>(std::malloc(nelem * sizeof(T)));
+}
 
 // Memory management debugging
 #ifdef MEM_USE_RTL

--- a/model/polymodel.cpp
+++ b/model/polymodel.cpp
@@ -1330,7 +1330,7 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
       pm->n_models = cf_ReadInt(infile);
       pm->rad = cf_ReadFloat(infile);
 
-      pm->submodel = (bsp_info *)mem_malloc(sizeof(bsp_info) * pm->n_models);
+      pm->submodel = mem_rmalloc<bsp_info>(pm->n_models);
       ASSERT(pm->submodel != nullptr);
       memset(pm->submodel, 0, sizeof(bsp_info) * pm->n_models);
 
@@ -1494,7 +1494,7 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
       int *start_index;
 
       if (nfaces) {
-        start_index = (int *)mem_malloc(sizeof(int) * nfaces);
+        start_index = mem_rmalloc<int>(nfaces);
         ASSERT(start_index);
       } else
         start_index = nullptr;
@@ -1617,7 +1617,7 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
 
     case ID_GPNT:
       pm->n_guns = cf_ReadInt(infile);
-      pm->gun_slots = (w_bank *)mem_malloc(sizeof(w_bank) * pm->n_guns);
+      pm->gun_slots = mem_rmalloc<w_bank>(pm->n_guns);
       ASSERT(pm->gun_slots != nullptr);
 
       for (i = 0; i < pm->n_guns; i++) {
@@ -1638,7 +1638,7 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
     case ID_ATTACH:
       pm->n_attach = cf_ReadInt(infile);
       if (pm->n_attach) {
-        pm->attach_slots = (a_bank *)mem_malloc(sizeof(a_bank) * pm->n_attach);
+        pm->attach_slots = mem_rmalloc<a_bank>(pm->n_attach);
         ASSERT(pm->attach_slots != nullptr);
 
         for (i = 0; i < pm->n_attach; i++) {
@@ -1691,7 +1691,7 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
       pm->num_wbs = cf_ReadInt(infile);
 
       if (pm->num_wbs) {
-        pm->poly_wb = (poly_wb_info *)mem_malloc(sizeof(poly_wb_info) * pm->num_wbs);
+        pm->poly_wb = mem_rmalloc<poly_wb_info>(pm->num_wbs);
 
         // Get each individual wb info struct
         for (i = 0; i < pm->num_wbs; i++) {
@@ -1725,7 +1725,7 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
 
     case ID_GROUND:
       pm->n_ground = cf_ReadInt(infile);
-      pm->ground_slots = (w_bank *)mem_malloc(sizeof(w_bank) * pm->n_ground);
+      pm->ground_slots = mem_rmalloc<w_bank>(pm->n_ground);
       ASSERT(pm->ground_slots != nullptr);
 
       for (i = 0; i < pm->n_ground; i++) {

--- a/model/polymodel.cpp
+++ b/model/polymodel.cpp
@@ -1419,9 +1419,9 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
       ASSERT(nverts < MAX_POLYGON_VECS);
 
       if (nverts) {
-        pm->submodel[n].verts = (vector *)mem_malloc(nverts * sizeof(vector));
-        pm->submodel[n].vertnorms = (vector *)mem_malloc(nverts * sizeof(vector));
-        pm->submodel[n].alpha = (float *)mem_malloc(nverts * sizeof(float));
+        pm->submodel[n].verts = mem_rmalloc<vector>(nverts);
+        pm->submodel[n].vertnorms = mem_rmalloc<vector>(nverts);
+        pm->submodel[n].alpha = mem_rmalloc<float>(nverts);
         ASSERT(pm->submodel[n].verts);
         ASSERT(pm->submodel[n].vertnorms);
         ASSERT(pm->submodel[n].alpha);
@@ -1474,9 +1474,9 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
       pm->submodel[n].num_faces = nfaces;
 
       if (nfaces) {
-        pm->submodel[n].faces = (polyface *)mem_malloc(nfaces * sizeof(polyface));
-        pm->submodel[n].face_min = (vector *)mem_malloc(nfaces * sizeof(vector));
-        pm->submodel[n].face_max = (vector *)mem_malloc(nfaces * sizeof(vector));
+        pm->submodel[n].faces = mem_rmalloc<polyface>(nfaces);
+        pm->submodel[n].face_min = mem_rmalloc<vector>(nfaces);
+        pm->submodel[n].face_max = mem_rmalloc<vector>(nfaces);
         ASSERT(pm->submodel[n].faces);
       } else {
         pm->submodel[n].faces = nullptr;
@@ -1524,13 +1524,13 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
 
       // Allocate our space
       if (current_count) {
-        sm->vertnum_memory = (int16_t *)mem_malloc(current_count * sizeof(int16_t));
+        sm->vertnum_memory = mem_rmalloc<int16_t>(current_count);
         ASSERT(sm->vertnum_memory);
 
-        sm->u_memory = (float *)mem_malloc(current_count * sizeof(float));
+        sm->u_memory = mem_rmalloc<float>(current_count);
         ASSERT(sm->u_memory);
 
-        sm->v_memory = (float *)mem_malloc(current_count * sizeof(float));
+        sm->v_memory = mem_rmalloc<float>(current_count);
         ASSERT(sm->v_memory);
       } else {
         sm->vertnum_memory = nullptr;

--- a/model/polymodel.cpp
+++ b/model/polymodel.cpp
@@ -1087,7 +1087,7 @@ void SetPolymodelProperties(bsp_info *subobj, char *props) {
     subobj->flags |= SOF_GLOW;
 
     if (subobj->glow_info == nullptr) // DAJ may already exist
-      subobj->glow_info = (glowinfo *)mem_malloc(sizeof(glowinfo));
+      subobj->glow_info = mem_rmalloc<glowinfo>();
 
     subobj->glow_info->glow_r = r;
     subobj->glow_info->glow_g = g;
@@ -1111,7 +1111,7 @@ void SetPolymodelProperties(bsp_info *subobj, char *props) {
     subobj->flags |= SOF_THRUSTER;
 
     if (subobj->glow_info == nullptr) // DAJ may already exist
-      subobj->glow_info = (glowinfo *)mem_malloc(sizeof(glowinfo));
+      subobj->glow_info = mem_rmalloc<glowinfo>();
 
     subobj->glow_info->glow_r = r;
     subobj->glow_info->glow_g = g;

--- a/model/polymodel.cpp
+++ b/model/polymodel.cpp
@@ -1802,9 +1802,9 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
           pm->submodel[i].num_key_angles = nframes;
         }
 
-        pm->submodel[i].keyframe_axis = (vector *)mem_malloc((pm->submodel[i].num_key_angles + 1) * sizeof(vector));
+        pm->submodel[i].keyframe_axis = mem_rmalloc<vector>(pm->submodel[i].num_key_angles + 1);
         pm->submodel[i].keyframe_angles = (int *)mem_malloc((pm->submodel[i].num_key_angles + 1) * sizeof(int));
-        pm->submodel[i].keyframe_matrix = (matrix *)mem_malloc((pm->submodel[i].num_key_angles + 1) * sizeof(matrix));
+        pm->submodel[i].keyframe_matrix = mem_rmalloc<matrix>(pm->submodel[i].num_key_angles + 1);
         if (timed) {
           pm->submodel[i].rot_start_time = (int *)mem_malloc((pm->submodel[i].num_key_angles + 1) * sizeof(int));
           ASSERT(pm->submodel[i].rot_start_time != nullptr);
@@ -1892,7 +1892,7 @@ int ReadNewModelFile(int polynum, CFILE *infile) {
         } else
           pm->submodel[i].num_key_pos = nframes;
 
-        pm->submodel[i].keyframe_pos = (vector *)mem_malloc((pm->submodel[i].num_key_pos + 1) * sizeof(vector));
+        pm->submodel[i].keyframe_pos = mem_rmalloc<vector>(pm->submodel[i].num_key_pos + 1);
         ASSERT(pm->submodel[i].keyframe_pos != nullptr);
 
         if (timed) {

--- a/music/sequencer.cpp
+++ b/music/sequencer.cpp
@@ -179,7 +179,7 @@ bool OutrageMusicSeq::Init(const char *theme_file) {
 
   // initialize memory buffers
   m_ins_buffer = mem_rmalloc<music_ins>(MAX_MUSIC_INSTRUCTIONS);
-  m_str_buffer = (char *)mem_malloc(MAX_MUSIC_STRLEN);
+  m_str_buffer = mem_rmalloc<char>(MAX_MUSIC_STRLEN);
   m_ins_curptr = m_ins_buffer;
   m_str_curptr = m_str_buffer;
   m_str_curptr[0] = 0;

--- a/music/sequencer.cpp
+++ b/music/sequencer.cpp
@@ -178,7 +178,7 @@ bool OutrageMusicSeq::Init(const char *theme_file) {
   Stop();
 
   // initialize memory buffers
-  m_ins_buffer = (music_ins *)mem_malloc(sizeof(music_ins) * MAX_MUSIC_INSTRUCTIONS);
+  m_ins_buffer = mem_rmalloc<music_ins>(MAX_MUSIC_INSTRUCTIONS);
   m_str_buffer = (char *)mem_malloc(MAX_MUSIC_STRLEN);
   m_ins_curptr = m_ins_buffer;
   m_str_curptr = m_str_buffer;

--- a/netcon/inetfile/Chttpget.cpp
+++ b/netcon/inetfile/Chttpget.cpp
@@ -663,7 +663,7 @@ int http_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
       http_lastaslu->abort = true;
 
     async_dns_lookup *newaslu;
-    newaslu = (async_dns_lookup *)mem_malloc(sizeof(async_dns_lookup));
+    newaslu = mem_rmalloc<async_dns_lookup>();
     memset(&newaslu->ip, 0, sizeof(uint32_t));
     newaslu->host = hostname;
     newaslu->done = false;

--- a/networking/networking.cpp
+++ b/networking/networking.cpp
@@ -1181,7 +1181,7 @@ int nw_SendReliable(uint32_t socketid, uint8_t *data, int length, bool urgent) {
       // mprintf(0,"Sending in nw_SendReliable() %d bytes seq=%d.\n",length,rsocket->theirsequence);
 
       rsocket->send_len[i] = length;
-      rsocket->sbuffers[i] = (reliable_net_sendbuffer *)mem_malloc(sizeof(reliable_net_sendbuffer));
+      rsocket->sbuffers[i] = mem_rmalloc<reliable_net_sendbuffer>();
 
       memcpy(rsocket->sbuffers[i]->buffer, data, length);
 
@@ -1507,7 +1507,7 @@ void nw_WorkReliable(uint8_t *data, int len, network_address *naddr) {
                 rsocket->recv_len[i] = max_len; // INTEL_SHORT(rcv_buff.data_len);
               else
                 rsocket->recv_len[i] = INTEL_SHORT(rcv_buff.data_len);
-              rsocket->rbuffers[i] = (reliable_net_rcvbuffer *)mem_malloc(sizeof(reliable_net_rcvbuffer));
+              rsocket->rbuffers[i] = mem_rmalloc<reliable_net_rcvbuffer>();
               memcpy(rsocket->rbuffers[i]->buffer, rcv_buff.data, rsocket->recv_len[i]);
               rsocket->rsequence[i] = INTEL_SHORT(rcv_buff.seq);
               // mprintf(0,"Adding packet to receive buffer in nw_ReceiveReliable().\n");
@@ -2134,7 +2134,7 @@ int nw_Asyncgethostbyname(uint32_t *ip, int command, char *hostname) {
 
 #if (!defined(POSIX))
     async_dns_lookup *newaslu;
-    newaslu = (async_dns_lookup *)mem_malloc(sizeof(async_dns_lookup));
+    newaslu = mem_rmalloc<async_dns_lookup>();
     memset(&newaslu->ip, 0, sizeof(uint32_t));
     newaslu->host = hostname;
     newaslu->done = false;

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -273,9 +273,9 @@ int opengl_InitCache() {
   OpenGL_lightmap_remap = (uint16_t *)mem_malloc(MAX_LIGHTMAPS * 2);
   ASSERT(OpenGL_lightmap_remap);
 
-  OpenGL_bitmap_states = (uint8_t *)mem_malloc(MAX_BITMAPS);
+  OpenGL_bitmap_states = mem_rmalloc<uint8_t>(MAX_BITMAPS);
   ASSERT(OpenGL_bitmap_states);
-  OpenGL_lightmap_states = (uint8_t *)mem_malloc(MAX_LIGHTMAPS);
+  OpenGL_lightmap_states = mem_rmalloc<uint8_t>(MAX_LIGHTMAPS);
   ASSERT(OpenGL_lightmap_states);
 
   // Setup textures and cacheing

--- a/sndlib/ddsoundload.cpp
+++ b/sndlib/ddsoundload.cpp
@@ -371,7 +371,7 @@ char SoundLoadWaveFile(const char *filename, float percent_volume, int sound_fil
         SoundFiles[sound_file_index].sample_length = aligned_size;
         SoundFiles[sound_file_index].np_sample_length = cksize;
 
-        SoundFiles[sound_file_index].sample_8bit = (uint8_t *)mem_malloc(aligned_size);
+        SoundFiles[sound_file_index].sample_8bit = mem_rmalloc<uint8_t>(aligned_size);
 
         cf_ReadBytes((uint8_t *)SoundFiles[sound_file_index].sample_8bit, cksize, cfptr);
 
@@ -438,7 +438,7 @@ char SoundLoadWaveFile(const char *filename, float percent_volume, int sound_fil
   } else if (SoundFiles[sound_file_index].sample_8bit == NULL && !f_high_quality) {
 
     SoundFiles[sound_file_index].sample_8bit =
-        (uint8_t *)mem_malloc(SoundFiles[sound_file_index].sample_length);
+        mem_rmalloc<uint8_t>(SoundFiles[sound_file_index].sample_length);
 
     // Do the volume clipping with the high quality sound
     for (count = 0; count < (int)SoundFiles[sound_file_index].sample_length; count++) {

--- a/sndlib/ddsoundload.cpp
+++ b/sndlib/ddsoundload.cpp
@@ -457,7 +457,7 @@ char SoundLoadWaveFile(const char *filename, float percent_volume, int sound_fil
 
   } else if (SoundFiles[sound_file_index].sample_16bit == NULL && f_high_quality) {
     SoundFiles[sound_file_index].sample_16bit =
-        (int16_t *)mem_malloc(SoundFiles[sound_file_index].sample_length * sizeof(int16_t));
+        mem_rmalloc<int16_t>(SoundFiles[sound_file_index].sample_length);
 
     // NOTE:  Interesting note on sound conversion:  16 bit sounds are signed (0 biase).  8 bit sounds are unsigned
     // (+128 biase).

--- a/sndlib/sdlsound.cpp
+++ b/sndlib/sdlsound.cpp
@@ -174,7 +174,7 @@ bool lnxsound::SetSoundQuality(char quality) {
         int count;
 
         ASSERT(SoundFiles[j].sample_8bit == nullptr);
-        SoundFiles[j].sample_8bit = (uint8_t *)mem_malloc(SoundFiles[j].sample_length);
+        SoundFiles[j].sample_8bit = mem_rmalloc<uint8_t>(SoundFiles[j].sample_length);
 
         // NOTE:  Interesting note on sound conversion:  16 bit sounds are signed (0 biase).  8 bit sounds are unsigned
         // (+128 biase).

--- a/stream_audio/streamaudio.cpp
+++ b/stream_audio/streamaudio.cpp
@@ -538,7 +538,7 @@ bool AudioStream::ReopenDigitalStream(uint8_t fbufidx, int nbufs) {
       if (m_buffer[m_fbufidx].data) {
         mem_free(m_buffer[m_fbufidx].data);
       }
-      m_buffer[m_fbufidx].data = (uint8_t *)mem_malloc(m_bufsize);
+      m_buffer[m_fbufidx].data = mem_rmalloc<uint8_t>(m_bufsize);
     }
     m_buffer[m_fbufidx].nbytes = AudioStream::ReadFileData(m_fbufidx, m_bufsize);
     m_buffer[m_fbufidx].flags = 0;
@@ -857,7 +857,7 @@ void AudioStream::UpdateData() {
       if (m_buffer[m_fbufidx].data) {
         mem_free(m_buffer[m_fbufidx].data);
       }
-      m_buffer[m_fbufidx].data = (uint8_t *)mem_malloc(m_bufsize);
+      m_buffer[m_fbufidx].data = mem_rmalloc<uint8_t>(m_bufsize);
     }
     m_buffer[m_fbufidx].nbytes = AudioStream::ReadFileData(m_fbufidx, m_bufsize);
     m_buffer[m_fbufidx].flags = 0;

--- a/ui/UIConsole.cpp
+++ b/ui/UIConsole.cpp
@@ -110,7 +110,7 @@ void UIConsoleGadget::Create(UIWindow *parent, int id, int x, int y, int font, i
   // extra 32 bytes per row for color coding.
   m_ConsoleBuffer = (char *)mem_malloc(m_Rows * m_Rowsize);
   m_PutsBufLen = 512;
-  m_PutsBuffer = (char *)mem_malloc(m_PutsBufLen);
+  m_PutsBuffer = mem_rmalloc<char>(m_PutsBufLen);
 
   m_ColorRows = new ddgr_color[m_Rows];
   memset(m_ConsoleBuffer, 0, m_Rows * m_Rowsize);
@@ -141,7 +141,7 @@ void UIConsoleGadget::puts(ddgr_color col, const char *str) {
   if (len >= m_PutsBufLen) {
     mem_free(m_PutsBuffer);
     m_PutsBufLen = len + 1;
-    m_PutsBuffer = (char *)mem_malloc(m_PutsBufLen);
+    m_PutsBuffer = mem_rmalloc<char>(m_PutsBufLen);
   }
 
   textaux_WordWrap(str, m_PutsBuffer, m_W - 2 * m_OffX, m_ConsoleFont);


### PR DESCRIPTION
## Pull Request Type

- [x] Runtime changes
  - [x] Other changes

### Description

UBSAN evaluates use of undefined variable contents at runtime; it's more effective against unintialized heap allocations, whereas compile-time is more effective to mark code paths that are perhaps not exercised during gameplay at all.
mem_malloc is rewritten to catch potentially allocating nontrivial class types, the latter of which is a result of adding initializers. This supersedes https://github.com/DescentDevelopers/Descent3/pull/568/commits/7777720695dc9b294ba01e22fbcd53032dfe5b38 which only fixed a few struct members.

### Related Issues

#568

### Checklist

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
