### PR TITLE
Fix crash when loading multiplayer level

### DIFF
--- a/Descent3/Player.cpp
+++ b/Descent3/Player.cpp
@@ -1336,7 +1336,7 @@ int PlayerGetRandomStartPosition(int slot) {
         room *rp = &Rooms[Players[num].start_roomnum];
         objnum = rp->objects;
       } else {
-        objnum = Terrain_seg[Players[num].start_roomnum].objects;
+        objnum = Terrain_seg[CELLNUM(Players[num].start_roomnum)].objects;
       }
       int bad = 0;
       for (; objnum != -1 && !bad; objnum = Objects[objnum].next) {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Fix crash when loading multiplayer level with outside/terrain player spawn position.

`player::start_roomnum` and `object::roomnum` encode a terrain cell number with the highest bit set. So when accessing `Terrain_seg[]` we need to remove that bit to get a valid index.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #442

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
