### PR TITLE
Compile macOS Intel Version on Apple Silicon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install macOS Intel dependencies
         if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
         run: |
-          $MACOS_ARCH_COMMAND eval "$(/usr/local/bin/brew shellenv)"
+          eval "$(/usr/local/bin/brew shellenv)"
           $MACOS_ARCH_COMMAND /usr/local/bin/brew bundle install
 
       - name: Install Linux dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,13 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install macOS Rosetta 2 and Brew
+      - name: Install macOS Rosetta 2
+        if: ${{ matrix.os.name == 'macOS-Intel' }}
+        run: |
+          /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+          echo "MACOS_ARCH_COMMAND=arch -x86_64" >> $GITHUB_ENV
+          
+      - name: Install Intel version of Brew
         if: ${{ matrix.os.name == 'macOS-Intel' }}
         shell: arch -x86_64 /bin/bash -e {0}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
         run: |
           eval "$(/usr/local/bin/brew shellenv)"
-          $MACOS_ARCH_COMMAND /usr/local/bin/brew bundle install
+          arch -x86_64 /usr/local/bin/brew bundle install
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,8 +82,13 @@ jobs:
         if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
         shell: arch -x86_64 /bin/bash -e {0}
         run: |
+          which brew
+          echo $PATH
           eval "$(/usr/local/bin/brew shellenv)"
-          /usr/local/bin/brew bundle install
+          which brew
+          echo $PATH
+          echo "PATH=$PATH" >> $GITHUB_ENV  # modify $PATH for future steps so the Intel Brew and its installs are enshrined as the default 
+          brew bundle install
           file /usr/local/bin/cmake
 
       - name: Install Linux dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           eval "$(/usr/local/bin/brew shellenv)"
           /usr/local/bin/brew bundle install
+          file /usr/local/bin/cmake
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,6 @@ jobs:
         if: ${{ matrix.os.name == 'macOS-Intel' }}
         shell: arch -x86_64 /bin/bash -e {0}
         run: |
-          /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-          echo "MACOS_ARCH_COMMAND=arch -x86_64" >> $GITHUB_ENV
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
       - name: Install macOS ARM dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,12 @@ jobs:
             cc: cl
             cxx: cl
             name: Windows-x64
-          - runner: macos-14
+          - runner: macos-14  # Apple Silicon, but we cross-compile
             preset: mac
             cc: cc
             cxx: c++
             name: macOS-Intel
-          - runner: macos-14
+          - runner: macos-14  # Apple Silicon
             preset: mac
             cc: cc
             cxx: c++
@@ -67,20 +67,19 @@ jobs:
       - name: Install Intel version of Brew
         if: ${{ matrix.os.name == 'macOS-Intel' }}
         shell: arch -x86_64 /bin/bash -e {0}
-        run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-      - name: Install macOS ARM dependencies
-        if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-ARM' }}
-        run: brew bundle install
+        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
       - name: Install macOS Intel dependencies
-        if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
+        if: ${{ matrix.os.name == 'macOS-Intel' }}
         shell: arch -x86_64 /bin/bash -e {0}
         run: |
-          eval "$(/usr/local/bin/brew shellenv)"
-          echo "PATH=$PATH" >> $GITHUB_ENV  # modify $PATH for future steps so the Intel Brew and its installs are enshrined as the default 
+          eval "$(/usr/local/bin/brew shellenv)"  # makes the Intel version of Brew and its installs are enshrined as the default 
+          echo "PATH=$PATH" >> $GITHUB_ENV  # modify $PATH so the above step persists into the future steps
           brew bundle install
+
+      - name: Install macOS ARM dependencies
+        if: ${{ matrix.os.name == 'macOS-ARM' }}
+        run: brew bundle install
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,38 +24,44 @@ jobs:
             cc: cl
             cxx: cl
             name: Windows-x64
+            shell: ''
           - runner: macos-14
             preset: mac
             cc: cc
             cxx: c++
             name: macOS-Intel
+            shell: arch -x86_64 /bin/bash -e {0}
           - runner: macos-14
             preset: mac
             cc: cc
             cxx: c++
             name: macOS-ARM
+            shell: ''
           - runner: ubuntu-latest
             preset: linux
             cc: gcc
             cxx: g++
             name: Linux-x64
+            shell: ''
           - runner: ubuntu-latest
             preset: linux
             cc: clang
             cxx: clang++
             name: Linux-x64-clang
+            shell: ''
           - runner: ubuntu-latest
             preset: linux-cross-arm64
             cc: gcc
             cxx: g++++
             name: Linux-cross-arm64
+            shell: ''
         build_type:
           - Debug
           - Release
 
     runs-on: ${{ matrix.os.runner }}
