### PR TITLE
Do no try opening audio streams when the '-nosound' option is specified

### DIFF
--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1912,7 +1912,7 @@ void InitD3Systems2(bool editor) {
 
   // the remaining sound system
   InitVoices();
-  InitD3Music(FindArg("-nomusic") ? false : true);
+  InitD3Music(FindArg("-nomusic")  || FindArg("-nosound") ? false : true);
   InitAmbientSoundSystem();
 
   InitGameSystems(editor);

--- a/editor/gameeditor.cpp
+++ b/editor/gameeditor.cpp
@@ -886,7 +886,7 @@ void InitEditGameSystems() {
   ddio_MouseMode(MOUSE_EXCLUSIVE_MODE);
 
   // Sound initialization
-  InitD3Music(FindArg("-nomusic") ? false : true);
+  InitD3Music(FindArg("-nomusic") || FindArg("-nosound") ? false : true);
   Sound_system.InitSoundLib(Descent, Sound_mixer, Sound_quality, false);
 
   //	UI init.
@@ -925,7 +925,7 @@ void InitGameEditSystems() {
   ddio_MouseMode(MOUSE_STANDARD_MODE);
 
   // Sound initialization for editor
-  InitD3Music(FindArg("-nomusic") ? false : true);
+  InitD3Music(FindArg("-nomusic") || FindArg("-nosound") ? false : true);
   Sound_system.InitSoundLib(Descent, Sound_mixer, Sound_quality, false);
 
   NewUIClose();

--- a/music/sequencer.cpp
+++ b/music/sequencer.cpp
@@ -395,7 +395,6 @@ next_ins:
 
       // skip instructions until error is cleared.
       if (!err) {
-        //	mprintf(0, "MUSIC: Error opening stream %s on channel %d.\n", name, m_dominant_strm);
         LOG_WARNING.printf("Error opening stream %s on channel %d.", name, m_dominant_strm);
         strm->error = true;
       }


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [x] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

When the option was specified, many messages were spamming the console in debug mode "Error opening stream X.osf on channel Y.". Now music is not started at all with "-nosound".


### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x]  I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
