### PR TITLE
Update macOS Usage Documentation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -66,9 +66,9 @@ conflicts.
     - On macOS, the `.app` bundle is currently not signed, so your operating
       system will not let you run it by double-clicking it. To remediate that,
       open your terminal and `cd` to `D3-open-source`. Run
-      `xattr -c ./Descent3.app` and then
-      `chmod +x ./Descent3.app/Content/MacOS/Descent3`, then run the game
-      using `./Descent3.app/Content/MacOS/Descent3`
+      `xattr -c ./Descent3.app`, `xattr -c ./netgames/*`,
+      `chmod +x ./Descent3.app/Contents/MacOS/Descent3`, and then run the game
+      using `./Descent3.app/Contents/MacOS/Descent3`
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [x] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

I updated the macOS usage documentation.

First, I updated the path of the folders inside the application bundle.

The second bigger change I made is to direct folks to remove the extended attributes from the `netgames` folder's contents.  The way Descent 3 loads the executable data inside those files makes macOS display a warning that it may not be free of malware when you try to start a multiplayer game.  See the below screenshot.  Removing the extended attributes stops the error and allows the multiplayer game to start.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

![Screenshot 2024-11-10 at 8 28 41 AM](https://github.com/user-attachments/assets/3dfa5b97-b930-4cbe-8335-4105b2dacba4)

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->

I've gotten this version of the game to work with the original Mac files.  The only thing that doesn't seem to load are the saved games.  There are also a few differences with where files are stored between the Mac version and where this version wants it.  I'm still figuring out what all the differences are, and I'll make a PR with updated documentation.