### PR TITLE
Disallow exiting pilot selection without selecting a pilot

### DIFF
--- a/Descent3/pilot.cpp
+++ b/Descent3/pilot.cpp
@@ -964,14 +964,12 @@ void PilotSelect() {
   NewPltUpdate(select.pilot_list, 0, pfilename);
 
   // if we get here than there is at least one pilot already
-  char old_file[_MAX_FNAME];
+  std::filesystem::path old_file;
 
   // use this in case they cancel out
   pfilename = Current_pilot.get_filename();
   if (cfexist(pfilename) != CFES_NOT_FOUND) {
-    strcpy(old_file, pfilename.c_str());
-  } else {
-    old_file[0] = '\0';
+    old_file =  std::filesystem::u8path(pfilename);
   }
 
   DoWaitMessage(false);
@@ -1023,7 +1021,7 @@ void PilotSelect() {
 
     case UID_CANCEL: {
       // Cancel out
-      bool found_old = (cfexist(old_file) != CFES_NOT_FOUND);
+      bool found_old = !old_file.empty();
       bool display_error;
 
       if (filecount && found_old)
@@ -1036,7 +1034,7 @@ void PilotSelect() {
         PilotListSelectChangeCallback(index);
 
         if (found_old) {
-          Current_pilot.set_filename(old_file);
+          Current_pilot.set_filename(old_file.u8string());
           PltReadFile(&Current_pilot, true, true);
 
           char pname[PILOT_STRING_SIZE];
@@ -1053,7 +1051,7 @@ void PilotSelect() {
       }
 
       if (display_error) {
-        if (filecount > 0 && old_file[0] != '\0') {
+        if (filecount > 0 && !old_file.empty()) {
           DoMessageBox(TXT_PLTERROR, TXT_OLDPILOTNOEXIST, MSGBOX_OK, UICOL_WINDOW_TITLE, UICOL_TEXT_NORMAL);
         } else {
           DoMessageBox(TXT_PLTERROR, TXT_NEEDTOCREATE, MSGBOX_OK, UICOL_WINDOW_TITLE, UICOL_TEXT_NORMAL);


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Message box did not display correctly when cancelling (ESC) the pilot selection menu, allowing entering the game without a valid pilot


### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

Completes #598 

Same vein as #594 

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [ ] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [ ] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [ ] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