-    env:
-      MACOS_ARCH_COMMAND: ''  # default to nothing
+#    env:
+#      MACOS_ARCH_COMMAND: ''  # default to nothing
 
     steps:
       - uses: actions/checkout@v4
@@ -66,11 +72,11 @@ jobs:
         if: ${{ matrix.os.name == 'macOS-Intel' }}
         run: |
           /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-          echo "MACOS_ARCH_COMMAND=arch -x86_64" >> $GITHUB_ENV
+#          echo "MACOS_ARCH_COMMAND=arch -x86_64" >> $GITHUB_ENV
           
       - name: Install Intel version of Brew
         if: ${{ matrix.os.name == 'macOS-Intel' }}
-        shell: arch -x86_64 /bin/bash -e {0}
+        shell: ${{ matrix.os.shell }}
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
@@ -80,16 +86,11 @@ jobs:
 
       - name: Install macOS Intel dependencies
         if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
-        shell: arch -x86_64 /bin/bash -e {0}
+        shell: ${{ matrix.os.shell }}
         run: |
-          which brew
-          echo $PATH
           eval "$(/usr/local/bin/brew shellenv)"
-          which brew
-          echo $PATH
           echo "PATH=$PATH" >> $GITHUB_ENV  # modify $PATH for future steps so the Intel Brew and its installs are enshrined as the default 
           brew bundle install
-          file /usr/local/bin/cmake
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}
@@ -126,21 +127,25 @@ jobs:
 
       - name: Configure CMake
         if: ${{ matrix.os.preset != 'linux-cross-arm64' }}
+        shell: ${{ matrix.os.shell }}
         env:
           CC: ${{ matrix.os.cc }}
           CXX: ${{ matrix.os.cxx }}
-        run: $MACOS_ARCH_COMMAND cmake --preset ${{ matrix.os.preset }} -DBUILD_TESTING=ON -DENABLE_LOGGER=ON -DFORCE_PORTABLE_INSTALL=ON -DBUILD_EDITOR=ON -DUSE_EXTERNAL_PLOG=ON
+        run: cmake --preset ${{ matrix.os.preset }} -DBUILD_TESTING=ON -DENABLE_LOGGER=ON -DFORCE_PORTABLE_INSTALL=ON -DBUILD_EDITOR=ON -DUSE_EXTERNAL_PLOG=ON
 
       - name: Build ${{ matrix.build_type }}
-        run: $MACOS_ARCH_COMMAND cmake --build --preset ${{ matrix.os.preset }} --config ${{ matrix.build_type }} --verbose
+        shell: ${{ matrix.os.shell }}
+        run: cmake --build --preset ${{ matrix.os.preset }} --config ${{ matrix.build_type }} --verbose
 
       - name: Run ${{ matrix.build_type }} Unittests
         if: ${{ matrix.os.preset != 'linux-cross-arm64' }}
-        run: $MACOS_ARCH_COMMAND ctest --preset ${{ matrix.os.preset }} -C ${{ matrix.build_type }}
+        shell: ${{ matrix.os.shell }}
+        run: ctest --preset ${{ matrix.os.preset }} -C ${{ matrix.build_type }}
 
       - name: Local install
+        shell: ${{ matrix.os.shell }}
         # There no cmake install presets so install in traditional way
