### PR TITLE
Fix two array size computations

### DIFF
--- a/Descent3/CtlCfgElem.cpp
+++ b/Descent3/CtlCfgElem.cpp
@@ -392,7 +392,7 @@ static int16_t key_binding_indices[] = {
     KEY_PADPERIOD, KEY_PADENTER, KEY_RCTRL, KEY_PADDIVIDE, KEY_RALT,     KEY_HOME,   KEY_UP,          KEY_PAGEUP,
     KEY_LEFT,      KEY_RIGHT,    KEY_END,   KEY_DOWN,      KEY_PAGEDOWN, KEY_INSERT, KEY_DELETE,      0xff};
 
-#define NUM_KEYBINDSTRINGS (sizeof(Ctltext_KeyBindings) / sizeof(char *))
+#define NUM_KEYBINDSTRINGS (sizeof(Ctltext_KeyBindings) / sizeof(Ctltext_KeyBindings[0]))
 
 #define F_ELEM_HILITE 0x1
 #define F_ELEM_ACTIVE 0x2

--- a/ddio/lnxmouse.cpp
+++ b/ddio/lnxmouse.cpp
@@ -537,7 +537,7 @@ const char *ddio_MouseGetBtnText(int btn) {
 }
 
 const char *ddio_MouseGetAxisText(int axis) {
-  if (axis >= (sizeof(Ctltext_MseAxisBindings) / sizeof(char *)) || axis < 0)
+  if (axis >= static_cast<int>(sizeof(Ctltext_MseAxisBindings) / sizeof(Ctltext_MseAxisBindings[0])) || axis < 0)
     return ("");
   return Ctltext_MseAxisBindings[axis];
 }


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

This fixes two wrong array size computations in the C++ code which might lead to an invalid memory access.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
