### PR TITLE
Fix some compiler warnings in the 2dlib directory

### DIFF
--- a/2dlib/font.cpp
+++ b/2dlib/font.cpp
@@ -168,15 +168,12 @@ inline int READ_FONT_DATA(FONTFILE ffile, void *buf, int size, int nelem) {
 }
 
 inline FONTFILE OPEN_FONT(const char *filename, bool &success) {
-  FONTFILE fp;
-  int file_id;
-
   success = false;
-  fp = (FONTFILE)cfopen(filename, "rb");
+  FONTFILE fp = (FONTFILE)cfopen(filename, "rb");
   if (!fp)
     return NULL;
 
-  file_id = READ_FONT_INT(fp);
+  uint32_t file_id = READ_FONT_INT(fp);
   if (file_id != 0xfeedbaba)
     return (FONTFILE)(-1);
 

--- a/2dlib/font.cpp
+++ b/2dlib/font.cpp
@@ -631,7 +631,7 @@ int grFont::draw_char(grSurface *sf, int x, int y, int ch, tCharProperties *chpr
 
 int grFont::draw_char(grSurface *sf, int x, int y, int ch, int sx, int sy, int sw, int sh, tCharProperties *chprop) {
   gr_font_record *ft;
-  int next_x = 0, width, index;
+  int next_x = 0, index;
 
   ASSERT(m_FontHandle > -1);
   if ((ch < min_ascii()) || (ch > max_ascii()))
@@ -643,6 +643,7 @@ int grFont::draw_char(grSurface *sf, int x, int y, int ch, int sx, int sy, int s
   index = ch - ft->font.min_ascii;
 
   //	draw either a color bitmap or mono font.
+  [[maybe_unused]] int width;
   if (ft->font.flags & FT_PROPORTIONAL) {
     width = (int)ft->font.char_widths[index];
   } else {

--- a/2dlib/memsurf.cpp
+++ b/2dlib/memsurf.cpp
@@ -265,9 +265,9 @@ void gr_mem_surf_Clear(ddgr_surface *dsf, ddgr_color col, int l, int t, int w, i
 bool gr_mem_surf_Blt(ddgr_surface *dsf, int dx, int dy, ddgr_surface *ssf, int sx, int sy, int sw, int sh) {
   //	Maybe we should allow slow 16bpp to 24bpp and vice-versa blts.
   //	for now, we wont.
-  mem_bitmap *sbm = (mem_bitmap *)ssf->obj, *dbm = (mem_bitmap *)dsf->obj;
+  mem_bitmap *dbm = (mem_bitmap *)dsf->obj;
 
-  ASSERT(dbm->bpp == sbm->bpp);
+  ASSERT(dbm->bpp == ((mem_bitmap *)ssf->obj)->bpp);
 
   switch (dbm->bpp) {
   case BPP_16:

--- a/2dlib/pen.cpp
+++ b/2dlib/pen.cpp
@@ -129,17 +129,8 @@ void grViewport::hline(ddgr_color col, int x1, int x2, int y1) {
   rend_DrawLine(x1, y1, x2, y1);
 }
 
-//	grViewport::line
-//		draws a clipped line
-
 void grViewport::line(ddgr_color color, int x1, int y1, int x2, int y2) {
-  int xa, ya, xb, yb;
   ASSERT(vp_Locked);
-
-  xa = global_x(x1);
-  ya = global_y(y1);
-  xb = global_x(x2);
-  yb = global_y(y2);
 
   rend_SetFlatColor(color);
   rend_DrawLine(x1, y1, x2, y2);

--- a/2dlib/pentext.cpp
+++ b/2dlib/pentext.cpp
@@ -333,23 +333,18 @@ void grViewport::draw_text_line_clip(int x, int y, char *str) {
 }
 
 void grViewport::draw_text_line(int x, int y, char *str) {
-  unsigned i, cur_x;
-
   /*	perform string drawing without viewport clipping.
           supports bitmap fonts or color(alpha) mapped fonts.
   */
-  cur_x = x;
-  for (i = 0; i < (int)strlen(str); i++) {
-    uint8_t ch;
-
-    ch = (uint8_t)str[i];
-
+  uint32_t cur_x = x;
+  for (size_t i = 0; i < strlen(str); i++) {
+    uint8_t ch = (uint8_t)str[i];
     if (ch == GR_COLOR_CHAR) {
-      if ((i + 3) >= (int)strlen(str))
+      if ((i + 3) >= strlen(str))
         Int3(); // This shouldn't happen!  bad string!
       set_text_color(GR_RGB(str[i + 1], str[i + 2], str[i + 3]));
       i += 4;
-      if (i >= (int)strlen(str))
+      if (i >= strlen(str))
         Int3(); // This shouldn't happen too.
       ch = (uint8_t)str[i];
     } else if (ch == '\t') { // tab char

--- a/2dlib/surface.cpp
+++ b/2dlib/surface.cpp
@@ -319,7 +319,6 @@ void grSurface::uniblt(int dx, int dy, grSurface *ssf, int sx, int sy, int sw, i
   //	mode 11b = dd_to_dd, 01b = mem_to_dd, 10b = dd_to_mem, 00b = mem_to_mem
   int mode = 0;
   ddgr_surface *dsfs = &ddsfObj, *ssfs = &ssf->ddsfObj;
-  bool err;
 
   //	setup blitting mode
   if (ssfs->type == SURFTYPE_GENERIC || ssfs->type == SURFTYPE_VIDEOSCREEN)
@@ -332,7 +331,7 @@ void grSurface::uniblt(int dx, int dy, grSurface *ssf, int sx, int sy, int sw, i
   */
   if (mode == 0x3) {
     ASSERT(!surf_Locked);
-    err = ddgr_surf_Blt(dsfs, dx, dy, ssfs, sx, sy, sw, sh);
+    ddgr_surf_Blt(dsfs, dx, dy, ssfs, sx, sy, sw, sh);
     return;
   }
 
@@ -340,7 +339,7 @@ void grSurface::uniblt(int dx, int dy, grSurface *ssf, int sx, int sy, int sw, i
                   just lock both surfaces and do a memory blt.
   */
   if (mode == 0) {
-    err = gr_mem_surf_Blt(dsfs, dx, dy, ssfs, sx, sy, sw, sh);
+    gr_mem_surf_Blt(dsfs, dx, dy, ssfs, sx, sy, sw, sh);
     return;
   }
 
@@ -359,7 +358,7 @@ void grSurface::uniblt(int dx, int dy, grSurface *ssf, int sx, int sy, int sw, i
     grSurface::scratch_mem_surf->flags = ssfs->flags;
 
     gr_mem_surf_Init(grSurface::scratch_mem_surf, data, rowsize);
-    err = gr_mem_surf_Blt(dsfs, dx, dy, grSurface::scratch_mem_surf, sx, sy, sw, sh);
+    gr_mem_surf_Blt(dsfs, dx, dy, grSurface::scratch_mem_surf, sx, sy, sw, sh);
 
     ssf->unlock();
     return;
@@ -380,7 +379,7 @@ void grSurface::uniblt(int dx, int dy, grSurface *ssf, int sx, int sy, int sw, i
     grSurface::scratch_mem_surf->flags = dsfs->flags;
 
     gr_mem_surf_Init(grSurface::scratch_mem_surf, m_DataPtr, m_DataRowsize);
-    err = gr_mem_surf_Blt(grSurface::scratch_mem_surf, dx, dy, ssfs, sx, sy, sw, sh);
+    gr_mem_surf_Blt(grSurface::scratch_mem_surf, dx, dy, ssfs, sx, sy, sw, sh);
 
     grSurface::unlock();
     return;

--- a/2dlib/surface.cpp
+++ b/2dlib/surface.cpp
@@ -667,11 +667,10 @@ void grSurface::xlat24_16(char *data, int w, int h) {
   char *sptr;
   uint16_t *dptr;
   int scol, dcol, row;
-  int rowsize_w, height, width;
+  int height, width;
 
   dptr = (uint16_t *)m_DataPtr;
   sptr = (char *)data;
-  rowsize_w = m_DataRowsize / 2;
   height = std::min(h, ddsfObj.h);
   width = std::min(w, ddsfObj.w);
 

--- a/2dlib/surface.cpp
+++ b/2dlib/surface.cpp
@@ -435,10 +435,9 @@ void grSurface::replace_color(ddgr_color sc, ddgr_color dc) {
 //	---------------------------------------------------------------------------
 
 char *grSurface::lock(int *rowsize) {
-  bool grerr;
-
   ASSERT(m_SurfInit);
 
+  bool grerr = false;
   switch (ddsfObj.type) {
   case SURFTYPE_VIDEOSCREEN:
   case SURFTYPE_GENERIC:

--- a/2dlib/surface.cpp
+++ b/2dlib/surface.cpp
@@ -512,18 +512,16 @@ char *grSurface::lock(int x, int y, int *rowsize) {
 }
 
 void grSurface::unlock() {
-  bool grerr;
-
   ASSERT(m_SurfInit);
   ASSERT(surf_Locked);
 
   switch (ddsfObj.type) {
   case SURFTYPE_VIDEOSCREEN:
   case SURFTYPE_GENERIC:
-    grerr = ddgr_surf_Unlock(&ddsfObj, m_OrigDataPtr);
+    ddgr_surf_Unlock(&ddsfObj, m_OrigDataPtr);
     break;
   case SURFTYPE_MEMORY:
-    grerr = gr_mem_surf_Unlock(&ddsfObj, m_OrigDataPtr);
+    gr_mem_surf_Unlock(&ddsfObj, m_OrigDataPtr);
     break;
   default:
     Int3(); // invalid type!!


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

These patches fix some compiler warnings in the 2dlib directory.

Most are unused variables or integer signedness missmatch warnings.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
