### PR TITLE
Fix dedicated runtime error

### DIFF
--- a/Descent3/Player.cpp
+++ b/Descent3/Player.cpp
@@ -3629,7 +3629,7 @@ int PlayerSetCustomTexture(int slot, char *filename) {
 //	Sets/Clears a permission for a ship on a given player
 //	if pnum is -1 then all players will be set, else player is the player number
 //	returns true on success
-bool PlayerSetShipPermission(int pnum, char *ship_name, bool allowed) {
+bool PlayerSetShipPermission(int pnum, const char *ship_name, bool allowed) {
   ASSERT(ship_name);
 
   if (pnum < -1 || pnum >= MAX_PLAYERS) // illegal value
@@ -3645,11 +3645,11 @@ bool PlayerSetShipPermission(int pnum, char *ship_name, bool allowed) {
 
   if (pnum == -1) {
     // go through everyone
-    for (int i = 0; i < MAX_PLAYERS; i++) {
+    for (auto &Player : Players) {
       if (allowed)
-        Players[i].ship_permissions |= bit;
+        Player.ship_permissions |= bit;
       else
-        Players[i].ship_permissions &= ~bit;
+        Player.ship_permissions &= ~bit;
     }
   } else {
     if (allowed)

--- a/Descent3/dedicated_server.cpp
+++ b/Descent3/dedicated_server.cpp
@@ -328,7 +328,11 @@ int LoadServerConfigFile() {
   }
 
   if (GameArgs[t + 1][0]) {
-    strcpy(Netgame.server_config_name, GameArgs[t + 1]);
+    Netgame.server_config_name = GameArgs[t + 1];
+    if (!std::filesystem::is_regular_file(Netgame.server_config_name)) {
+      mprintf(0, "Cannot find configuration file for dedicated server!\n");
+      Int3();
+    }
   } else {
     PrintDedicatedMessage(TXT_DS_MISSINGCONFIG);
     PrintDedicatedMessage("\n");
@@ -337,7 +341,7 @@ int LoadServerConfigFile() {
 
   //	open file
   if (!inf.Open(Netgame.server_config_name, "[server config file]", DedicatedServerLex)) {
-    PrintDedicatedMessage(TXT_DS_BADCONFIG, Netgame.server_config_name);
+    PrintDedicatedMessage(TXT_DS_BADCONFIG, Netgame.server_config_name.u8string().c_str());
     PrintDedicatedMessage("\n");
     return 0;
   }

--- a/Descent3/dedicated_server.cpp
+++ b/Descent3/dedicated_server.cpp
@@ -311,7 +311,6 @@ int LoadServerConfigFile() {
   char operand[INFFILE_LINELEN]; // operand
   int t = FindArgChar("-dedicated", 'd');
 
-  //	int t=FindArg ("-dedicated");
   if (!t) {
     PrintDedicatedMessage(TXT_DS_BADCOMMANDLINE);
     PrintDedicatedMessage("\n");
@@ -322,9 +321,9 @@ int LoadServerConfigFile() {
   MultiResetSettings();
 
   // Make all ships available
-  for (int i = 0; i < MAX_SHIPS; i++) {
-    if (Ships[i].used)
-      PlayerSetShipPermission(-1, Ships[i].name, true);
+  for (auto const &Ship : Ships) {
+    if (Ship.used)
+      PlayerSetShipPermission(-1, Ship.name, true);
   }
 
   if (GameArgs[t + 1][0]) {

--- a/Descent3/multi_external.h
+++ b/Descent3/multi_external.h
@@ -249,7 +249,7 @@ struct netgame_info {
   char mission[MSN_NAMELEN];
   char mission_name[MISSION_NAME_LEN];
   char scriptname[NETGAME_SCRIPT_LEN];
-  char server_config_name[PAGENAME_LEN];
+  std::filesystem::path server_config_name;
   char connection_name[PAGENAME_LEN];
   network_address server_address; // The address of the server that we're talking to - not used if we are the server
 

--- a/Descent3/player.h
+++ b/Descent3/player.h
@@ -547,7 +547,7 @@ int PlayerChooseDeathFate(int slot, float damage, bool melee);
 //	Sets/Clears a permission for a ship on a given player
 //	if pnum is -1 then all players will be set, else player is the player number
 //	returns true on success
-bool PlayerSetShipPermission(int pnum, char *ship_name, bool allowed);
+bool PlayerSetShipPermission(int pnum, const char *ship_name, bool allowed);
 
 //	Resets the ship permissions for a given player
 //	pass false for set_default if you don't want the default ship allowed


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [x] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

`netgame_info` is limited by PAGENAME_LEN (35) and this cause SIG_ABORT if user pass very long filename to `-dedicated` config option, as discovered in #571. Additional check for filename existence.
Minor enhancements to related code.


### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

Fixes #571

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
