### PR TITLE
Fix undefined behavior in memory allocation

### DIFF
--- a/mem/mem.h
+++ b/mem/mem.h
@@ -76,17 +76,6 @@
 #include <cstdlib>
 #include <type_traits>
 
-template<typename T> static inline T *mem_rmalloc()
-{
-	static_assert(std::is_trivially_constructible_v<T> && std::is_trivially_destructible_v<T>);
-	return static_cast<T *>(std::malloc(sizeof(T)));
-}
-template<typename T> static inline T *mem_rmalloc(std::size_t nelem)
-{
-	static_assert(std::is_trivially_constructible_v<T> && std::is_trivially_destructible_v<T>);
-	return static_cast<T *>(std::malloc(nelem * sizeof(T)));
-}
-
 // Memory management debugging
 #ifdef MEM_USE_RTL
 #define mem_malloc(d) malloc(d) // Use this if your going to run BoundsChecker
@@ -106,10 +95,10 @@ template<typename T> static inline T *mem_rmalloc(std::size_t nelem)
 extern bool Mem_low_memory_mode;
 extern bool Mem_superlow_memory_mode; // DAJ
 
-//	use if you want to manually print out a memory error
+// use if you want to manually print out a memory error
 #define mem_error() mem_error_msg(__FILE__, __LINE__)
 
-//	initializes memory library.
+// initializes memory library.
 void mem_Init();
 
 // shutsdown memory
@@ -124,7 +113,7 @@ void *mem_malloc_sub(int size, const char *file, int line);
 // Frees a previously allocated block of memory
 void mem_free_sub(void *memblock);
 
-//	prints out a memory error message
+// prints out a memory error message
 void mem_error_msg(const char *file, int line, int size = -1);
 
 char *mem_strdup_sub(const char *src, const char *file, int line);
@@ -136,5 +125,17 @@ int mem_size_sub(void *memblock);
 bool mem_dumpmallocstofile(char *filename);
 
 void mem_heapcheck();
+
+// type aware memory allocation
+template<typename T> static inline T *mem_rmalloc()
+{
+  static_assert(std::is_trivially_constructible_v<T> && std::is_trivially_destructible_v<T>);
+  return static_cast<T *>(mem_malloc(sizeof(T)));
+}
+template<typename T> static inline T *mem_rmalloc(std::size_t nelem)
+{
+  static_assert(std::is_trivially_constructible_v<T> && std::is_trivially_destructible_v<T>);
+  return static_cast<T *>(mem_malloc(nelem * sizeof(T)));
+}
 
 #endif


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Currently `mem_rmalloc` uses `std::malloc` for memory allocation and the deallocation is performed in `mem_free`
which calls `::free`. This does seem to work but is **undefined behavior** because memory allocated with `std::malloc`
should be freed with `std::free` not `::free`.

We should use either 
- the C interface: `::malloc` and `::free`, or
- C++ interface: `std::malloc` and `std::free`.

The `mem_malloc/mem_free` functions already use the C interface so it makes sense to let `mem_rmalloc` simply call
`mem_malloc` instead of `std::malloc` directly. There's also no speed difference because everything is inline or a macro. 

This changes the `mem_rmalloc` function to call `mem_malloc` instead of `std::malloc` to match the `mem_free` call.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