-        run: $MACOS_ARCH_COMMAND cmake --install builds/${{ matrix.os.preset }}/ --config ${{ matrix.build_type }}
+        run: cmake --install builds/${{ matrix.os.preset }}/ --config ${{ matrix.build_type }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,16 +69,14 @@ jobs:
         shell: arch -x86_64 /bin/bash -e {0}
         run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-      - name: Install macOS Intel dependencies
+      - name: Enshrine Intel version of Brew
         if: ${{ matrix.os.name == 'macOS-Intel' }}
         shell: arch -x86_64 /bin/bash -e {0}
         run: |
           eval "$(/usr/local/bin/brew shellenv)"  # makes the Intel version of Brew and its installs are enshrined as the default 
           echo "PATH=$PATH" >> $GITHUB_ENV  # modify $PATH so the above step persists into the future steps
-          brew bundle install
 
-      - name: Install macOS ARM dependencies
-        if: ${{ matrix.os.name == 'macOS-ARM' }}
+      - name: Install macOS dependencies
         run: brew bundle install
 
       - name: Install Linux dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,17 +67,19 @@ jobs:
       - name: Install Intel version of Brew
         if: ${{ matrix.os.name == 'macOS-Intel' }}
         shell: arch -x86_64 /bin/bash -e {0}
-        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-      - name: Enshrine Intel version of Brew
-        if: ${{ matrix.os.name == 'macOS-Intel' }}
-        shell: arch -x86_64 /bin/bash -e {0}
         run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           eval "$(/usr/local/bin/brew shellenv)"  # makes the Intel version of Brew and its installs are enshrined as the default 
           echo "PATH=$PATH" >> $GITHUB_ENV  # modify $PATH so the above step persists into the future steps
 
       - name: Install macOS dependencies
-        run: brew bundle install
+        if: ${{ matrix.os.preset == 'mac' }}
+        run: |
+          file $(which cmake)
+          which brew
+          brew bundle install
+          file $(which cmake)
+          file /usr/local/bin/cmake
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,12 @@ jobs:
             cc: cl
             cxx: cl
             name: Windows-x64
-          - runner: macos-13 # Should be Intel
+          - runner: macos-14
             preset: mac
             cc: cc
             cxx: c++
             name: macOS-Intel
-          - runner: macos-14 # This is supposed to be M1
+          - runner: macos-14
             preset: mac
             cc: cc
             cxx: c++
@@ -54,17 +54,28 @@ jobs:
           - Release
 
     runs-on: ${{ matrix.os.runner }}
+    env:
+      MACOS_ARCH_COMMAND: ''  # default to nothing
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install macOS dependencies
-        if: ${{ matrix.os.preset == 'mac' }}
+      - name: Install macOS Rosetta 2 and Brew
+        if: ${{ matrix.os.name == 'macOS-Intel' }}
         run: |
-          # Install packages from Homebrew
-          brew bundle install
+          /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+          echo "MACOS_ARCH_COMMAND=arch -x86_64" >> $GITHUB_ENV
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+      - name: Install macOS ARM dependencies
+        if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-ARM' }}
+        run: brew bundle install
+
+      - name: Install macOS Intel dependencies
+        if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
+        run: arch -x86_64 /usr/local/homebrew/bin/brew bundle install
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}
@@ -104,18 +115,18 @@ jobs:
         env:
           CC: ${{ matrix.os.cc }}
           CXX: ${{ matrix.os.cxx }}
-        run: cmake --preset ${{ matrix.os.preset }} -DBUILD_TESTING=ON -DENABLE_LOGGER=ON -DFORCE_PORTABLE_INSTALL=ON -DBUILD_EDITOR=ON -DUSE_EXTERNAL_PLOG=ON
+        run: $MACOS_ARCH_COMMAND cmake --preset ${{ matrix.os.preset }} -DBUILD_TESTING=ON -DENABLE_LOGGER=ON -DFORCE_PORTABLE_INSTALL=ON -DBUILD_EDITOR=ON -DUSE_EXTERNAL_PLOG=ON
 
       - name: Build ${{ matrix.build_type }}
-        run: cmake --build --preset ${{ matrix.os.preset }} --config ${{ matrix.build_type }} --verbose
+        run: $MACOS_ARCH_COMMAND cmake --build --preset ${{ matrix.os.preset }} --config ${{ matrix.build_type }} --verbose
 
       - name: Run ${{ matrix.build_type }} Unittests
         if: ${{ matrix.os.preset != 'linux-cross-arm64' }}
-        run: ctest --preset ${{ matrix.os.preset }} -C ${{ matrix.build_type }}
+        run: $MACOS_ARCH_COMMAND ctest --preset ${{ matrix.os.preset }} -C ${{ matrix.build_type }}
 
       - name: Local install
         # There no cmake install presets so install in traditional way
