### PR TITLE
Registry: read hexadecimal values correctly

### DIFF
--- a/linux/registry.cpp
+++ b/linux/registry.cpp
@@ -1,5 +1,5 @@
 /*
-* Descent 3 
+* Descent 3
 * Copyright (C) 2024 Parallax Software
 *
 * This program is free software: you can redistribute it and/or modify
@@ -51,7 +51,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cctype>
-
+#include <sstream>
 #include "log.h"
 #include "registry.h"
 
@@ -60,19 +60,11 @@
 #endif
 
 // Convert a string that represents a hex value into an int
-int hextoi(char *p) {
-  int value = 0;
-  while ((p) && (*p) && isalnum(*p)) {
-    *p = toupper(*p);
-    if ((*p >= '0') && (*p <= '9'))
-      value = (value * 16) + ((*p) - '0');
-    else if ((*p >= 'A') && (*p <= 'F'))
-      value = (value * 16) + ((*p) - 'A');
-    else
-      return value;
-
-    p++;
-  }
+int hextoi(char *hexstring) {
+  int value;
+  std::stringstream ss;
+  ss << std::hex << hexstring;
+  ss >> value;
   return value;
 }
 
@@ -289,7 +281,6 @@ bool CRegistry::Import() {
         }
         // now we "SHOULD" know the type, parse the info
         char data[300];
-        int idata;
         switch (type) {
         case REGT_STRING:
           PARSE_STRING(newbuff);
@@ -310,7 +301,7 @@ bool CRegistry::Import() {
           PARSE_STRING(newbuff);
           ptr += 7; // blow by =dword:
           PARSE_TOKEN(data);
-          idata = hextoi(data);
+          int idata = hextoi(data);
           if (!CreateRecord(newbuff, REGT_DWORD, &idata)) {
             // mprintf(0,"Unable to create dword record: %s\n",newbuff);
           } else {


### PR DESCRIPTION

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Hex string values from the registry containing an alpha character were parsed incorrectly. Use more standard hex parsing instead of hand-made incorrect function

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

#590

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
