### PR TITLE
Resolve crash on inventory pickup

### DIFF
--- a/manage/generic.cpp
+++ b/manage/generic.cpp
@@ -1913,8 +1913,11 @@ int mng_AssignGenericPageToObjInfo(mngs_generic_page *genericpage, int n, CFILE 
 
   // copy our values
   //	memcpy (objinfopointer,&genericpage->objinfo_struct,sizeof(*objinfopointer));
+  // Description pointer is simply moved
   memcpy(objinfopointer, &genericpage->objinfo_struct,
          sizeof(*objinfopointer) - sizeof(anim_elem *) - sizeof(otype_wb_info *) - sizeof(t_ai_info *));
+  genericpage->objinfo_struct.description = nullptr;
+
   strcpy(objinfopointer->name, genericpage->objinfo_struct.name);
   if (objinfopointer->anim)
     memcpy(objinfopointer->anim, &genericpage->anim, sizeof(genericpage->anim));


### PR DESCRIPTION
Commit d185ab951418a08383e5c7cc60d12339d404f57c broke the pointer-moving logic. When the allweapons cheat is executed or when e.g. the afterburner is picked up, ASAN terminates the program with:

```
==8330==ERROR: AddressSanitizer: heap-use-after-free on address 0x50f00007ab60
at pc 0x7f23334f6843 bp 0x7ffe724d2b10 sp 0x7ffe724d22d0
READ of size 3 at 0x50f00007ab60 thread T0
    f0 strdup
    f1 Inventory::AddCounterMeasure(int, int, int, int, char const*) Descent3/Inventory.cpp:575
    f2 Inventory::Add(int, int, object*, int, int, int, char const*) Descent3/Inventory.cpp:520
    f3 DemoCheats(int) Descent3/GameCheat.cpp:606
    f4 ProcessKeys() Descent3/GameLoop.cpp:2420
    f5 GameFrame() Descent3/GameLoop.cpp:2956
    f6 GameSequencer() Descent3/gamesequence.cpp:1212
    f7 PlayGame() Descent3/game.cpp:826
    f8 MainLoop() Descent3/descent.cpp:554
    f9 Descent3() Descent3/descent.cpp:507
    f10 oeD3LnxApp::run() Descent3/sdlmain.cpp:142
    f11 main Descent3/sdlmain.cpp:323

0x50f00007ab60 is located 0 bytes inside of 175-byte region [0x50f00007ab60,0x50f00007ac0f)
freed by thread T0 here:
    f1 mng_LoadNetGenericPage(CFILE*, bool) manage/generic.cpp:2216
    f2 mng_LoadNetPages(int) manage/manage.cpp:1281
    f3 mng_LoadTableFiles(int) manage/manage.cpp:648
    f4 InitD3Systems2(bool) Descent3/init.cpp:1891
    f5 Descent3() Descent3/descent.cpp:503
    f6 oeD3LnxApp::run() Descent3/sdlmain.cpp:142
    f7 main Descent3/sdlmain.cpp:323

previously allocated by thread T0 here:
    f0 malloc
    f1 mem_rmalloc<char> mem/mem.h:138
    f2 mng_ReadNewGenericPage(CFILE*, mngs_generic_page*) manage/generic.cpp:1145
    f3 mng_LoadNetGenericPage(CFILE*, bool) manage/generic.cpp:2196
    f4 mng_LoadNetPages(int) manage/manage.cpp:1281
    f5 mng_LoadTableFiles(int) manage/manage.cpp:648
    f6 InitD3Systems2(bool) Descent3/init.cpp:1891
    f7 Descent3() Descent3/descent.cpp:503
    f8 oeD3LnxApp::run() Descent3/sdlmain.cpp:142
    f9 main Descent3/sdlmain.cpp:323
```

The pointer value of mngs_generic_page::description was copied to object_info::description (by function
``mng_AssignGenericPageToObjInfo``) and then the page was freed in ``mng_LoadNetGenericPage``, leaving object_info::description non-NULL and dangling.

Fixes: d185ab951418a08383e5c7cc60d12339d404f57c

## Pull Request Type

- [x] Runtime changes
  - [x] Other changes

### Checklist

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
