### PR TITLE
Reduce MAX_LOADED_MODULES to its original value

### DIFF
--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -430,15 +430,13 @@
 
 bool Show_osiris_debug = false;
 
-#define MAX_LOADED_MODULES 96 // maximum number of dlls that can be loaded at a time
+#define MAX_LOADED_MODULES 64 // maximum number of dlls that can be loaded at a time
 
 #define OSIMF_INUSE 0x1        // slot in use
 #define OSIMF_LEVEL 0x2        // level module
 #define OSIMF_DLLELSEWHERE 0x4 // mission module
 #define OSIMF_INTEMPDIR 0x8    // the dll was extracted from a hog and it is in a temp file
-#define OSIMF_NOUNLOAD                                                                                                 \
-  0x10 // the dll should not be unloaded if the reference count is
-       // 0, only when the level ends
+#define OSIMF_NOUNLOAD 0x10    // the dll should not be unloaded if the reference count is 0, only when the level ends
 
 // The exported DLL function call prototypes
 #if defined(POSIX)


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
`MAX_LOADED_MODULES` was increased after introduction of `d3-win.hog` to account for the new x64 DLLs being loaded additional to existing DLLs from original game data. With #603 we don't load the old libs anymore and the limit can be reduced to its original value.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Followup to #603

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
