### PR TITLE
Rework fvi_room patch

### DIFF
--- a/physics/findintersection.cpp
+++ b/physics/findintersection.cpp
@@ -4708,8 +4708,8 @@ int fvi_room(int room_index, int from_portal, int room_obj) {
           // If we hit the face...
           if (face_hit_type) {
             if ((fvi_query_ptr->flags & FQ_RECORD) && (face_info & FPF_RECORD) &&
-                Fvi_num_recorded_faces > 0 &&
-                !(Fvi_recorded_faces[Fvi_num_recorded_faces - 1].face_index == i &&
+                !(Fvi_num_recorded_faces > 0 &&
+                  Fvi_recorded_faces[Fvi_num_recorded_faces - 1].face_index == i &&
                   Fvi_recorded_faces[Fvi_num_recorded_faces - 1].room_index == room_index)) {
               ASSERT(Fvi_num_recorded_faces < MAX_RECORDED_FACES);
               if (Fvi_num_recorded_faces < MAX_RECORDED_FACES) {


### PR DESCRIPTION

## Pull Request Type

- [x] Runtime changes
  - [x] Other changes

### Description

In Retribution level 15, the cinematic animation would not start playing when entering Dravis's room (after defating Hellion).

Fixes: cb5c2913b29a331231ba4268d29a15028165dccc

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
