### PR TITLE
fill in x and y only if axes are valid

### DIFF
--- a/ddio/sdlcontroller.cpp
+++ b/ddio/sdlcontroller.cpp
@@ -901,11 +901,11 @@ bool sdlgameController::enum_controllers() {
       m_ControlList[num_devs].buttons = jc.num_btns;
       m_ControlList[num_devs].btnmask = 0;
       m_ControlList[num_devs].flags =
-          CTF_X_AXIS | CTF_Y_AXIS | ((jc.axes_mask & JOYFLAG_ZVALID) ? CTF_Z_AXIS : 0) |
-          ((jc.axes_mask & JOYFLAG_RVALID) ? CTF_R_AXIS : 0) | ((jc.axes_mask & JOYFLAG_UVALID) ? CTF_U_AXIS : 0) |
-          ((jc.axes_mask & JOYFLAG_VVALID) ? CTF_V_AXIS : 0) | ((jc.axes_mask & JOYFLAG_POVVALID) ? CTF_POV : 0) |
-          ((jc.axes_mask & JOYFLAG_POV2VALID) ? CTF_POV2 : 0) | ((jc.axes_mask & JOYFLAG_POV3VALID) ? CTF_POV3 : 0) |
-          ((jc.axes_mask & JOYFLAG_POV4VALID) ? CTF_POV4 : 0);
+          ((jc.axes_mask & JOYFLAG_XVALID) ? CTF_X_AXIS : 0) | ((jc.axes_mask & JOYFLAG_YVALID) ? CTF_Y_AXIS : 0) |
+          ((jc.axes_mask & JOYFLAG_ZVALID) ? CTF_Z_AXIS : 0) | ((jc.axes_mask & JOYFLAG_RVALID) ? CTF_R_AXIS : 0) |
+          ((jc.axes_mask & JOYFLAG_UVALID) ? CTF_U_AXIS : 0) | ((jc.axes_mask & JOYFLAG_VVALID) ? CTF_V_AXIS : 0) |
+          ((jc.axes_mask & JOYFLAG_POVVALID) ? CTF_POV : 0) | ((jc.axes_mask & JOYFLAG_POV2VALID) ? CTF_POV2 : 0) |
+          ((jc.axes_mask & JOYFLAG_POV3VALID) ? CTF_POV3 : 0) | ((jc.axes_mask & JOYFLAG_POV4VALID) ? CTF_POV4 : 0);
       m_ControlList[num_devs].normalizer[0] = (jc.maxx - jc.minx) / 2.0f;
       m_ControlList[num_devs].normalizer[1] = (jc.maxy - jc.miny) / 2.0f;
       m_ControlList[num_devs].normalizer[2] = (jc.maxz - jc.minz) / 2.0f;

--- a/ddio/sdljoy.cpp
+++ b/ddio/sdljoy.cpp
@@ -284,8 +284,12 @@ void joy_GetPos(tJoystick joy, tJoyPos *pos) {
     uint32_t mask;
 
     mask = Joysticks[joy].caps.axes_mask;
-    pos->x = SDL_JoystickGetAxis(stick, 0);
-    pos->y = SDL_JoystickGetAxis(stick, 1);
+    if (mask & JOYFLAG_XVALID) {
+      pos->x = SDL_JoystickGetAxis(stick, 0);
+    }
+    if (mask & JOYFLAG_YVALID) {
+      pos->y = SDL_JoystickGetAxis(stick, 1);
+    }
     if (mask & JOYFLAG_ZVALID) {
       pos->z = SDL_JoystickGetAxis(stick, 2);
     }


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [x] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
SDL identifies Android's keyboard as a D-Pad, and thus a "joystick", even though it has no available axis inputs. Checking _all_ axes for validity, instead of just Z onward, enables this to work fine.

### Related Issues

### Checklist
- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
