### PR TITLE
Fix Windows x86 build

### DIFF
--- a/renderer/dyna_gl.h
+++ b/renderer/dyna_gl.h
@@ -63,7 +63,7 @@ inline void CheckError() {
 
 template <typename T> struct FnPtr;
 template <typename Ret, typename... Args>
-struct FnPtr<Ret(Args...)> {
+struct FnPtr<Ret GLFUNCCALL(Args...)> {
   explicit FnPtr(std::string_view name, bool optional = false);
 
   Ret operator()(Args... args) const {
@@ -99,7 +99,7 @@ static void LoadGLFnPtrs() {
 }
 
 template<typename Ret, typename... Args>
-FnPtr<Ret(Args...)>::FnPtr(std::string_view name, bool optional) : fn_{} {
+FnPtr<Ret GLFUNCCALL(Args...)>::FnPtr(std::string_view name, bool optional) : fn_{} {
   inits_.push_back(std::make_tuple(reinterpret_cast<void**>(&fn_), name, optional));
 }
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
This fixes compilation of Windows x86 builds when creating template instantiations of `FnPtr` with functions using `__stdcall`.
The x64 case works because the `decltype` of `void __stdcall Fun(...)` is the same as `void Fun(...)` so the missing `GLFUNCCALL` in the declaration does not matter.
With this change I was able to run a local x86 build of the game.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Related to #631

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
