### PR TITLE
Fixed access of map::iterator to recently deleted element

### DIFF
--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -3200,12 +3200,14 @@ void Osiris_ClearExtractedScripts(bool mission_only) {
     return;
   }
 
-  for (auto it = OSIRIS_Extracted_scripts.begin(); it != OSIRIS_Extracted_scripts.end(); ++it) {
-    if (mission_only && (!(it->second.flags & OESF_MISSION)))
-      continue;
-
-    std::filesystem::remove(OSIRIS_Extracted_script_dir / it->second.temp_filename);
-    OSIRIS_Extracted_scripts.erase(it);
+  for (auto it = OSIRIS_Extracted_scripts.begin(); it != OSIRIS_Extracted_scripts.end();) {
+    if (mission_only && (!(it->second.flags & OESF_MISSION))) {
+      ++it;
+    }
+    else {
+      std::filesystem::remove(OSIRIS_Extracted_script_dir / it->second.temp_filename);
+      it = OSIRIS_Extracted_scripts.erase(it);
+    }
   }
 
   if (!mission_only) {

--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -918,7 +918,7 @@ int get_full_path_to_module(const std::filesystem::path &module_name, std::files
       return -2;
 
     // search through our list of extracted files to find it...
-    if (OSIRIS_Extracted_scripts.find(std::filesystem::path(basename)) != OSIRIS_Extracted_scripts.end()) {
+    if (OSIRIS_Extracted_scripts.find(basename) != OSIRIS_Extracted_scripts.end()) {
       fullpath = OSIRIS_Extracted_script_dir / OSIRIS_Extracted_scripts[basename].temp_filename;
       return 0;
     }


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Deleting an element from a `std::map` invalidates the `iterator` to that element. So trying to continue the loop will lead to bad things. Fortunately `map::erase()` returns an iterator to the next element that we can assign to `it` to correctly continue the loop.
Also removed a left over cast of `basename` to `std::filesystem::path`.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #604 

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
