### PR TITLE
Grab keyboard when the game is not launched with -nomousegrab

### DIFF
--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -467,6 +467,7 @@ int opengl_Setup(oeApplication *app, const int *width, const int *height) {
 
     bool grabMouse = FindArgChar("-nomousegrab", 'm') == 0;
     SDL_SetWindowRelativeMouseMode(GSDLWindow, grabMouse);
+    SDL_SetWindowKeyboardGrab(GSDLWindow, grabMouse);
 
     SDL_SetWindowFullscreen(GSDLWindow, fullscreen);
   } else {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [x] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Avoid system shortcuts getting in the way of the game by grabbing the keyboard. Per the doc, only alt+tab is allowed when the game is in full-screen (https://wiki.libsdl.org/SDL3/SDL_SetWindowKeyboardGrab)

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

#664 

~~Will change signature when ported to SDL3 (cf #663 )~~