### PR TITLE
Remove scaling of terrain fog ranges based on zoom

### DIFF
--- a/Descent3/terrainrender.cpp
+++ b/Descent3/terrainrender.cpp
@@ -1372,7 +1372,7 @@ void RenderTerrain(uint8_t from_mine, int left, int top, int right, int bot) {
 #else
   const float kTerrainRenderDistance = 1200.0f;
 #endif
-  VisibleTerrainZ = kTerrainRenderDistance * Matrix_scale.z;
+  VisibleTerrainZ = kTerrainRenderDistance;
   Far_fog_border = VisibleTerrainZ;
 
   // Set up our z wall


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [x] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
This fixes visibility range decreasing massively on maximum weapon zoom of e.g. Mass Driver.
This also brings it in line with the 'non-terrain' rendering in https://github.com/DescentDevelopers/Descent3/blob/7ca92bd1bd31db1500baca1b1423435f2db5ecaa/Descent3/render.cpp#L3446

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #508

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
