### PR TITLE
Fix level loading

### DIFF
--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -1811,7 +1811,6 @@ bool mn3_Open(const char *mn3file) {
   char pathname[_MAX_PATH];
   char filename[PSFILENAME_LEN + 1];
   char ext[PSFILENAME_LEN];
-  int mn3_handle;
   // concatanate the mn3 extension if it isn't there.
   char tempMn3File[_MAX_PATH];
   if (!IS_MN3_FILE(mn3file)) {
@@ -1823,11 +1822,9 @@ bool mn3_Open(const char *mn3file) {
 
   ddio_MakePath(pathname, D3MissionsDir, mn3file, NULL);
   // open MN3 HOG.
-  mn3_handle = cf_OpenLibrary(mn3file);
+  int mn3_handle = cf_OpenLibrary(mn3file);
   if (mn3_handle == 0) {
     return false;
-  } else {
-    Osiris_ExtractScriptsFromHog(mn3_handle, true);
   }
   // do table file stuff.
   ddio_SplitPath(mn3file, NULL, filename, ext);

--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -429,15 +429,13 @@
 
 bool Show_osiris_debug = false;
 
-#define MAX_LOADED_MODULES 96 // maximum number of dlls that can be loaded at a time
+#define MAX_LOADED_MODULES 64 // maximum number of dlls that can be loaded at a time
 
 #define OSIMF_INUSE 0x1        // slot in use
 #define OSIMF_LEVEL 0x2        // level module
 #define OSIMF_DLLELSEWHERE 0x4 // mission module
 #define OSIMF_INTEMPDIR 0x8    // the dll was extracted from a hog and it is in a temp file
-#define OSIMF_NOUNLOAD                                                                                                 \
-  0x10 // the dll should not be unloaded if the reference count is
-       // 0, only when the level ends
+#define OSIMF_NOUNLOAD 0x10    // the dll should not be unloaded if the reference count is 0, only when the level ends
 
 // The exported DLL function call prototypes
 #if defined(POSIX)

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1501,8 +1501,6 @@ void InitIOSystems(bool editor) {
   ddio_MakePath(fullname, LocalD3Dir, "extra13.hog", NULL);
   extra13_hid = cf_OpenLibrary(fullname);
 
-  // last library opened is the first to be searched for dynamic libs, so put
-  // this one at the end to find our newly build script libraries first
   ddio_MakePath(fullname, LocalD3Dir, PRIMARY_HOG, NULL);
   sys_hid = cf_OpenLibrary(fullname);
 
@@ -1528,19 +1526,15 @@ void InitIOSystems(bool editor) {
     }
   }
 
-  // Initialize debug graph early incase any system uses it in its init
+  // Initialize debug graph early in case any system uses it in its init
   INIT_MESSAGE(("Initializing debug graph."));
   DebugGraph_Initialize();
 
-  //	initialize all the OSIRIS systems
-  //	extract from extra.hog first, so its DLL files are listed ahead of d3.hog's
+  // initialize all the OSIRIS systems
+  // extract only DLL files from our own build hog file, everything else is outdated code from original game data
   INIT_MESSAGE(("Initializing OSIRIS."));
   Osiris_InitModuleLoader();
-  Osiris_ExtractScriptsFromHog(extra13_hid, false);
-  Osiris_ExtractScriptsFromHog(extra_hid, false);
-  Osiris_ExtractScriptsFromHog(merc_hid, false);
   Osiris_ExtractScriptsFromHog(sys_hid, false);
-  Osiris_ExtractScriptsFromHog(d3_hid, false);
 }
 
 bool MercInstalled() { return merc_hid > 0; }


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
I believe some changes from #591 broke loading levels or anything that loads dynamic libs from hog files (at least on Windows). Instead of loading the new x64 DLLs from d3-win.hog, the old x86 DLLs from the original game data are loaded, which fails spectacularly.

There is this comment still, that isn't true anymore: https://github.com/DescentDevelopers/Descent3/blob/3a7c86a2d257718bc9c6071fc6007a839ee6f3b7/Descent3/init.cpp#L1504-L1505

`Osiris_ExtractScriptsFromHog()` will happily overwrite existing entries of foo.dll in `OSIRIS_Extracted_scripts` with the last loaded temp filename from either d3.hog or any .mn3 file loaded at level start.

Trying to fix the problem, I asked myself: Why do we even load the old dynamic libs at all? We extract both old and new libs to the temp directory, only to ignore the old ones and only load the new ones. We can skip all that and only extract and load the new ones. Which this PR tries to do.

On Linux/Mac we might have a subtle difference. Since the original builds are already x64 and loading the old dynamic libs might just work, without us realizing that we don't load our new/fixed code from d3-linux|mac.hog.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