-        run: cmake --install builds/${{ matrix.os.preset }}/ --config ${{ matrix.build_type }}
+        run: $MACOS_ARCH_COMMAND cmake --install builds/${{ matrix.os.preset }}/ --config ${{ matrix.build_type }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,11 @@ jobs:
 
       - name: Install macOS Rosetta 2 and Brew
         if: ${{ matrix.os.name == 'macOS-Intel' }}
+        shell: arch -x86_64 /bin/bash -e {0}
         run: |
           /usr/sbin/softwareupdate --install-rosetta --agree-to-license
           echo "MACOS_ARCH_COMMAND=arch -x86_64" >> $GITHUB_ENV
-          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
       - name: Install macOS ARM dependencies
         if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-ARM' }}
@@ -75,9 +76,10 @@ jobs:
 
       - name: Install macOS Intel dependencies
         if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
+        shell: arch -x86_64 /bin/bash -e {0}
         run: |
           eval "$(/usr/local/bin/brew shellenv)"
-          arch -x86_64 /usr/local/bin/brew bundle install
+          /usr/local/bin/brew bundle install
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,44 +24,36 @@ jobs:
             cc: cl
             cxx: cl
             name: Windows-x64
-            shell: ''
           - runner: macos-14
             preset: mac
             cc: cc
             cxx: c++
             name: macOS-Intel
-            shell: arch -x86_64 /bin/bash -e {0}
           - runner: macos-14
             preset: mac
             cc: cc
             cxx: c++
             name: macOS-ARM
-            shell: ''
           - runner: ubuntu-latest
             preset: linux
             cc: gcc
             cxx: g++
             name: Linux-x64
-            shell: ''
           - runner: ubuntu-latest
             preset: linux
             cc: clang
             cxx: clang++
             name: Linux-x64-clang
-            shell: ''
           - runner: ubuntu-latest
             preset: linux-cross-arm64
             cc: gcc
             cxx: g++++
             name: Linux-cross-arm64
-            shell: ''
         build_type:
           - Debug
           - Release
 
     runs-on: ${{ matrix.os.runner }}
-#    env:
-#      MACOS_ARCH_COMMAND: ''  # default to nothing
 
     steps:
       - uses: actions/checkout@v4
@@ -70,13 +62,11 @@ jobs:
 
       - name: Install macOS Rosetta 2
         if: ${{ matrix.os.name == 'macOS-Intel' }}
-        run: |
-          /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-#          echo "MACOS_ARCH_COMMAND=arch -x86_64" >> $GITHUB_ENV
-          
+        run: /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+
       - name: Install Intel version of Brew
         if: ${{ matrix.os.name == 'macOS-Intel' }}
-        shell: ${{ matrix.os.shell }}
+        shell: arch -x86_64 /bin/bash -e {0}
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
@@ -86,7 +76,7 @@ jobs:
 
       - name: Install macOS Intel dependencies
         if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
-        shell: ${{ matrix.os.shell }}
+        shell: arch -x86_64 /bin/bash -e {0}
         run: |
           eval "$(/usr/local/bin/brew shellenv)"
           echo "PATH=$PATH" >> $GITHUB_ENV  # modify $PATH for future steps so the Intel Brew and its installs are enshrined as the default 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,7 @@ jobs:
 
       - name: Install macOS dependencies
         if: ${{ matrix.os.preset == 'mac' }}
-        run: |
-          file $(which cmake)
-          which brew
-          brew bundle install
-          file $(which cmake)
-          file /usr/local/bin/cmake
+        run: brew bundle install
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,9 @@ jobs:
 
       - name: Install macOS Intel dependencies
         if: ${{ matrix.os.preset == 'mac' && matrix.os.name == 'macOS-Intel' }}
-        run: arch -x86_64 /usr/local/homebrew/bin/brew bundle install
+        run: |
+          $MACOS_ARCH_COMMAND eval "$(/usr/local/bin/brew shellenv)"
+          $MACOS_ARCH_COMMAND /usr/local/bin/brew bundle install
 
       - name: Install Linux dependencies
         if: ${{ matrix.os.runner == 'ubuntu-latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,23 +117,19 @@ jobs:
 
       - name: Configure CMake
         if: ${{ matrix.os.preset != 'linux-cross-arm64' }}
-        shell: ${{ matrix.os.shell }}
         env:
           CC: ${{ matrix.os.cc }}
           CXX: ${{ matrix.os.cxx }}
         run: cmake --preset ${{ matrix.os.preset }} -DBUILD_TESTING=ON -DENABLE_LOGGER=ON -DFORCE_PORTABLE_INSTALL=ON -DBUILD_EDITOR=ON -DUSE_EXTERNAL_PLOG=ON
 
       - name: Build ${{ matrix.build_type }}
-        shell: ${{ matrix.os.shell }}
         run: cmake --build --preset ${{ matrix.os.preset }} --config ${{ matrix.build_type }} --verbose
 
       - name: Run ${{ matrix.build_type }} Unittests
         if: ${{ matrix.os.preset != 'linux-cross-arm64' }}
-        shell: ${{ matrix.os.shell }}
         run: ctest --preset ${{ matrix.os.preset }} -C ${{ matrix.build_type }}
 
       - name: Local install
-        shell: ${{ matrix.os.shell }}
         # There no cmake install presets so install in traditional way
         run: cmake --install builds/${{ matrix.os.preset }}/ --config ${{ matrix.build_type }}
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Eventually the GitHub runner `macos-13` will be deprecated and removed by GitHub.  This work is to get the macOS Intel version to compile with the Apple Silicon `macos-14` runner.  This work is also the first step towards making a universal (fat) binary that contains both Apple Silicon and Intel architectures in one binary.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

_None_.

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

_None_.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->

_None_.
