### PR TITLE
[Init] Fixed Default_pilot initialization

### DIFF
--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1349,9 +1349,10 @@ void LoadGameSettings() {
   }
 
   int len = _MAX_PATH;
-  char temp_str[_MAX_PATH];
-  Database->read("Default_pilot", temp_str, &len);
-  Default_pilot = temp_str;
+  char temp_str[_MAX_PATH] = "";
+  if (Database->read("Default_pilot", temp_str, &len)) {
+    Default_pilot = temp_str;
+  }
 
   // Now that we have read in all the data, set the detail level if it is a predef setting (custom is ignored in
   // function)


### PR DESCRIPTION
When we have no config file yet, e.g. on first start of the game, or the entry for "Default_pilot" is missing in the config, the variable Default_pilot will be filled with random memory. This might later crash when we try to interpret this string as std::filesystem::path in PilotSelect() in pilot.cpp.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
When we have no config file yet, e.g. on first start of the game, or the entry for "Default_pilot" is missing in the config, the variable Default_pilot will be filled with random memory. This might later crash when we try to interpret this string as std::filesystem::path in PilotSelect() in pilot.cpp.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #594

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
