### PR TITLE
Comply with CMake 3.31 policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ endif()
 add_custom_target(get_git_hash ALL)
 
 add_custom_command(
+  POST_BUILD
   TARGET get_git_hash
   COMMAND ${CMAKE_COMMAND}
     -D SOURCE_DIR=${PROJECT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ project(Descent3
   VERSION 1.6.0
 )
 
+if(POLICY CMP0177) # install() DESTINATION path are normalized
+  cmake_policy(SET CMP0177 NEW)
+endif()
+
 option(BUILD_TESTING "Enable testing. Requires GTest." OFF)
 option(ENABLE_LOGGER "Enable logging to the terminal" OFF)
 option(ENABLE_MEM_RTL "Enable Real-time library memory management functions (disable to verbose memory allocations)" ON)


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

CMake 3.31 introduces policies CMP0175 and CMP177, triggering warnings at configure time. Fix them.