### PR TITLE
Fix debug break when starting missions with scripts

### DIFF
--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -3130,58 +3130,33 @@ int Osiris_ExtractScriptsFromHog(int library_handle, bool is_mission_hog) {
 
   LOG_DEBUG << "Search started";
   if (cf_LibraryFindFirst(library_handle, script_extension, filename)) {
-    temp_filename = ddio_GetTmpFileName(tempdir, "d3s");
-    if (temp_filename.empty())
-      Int3();
-    else {
-      // extract it out
-      cf_CopyFile(temp_filename, filename);
+    do {
+      // generate temp filename
+      temp_filename = ddio_GetTmpFileName(tempdir, "d3s");
+      if (temp_filename.empty())
+        Int3();
+      else {
+        // extract it out
+        cf_CopyFile(temp_filename, filename);
 
-      temp_file = temp_filename.filename();
-      temp_realname = std::filesystem::path(filename).stem().u8string();
-      // Lowercase for optimized search
-      std::transform(temp_realname.begin(), temp_realname.end(), temp_realname.begin(), [](unsigned char c) {
-        return std::tolower(c);
-      });
+        temp_file = temp_filename.filename();
+        temp_realname = std::filesystem::path(filename).stem().u8string();
+        // Lowercase for optimized search
+        std::transform(temp_realname.begin(), temp_realname.end(), temp_realname.begin(), [](unsigned char c) {
+          return std::tolower(c);
+        });
 
-      if (is_mission_hog) {
-        t.flags = OESF_MISSION;
-      }
-      t.temp_filename = temp_file;
-      OSIRIS_Extracted_scripts.insert_or_assign(temp_realname, t);
-
-      LOG_DEBUG.printf("Extracted %s as %s", temp_realname.c_str(), temp_filename.u8string().c_str());
-
-      count++;
-
-      while (cf_LibraryFindNext(filename)) {
-        // generate temp filename
-        temp_filename = ddio_GetTmpFileName(tempdir, "d3s");
-        if (temp_filename.empty())
-          Int3();
-        else {
-          // extract it out
-          cf_CopyFile(temp_filename, filename);
-
-          temp_file = temp_filename.filename();
-          temp_realname = std::filesystem::path(filename).stem().u8string();
-          // Lowercase for optimized search
-          std::transform(temp_realname.begin(), temp_realname.end(), temp_realname.begin(), [](unsigned char c) {
-            return std::tolower(c);
-          });
-
-          if (is_mission_hog) {
-            t.flags = OESF_MISSION;
-          }
-          t.temp_filename = temp_file;
-          OSIRIS_Extracted_scripts.insert_or_assign(temp_realname, t);
-
-          LOG_DEBUG.printf("Extracted %s as %s", temp_realname.c_str(), temp_filename.u8string().c_str());
-
-          count++;
+        if (is_mission_hog) {
+          t.flags = OESF_MISSION;
         }
+        t.temp_filename = temp_file;
+        OSIRIS_Extracted_scripts.insert_or_assign(temp_realname, t);
+
+        LOG_DEBUG.printf("Extracted %s as %s", temp_realname.c_str(), temp_filename.u8string().c_str());
+
+        count++;
       }
-    }
+    } while (cf_LibraryFindNext(filename));
   }
 
   LOG_DEBUG.printf("Extracted %d scripts", count);


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

This pull request prevents this error from happening when you start a new single player game on Windows:

![Descent 3 Debug Break&NewLine;&NewLine;Int3 in C:\Users\Anon Y. Mous\Documents\Descent3-backup\Descent3\OsirisLoadandBind.cpp at line 1005.&NewLine;&NewLine;It's probably safe to continue.  Continue?&NewLine;&NewLine;Choose one of these options: Yes or No.](https://github.com/user-attachments/assets/7cf0393f-2972-4e53-93c4-78a1a35cc0f6)

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

Fixes #605.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
