### PR TITLE
Add HD resolution & FOV settings

### DIFF
--- a/Descent3/GameLoop.cpp
+++ b/Descent3/GameLoop.cpp
@@ -870,7 +870,7 @@
 extern bool Display_renderer_stats;
 
 // Current zoom factor (this is the tan of 29.25, which is half our FOV of 58.5)
-float Render_FOV = D3_DEFAULT_FOV;
+float Render_FOV = Render_FOV_setting;
 float Render_zoom = D3_DEFAULT_ZOOM;
 
 // How long (in seconds) the last frame took
@@ -2117,7 +2117,7 @@ void ProcessTestKeys(int key) {
     break;
 
   case KEY_8:
-    Render_FOV = D3_DEFAULT_FOV;
+    Render_FOV = Render_FOV_setting;
     AddHUDMessage("FOV has been reset to %f", Render_FOV);
     break;
 

--- a/Descent3/WeaponFire.cpp
+++ b/Descent3/WeaponFire.cpp
@@ -2680,7 +2680,7 @@ void DoZoomStay() {
     if (Zoom_fov_time < 0) {
       Zoom_fov_time = 0;
       Players[Player_num].flags &= ~PLAYER_FLAGS_ZOOMED;
-      Render_FOV = D3_DEFAULT_FOV;
+      Render_FOV = Render_FOV_setting;
     }
   }
 }
@@ -2689,7 +2689,7 @@ void DoZoomStay() {
 void DoZoomEffect(player_weapon *pw, uint8_t clear) {
   if (pw->firing_time < .5) {
     Players[Player_num].turn_scalar = 1.0;
-    Render_FOV = D3_DEFAULT_FOV;
+    Render_FOV = Render_FOV_setting;
 
     if (!clear)
       DoZoomStay();
@@ -2738,7 +2738,7 @@ void DoZoomEffect(player_weapon *pw, uint8_t clear) {
   // calculate zoom effect
   float norm = (pw->firing_time - .5) * 2;
 
-  Render_FOV = (ZOOM_FOV_TARGET * norm) + ((1.0 - norm) * D3_DEFAULT_FOV);
+  Render_FOV = (ZOOM_FOV_TARGET * norm) + ((1.0 - norm) * Render_FOV_setting);
 
   return;
 }

--- a/Descent3/config.cpp
+++ b/Descent3/config.cpp
@@ -747,6 +747,13 @@ struct video_menu {
     if (GetScreenMode() == SM_GAME) {
       Render_preferred_state.bit_depth = Render_preferred_bitdepth;
       rend_SetPreferredState(&Render_preferred_state);
+
+      SetScreenMode(GetScreenMode(), true);
+
+      int temp_w = Video_res_list[Game_video_resolution].width;
+      int temp_h = Video_res_list[Game_video_resolution].height;
+      Current_pilot.set_hud_data(NULL, NULL, NULL, &temp_w, &temp_h);
+  
     }
 
     Render_FOV_setting = static_cast<float>(fov[0]) + D3_DEFAULT_FOV;
@@ -791,18 +798,6 @@ struct video_menu {
         int newindex = resolution_list->GetCurrentIndex();
         if (static_cast<size_t>(newindex) < Video_res_list.size()) {
           Game_video_resolution = newindex;
-          int temp_w, temp_h;
-          int old_sm = GetScreenMode();
-
-          if (old_sm == SM_GAME) {
-            SetScreenMode(SM_NULL);
-            SetScreenMode(old_sm, true);
-          }
-
-          temp_w = Video_res_list[Game_video_resolution].width;
-          temp_h = Video_res_list[Game_video_resolution].height;
-          Current_pilot.set_hud_data(NULL, NULL, NULL, &temp_w, &temp_h);
-
           std::string res = Video_res_list[Game_video_resolution].getName();
           snprintf(resolution_string, res.size() + 1, res.c_str());
         }

--- a/Descent3/config.cpp
+++ b/Descent3/config.cpp
@@ -657,6 +657,7 @@ static void config_gamma() {
   }
 }
 
+
 //////////////////////////////////////////////////////////////////
 // VIDEO MENU
 //
@@ -666,6 +667,7 @@ struct video_menu {
   bool *filtering; // settings
   bool *mipmapping;
   bool *vsync;
+  char *resolution_string;
 
   int *bitdepth; // bitdepths
 
@@ -675,7 +677,11 @@ struct video_menu {
 
     // video resolution
     sheet->NewGroup(TXT_RESOLUTION, 0, 0);
-    sheet->AddLongButton("Change resolution", IDV_CHANGEWINDOW);
+    constexpr int RES_BUFFER_SIZE = 15;
+    resolution_string = sheet->AddChangeableText(RES_BUFFER_SIZE);
+    std::string res = Video_res_list[Game_video_resolution].getName();
+    snprintf(resolution_string, res.size() + 1, res.c_str());
+    sheet->AddLongButton("Change", IDV_CHANGE_RES_WINDOW);
 
 #if !defined(POSIX)
     // renderer bit depth
@@ -778,6 +784,9 @@ struct video_menu {
           temp_w = Video_res_list[Game_video_resolution].width;
           temp_h = Video_res_list[Game_video_resolution].height;
           Current_pilot.set_hud_data(NULL, NULL, NULL, &temp_w, &temp_h);
+
+          std::string res = Video_res_list[Game_video_resolution].getName();
+          snprintf(resolution_string, res.size() + 1, res.c_str());
         }
       }
 

--- a/Descent3/config.cpp
+++ b/Descent3/config.cpp
@@ -518,22 +518,22 @@ static void gamma_callback(newuiTiledWindow *wnd, void *data) {
     pnts[i].p3_flags = PF_PROJECTED;
   }
 
-  pnts[0].p3_sx = startx;
+  pnts[0].p3_sx = static_cast<float>(startx);
   pnts[0].p3_sy = GAMMA_SLICE_Y;
   pnts[0].p3_u = 0;
   pnts[0].p3_v = 0;
 
-  pnts[1].p3_sx = startx + GAMMA_SLICE_WIDTH;
+  pnts[1].p3_sx = static_cast<float>(startx + GAMMA_SLICE_WIDTH);
   pnts[1].p3_sy = GAMMA_SLICE_Y;
   pnts[1].p3_u = 2;
   pnts[1].p3_v = 0;
 
-  pnts[2].p3_sx = startx + GAMMA_SLICE_WIDTH;
+  pnts[2].p3_sx = static_cast<float>(startx + GAMMA_SLICE_WIDTH);
   pnts[2].p3_sy = GAMMA_SLICE_Y + GAMMA_SLICE_HEIGHT;
   pnts[2].p3_u = 2;
   pnts[2].p3_v = 1;
 
-  pnts[3].p3_sx = startx;
+  pnts[3].p3_sx = static_cast<float>(startx);
   pnts[3].p3_sy = GAMMA_SLICE_Y + GAMMA_SLICE_HEIGHT;
   pnts[3].p3_u = 0;
   pnts[3].p3_v = 1;
@@ -677,6 +677,7 @@ struct video_menu {
 
   // sets the menu up.
   newuiSheet *setup(newuiMenu *menu) {
+    int iTemp = 0;
     sheet = menu->AddOption(IDV_VCONFIG, TXT_OPTVIDEO, NEWUIMENU_MEDIUM);
 
     // video resolution
@@ -692,7 +693,7 @@ struct video_menu {
     settings.min_val.f = D3_DEFAULT_FOV;
     settings.max_val.f = 90.f;
     settings.type = SLIDER_UNITS_FLOAT;
-    fov = sheet->AddSlider("FOV", settings.max_val.f - settings.min_val.f, Render_FOV_setting - D3_DEFAULT_FOV,
+    fov = sheet->AddSlider("FOV", static_cast<int16_t>(settings.max_val.f - settings.min_val.f), static_cast<int16_t>(Render_FOV_setting - D3_DEFAULT_FOV),
                            &settings);
 
 #if !defined(POSIX)
@@ -1278,7 +1279,7 @@ struct details_menu {
     // sliders
     tSliderSettings slider_set;
     sheet->NewGroup(TXT_GEOMETRY, 90, 0);
-    iTemp = MAXIMUM_TERRAIN_DETAIL - Detail_settings.Pixel_error - MINIMUM_TERRAIN_DETAIL;
+    iTemp = static_cast<int>(MAXIMUM_TERRAIN_DETAIL - Detail_settings.Pixel_error - MINIMUM_TERRAIN_DETAIL);
     if (iTemp < 0)
       iTemp = 0;
     slider_set.min_val.i = MINIMUM_TERRAIN_DETAIL;
@@ -1312,7 +1313,7 @@ struct details_menu {
     Detail_settings.Fog_enabled = *fog;
     Detail_settings.Mirrored_surfaces = *mirror;
     Detail_settings.Object_complexity = *objcomp;
-    Detail_settings.Pixel_error = MAXIMUM_TERRAIN_DETAIL - ((*pixel_err) + MINIMUM_TERRAIN_DETAIL);
+    Detail_settings.Pixel_error = static_cast<float>(MAXIMUM_TERRAIN_DETAIL - ((*pixel_err) + MINIMUM_TERRAIN_DETAIL));
     Detail_settings.Powerup_halos = *powerup_halo;
     Detail_settings.Procedurals_enabled = *procedurals;
     Detail_settings.Scorches_enabled = *scorches;
@@ -1376,7 +1377,7 @@ void details_menu::set_preset_details(int setting) {
   // now go through all the config items and set to the new values
   int iTemp;
 
-  iTemp = MAXIMUM_TERRAIN_DETAIL - ds.Pixel_error - MINIMUM_TERRAIN_DETAIL;
+  iTemp = static_cast<int>(MAXIMUM_TERRAIN_DETAIL - ds.Pixel_error - MINIMUM_TERRAIN_DETAIL);
   if (iTemp < 0)
     iTemp = 0;
   *pixel_err = (int16_t)(iTemp);

--- a/Descent3/config.cpp
+++ b/Descent3/config.cpp
@@ -310,7 +310,8 @@
 
 #define STAT_SCORE STAT_TIMER
 
-std::vector<tVideoResolution> Video_res_list = {{512, 384},
+std::vector<tVideoResolution> Video_res_list = {{0,0},
+                                                {512, 384},
                                                 {640, 480},
                                                 {800, 600},
                                                 {960, 720},
@@ -335,7 +336,7 @@ std::vector<tVideoResolution> Video_res_list = {{512, 384},
                                                 {3440, 1440},
                                                 {3840, 1600}};
 
-const int DEFAULT_RESOLUTION = 7; // 1280x720
+const int DEFAULT_RESOLUTION = 0; // Screen resolution
 int Game_video_resolution = DEFAULT_RESOLUTION;
 float Render_FOV_setting = 72.0f;
 

--- a/Descent3/config.h
+++ b/Descent3/config.h
@@ -132,24 +132,46 @@ struct tGameToggles {
 
 extern tGameToggles Game_toggles;
 
-// this list should match the list in config.cpp to work.
-#define N_SUPPORTED_VIDRES 8
-
 // stored resolution list and desired game resolution
-struct tVideoResolution {
+struct tVideoResolution
+{
   uint16_t width;
   uint16_t height;
 
-  std::string getName() const {
+  std::string getName() const
+  {
     std::stringstream ss;
     ss << this->width << "x" << this->height;
     return ss.str();
   }
+
+  bool operator==(const tVideoResolution& other) {
+    return other.width == this->width && other.height == this->height;
+  }
+
+  struct tVideoResolutionCompare
+  {
+    bool operator()(const tVideoResolution &lres, const tVideoResolution &rres) const
+    {
+      if (lres.width != rres.width)
+      {
+        return lres.width < rres.width;
+      }
+      return lres.height < rres.height;
+    }
+  };
 };
 
 extern std::vector<tVideoResolution> Video_res_list;
-extern const int DEFAULT_RESOLUTION;
-extern int Game_video_resolution;
+extern int Default_resolution_id;
+extern int Current_video_resolution_id;
+extern int Display_id;
+
+/**
+ * List all unique resolutions for the detected displays,
+ * and set variables Video_res_list, Game_video_resolution and Display_id
+ */
+void ConfigureDisplayResolutions();
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // KEEP THESE MEMBERS IN THE SAME ORDER, IF YOU ADD,REMOVE, OR CHANGE ANYTHING IN THIS STRUCT, MAKE SURE YOU

--- a/Descent3/config.h
+++ b/Descent3/config.h
@@ -118,6 +118,8 @@
 #define CONFIG_H_
 
 #include <cstdint>
+#include <sstream>
+#include <vector>
 
 // Main menu configuration functions
 
@@ -133,20 +135,20 @@ extern tGameToggles Game_toggles;
 // this list should match the list in config.cpp to work.
 #define N_SUPPORTED_VIDRES 8
 
-#define RES_512X384 0
-#define RES_640X480 1
-#define RES_800X600 2
-#define RES_960X720 3
-#define RES_1024X768 4
-#define RES_1280X960 5
-#define RES_1600X1200 6
 // stored resolution list and desired game resolution
 struct tVideoResolution {
   uint16_t width;
   uint16_t height;
+
+  std::string getName() const {
+    std::stringstream ss;
+    ss << this->width << "x" << this->height;
+    return ss.str();
+  }
 };
 
-extern tVideoResolution Video_res_list[];
+extern std::vector<tVideoResolution> Video_res_list;
+extern const int DEFAULT_RESOLUTION;
 extern int Game_video_resolution;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/Descent3/descent.cpp
+++ b/Descent3/descent.cpp
@@ -407,6 +407,7 @@
 #include "args.h"
 #include "multi_dll_mgr.h"
 #include "localization.h"
+#include "config.h"
 #include "uisys.h"
 
 //	---------------------------------------------------------------------------
@@ -475,6 +476,7 @@ void Descent3() {
     }
     // Show intro & loading screens if not dedicated server
     if (!Dedicated_server) {
+      ConfigureDisplayResolutions();
       SetScreenMode(SM_CINEMATIC);
 
       // Show the intro movie

--- a/Descent3/descent.h
+++ b/Descent3/descent.h
@@ -174,7 +174,7 @@ enum function_mode {
 extern bool Descent_overrided_intro;
 
 // This is the default FOV
-#define D3_DEFAULT_FOV 72.0
+#define D3_DEFAULT_FOV 72.0f
 // This is the default zoom factor to be used for the game 3D view.
 #define D3_DEFAULT_ZOOM 0.726f
 

--- a/Descent3/game.cpp
+++ b/Descent3/game.cpp
@@ -982,7 +982,7 @@ void SetScreenMode(int sm, bool force_res_change) {
         // We're using the default, so change some values for the menus
         rend_initted = 1;
         LOG_INFO << "Changing menu settings to default!";
-        Game_video_resolution = RES_640X480;
+        Game_video_resolution = DEFAULT_RESOLUTION;
         Render_preferred_state.bit_depth = 32;
         scr_width = 640;
         scr_height = 480;
@@ -1000,7 +1000,7 @@ void SetScreenMode(int sm, bool force_res_change) {
           // We're using the default, so change some values for the menus
           rend_initted = 1;
           LOG_INFO << "Changing menu settings to default!";
-          Game_video_resolution = RES_640X480;
+          Game_video_resolution = DEFAULT_RESOLUTION;
           Render_preferred_state.bit_depth = 32;
           scr_width = 640;
           scr_height = 480;

--- a/Descent3/game.cpp
+++ b/Descent3/game.cpp
@@ -910,32 +910,6 @@ int GetScreenMode() { return Screen_mode; }
 int rend_initted = 0;
 int Low_vidmem = 0;
 
-int GetSDLDisplayId() {
-  int display_num = 0;
-  int display_arg = FindArg("-display");
-  int display_count = 0;
-
-  SDL_DisplayID *displays = SDL_GetDisplays(&display_count);
-
-  if (display_arg != 0) {
-    if (const char *arg_index_str = GetArg(display_arg + 1); arg_index_str == nullptr) {
-      LOG_WARNING << "No parameter for -display given";
-    } else {
-      int arg_index = atoi(arg_index_str);
-      if ((arg_index < 0) || (arg_index >= display_count)) {
-        LOG_WARNING.printf("Parameter for -display must be in the range 0..%i", display_count - 1);
-      } else {
-        display_num = arg_index;
-      }
-    }
-  }
-
-  int display_id = displays[display_num];
-  SDL_free(displays);
-
-  return display_id;
-}
-
 void SetScreenMode(int sm, bool force_res_change) {
   static int old_sm = SM_NULL;
   static int rend_width = 0, rend_height = 0;
@@ -966,17 +940,11 @@ void SetScreenMode(int sm, bool force_res_change) {
       rend_initted = 0;
     }
   } else {
-    // Default resolution: use current display mode
-    int display_id = GetSDLDisplayId();
-    const SDL_DisplayMode *mode = SDL_GetCurrentDisplayMode(display_id);
-    Video_res_list[0].width = mode->w;
-    Video_res_list[0].height = mode->h;
-
     int scr_width, scr_height, scr_bitdepth;
 
     if (sm == SM_GAME) {
-      scr_width = Video_res_list[Game_video_resolution].width;
-      scr_height = Video_res_list[Game_video_resolution].height;
+      scr_width = Video_res_list[Current_video_resolution_id].width;
+      scr_height = Video_res_list[Current_video_resolution_id].height;
       scr_bitdepth = Render_preferred_bitdepth;
     } else {
       scr_width = FIXED_SCREEN_WIDTH;
@@ -1013,7 +981,7 @@ void SetScreenMode(int sm, bool force_res_change) {
         // We're using the default, so change some values for the menus
         rend_initted = 1;
         LOG_INFO << "Changing menu settings to default!";
-        Game_video_resolution = DEFAULT_RESOLUTION;
+        Current_video_resolution_id = Default_resolution_id;
         Render_preferred_state.bit_depth = 32;
         scr_width = 640;
         scr_height = 480;
@@ -1031,7 +999,7 @@ void SetScreenMode(int sm, bool force_res_change) {
           // We're using the default, so change some values for the menus
           rend_initted = 1;
           LOG_INFO << "Changing menu settings to default!";
-          Game_video_resolution = DEFAULT_RESOLUTION;
+          Current_video_resolution_id = Default_resolution_id;
           Render_preferred_state.bit_depth = 32;
           scr_width = 640;
           scr_height = 480;

--- a/Descent3/gameloop.h
+++ b/Descent3/gameloop.h
@@ -108,6 +108,7 @@ void GameFrame(void);
 void GameRenderWorld(object *viewer, vector *viewer_eye, int viewer_roomnum, matrix *viewer_orient, float zoom,
                      bool rear_view);
 
+extern float Render_FOV_setting;
 extern float Render_zoom;
 extern float Render_FOV;
 

--- a/Descent3/hud.cpp
+++ b/Descent3/hud.cpp
@@ -1416,12 +1416,16 @@ void RenderHUDItems(tStatMask stat_mask) {
   font_aspect_x = (float)Game_window_w / Max_window_w;
   font_aspect_y = (float)Game_window_h / Max_window_h;
 
+  // Add HUD text scaling for large screens
+  constexpr float scaling_height_threshold = 1080.0f;
+  float scaling_factor = std::max(1.0f, Max_window_h / scaling_height_threshold);
+
   if (font_aspect_x <= 0.60f) {
-    grtext_SetFontScale(0.60f);
+    grtext_SetFontScale(0.60f * scaling_factor);
   } else if (font_aspect_x <= 0.80f) {
-    grtext_SetFontScale(0.80f);
+    grtext_SetFontScale(0.80f * scaling_factor);
   } else {
-    grtext_SetFontScale(1.0f);
+    grtext_SetFontScale(scaling_factor);
   }
 
   //	do framerate calculations

--- a/Descent3/huddisplay.cpp
+++ b/Descent3/huddisplay.cpp
@@ -963,7 +963,6 @@ void RenderHUDScore(tHUDItem *item) {
   snprintf(buf, sizeof(buf), "%s: %d ", TXT_SCORE, Players[Player_num].score);
 
   win_w = (Max_window_w - Game_window_w) * (Hud_aspect_x);
-  //	if (Game_video_resolution==RES_512X384) { win_w = win_w + 10; }
 
   int w = RenderHUDGetTextLineWidth(buf); // * win_w)/(Game_window_w);
   RenderHUDText(item->color, HUD_ALPHA, 0, item->x - w - win_w, item->y, buf);

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1157,7 +1157,7 @@ void SaveGameSettings() {
   Database->write("DetailObjectComp", Detail_settings.Object_complexity);
   Database->write("DetailPowerupHalos", Detail_settings.Powerup_halos);
 
-  Database->write("RS_resolution", Game_video_resolution);
+  Database->write("RS_resolution", Current_video_resolution_id);
   Database->write("RS_fov", static_cast<int>(Render_FOV_setting));
 
   Database->write("RS_bitdepth", Render_preferred_bitdepth);
@@ -1234,7 +1234,7 @@ void LoadGameSettings() {
   D3Use_force_feedback = true;
   D3Force_gain = 1.0f;
   D3Force_auto_center = true;
-  Game_video_resolution = DEFAULT_RESOLUTION;
+  Current_video_resolution_id = Default_resolution_id;
   PlayPowerupVoice = true;
   PlayVoices = true;
   Sound_mixer = SOUND_MIXER_SOFTWARE_16;
@@ -1290,7 +1290,7 @@ void LoadGameSettings() {
   Database->read_int("RoomLeveling", &Default_player_room_leveling);
   Database->read("Specmapping", &Detail_settings.Specular_lighting);
   Database->read("RS_bitdepth", &Render_preferred_bitdepth, sizeof(Render_preferred_bitdepth));
-  Database->read_int("RS_resolution", &Game_video_resolution);
+  Database->read_int("RS_resolution", &Current_video_resolution_id);
   
   int tempfov = 0;
   Database->read_int("RS_fov", &tempfov);
@@ -1369,21 +1369,6 @@ void LoadGameSettings() {
 
   Database->read_int("PredefDetailSetting", &level);
   ConfigSetDetailLevel(level);
-  int widtharg = FindArg("-Width");
-  int heightarg = FindArg("-Height");
-
-  if (widtharg && !heightarg) {
-    LOG_ERROR << "Specify '-Height' argument when setting '-Width'";
-  }
-  if (heightarg && !widtharg) {
-    LOG_ERROR << "Specify '-Width' argument when setting '-Height'";
-  }
-
-  if (widtharg && heightarg) {
-    Video_res_list.emplace_back(tVideoResolution{static_cast<unsigned short>(atoi(GameArgs[widtharg + 1])),
-                                                 static_cast<unsigned short>(atoi(GameArgs[heightarg + 1]))});
-    Game_video_resolution = Video_res_list.size() - 1;
-  }
 
   // Motion blur
   Use_motion_blur = 0;

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -980,6 +980,8 @@
 #include "gamecinematics.h"
 #include "debuggraph.h"
 
+#include <algorithm>
+
 // Uncomment this to allow all languages
 #define ALLOW_ALL_LANG 1
 
@@ -1156,6 +1158,7 @@ void SaveGameSettings() {
   Database->write("DetailPowerupHalos", Detail_settings.Powerup_halos);
 
   Database->write("RS_resolution", Game_video_resolution);
+  Database->write("RS_fov", static_cast<int>(Render_FOV_setting));
 
   Database->write("RS_bitdepth", Render_preferred_bitdepth);
   Database->write("RS_bilear", Render_preferred_state.filtering);
@@ -1288,6 +1291,13 @@ void LoadGameSettings() {
   Database->read("Specmapping", &Detail_settings.Specular_lighting);
   Database->read("RS_bitdepth", &Render_preferred_bitdepth, sizeof(Render_preferred_bitdepth));
   Database->read_int("RS_resolution", &Game_video_resolution);
+  
+  int tempfov = 0;
+  Database->read_int("RS_fov", &tempfov);
+  tempfov = std::clamp(tempfov, static_cast<int>(D3_DEFAULT_FOV), 90);
+  Render_FOV_setting = static_cast<float>(tempfov);
+  Render_FOV = Render_FOV_setting;
+
   Database->read_int("RS_bilear", &Render_preferred_state.filtering);
   Database->read_int("RS_mipping", &Render_preferred_state.mipping);
   Database->read_int("RS_color_model", &Render_state.cur_color_model);

--- a/Descent3/object.cpp
+++ b/Descent3/object.cpp
@@ -2490,7 +2490,7 @@ void ObjDoEffects(object *obj) {
       // Stop doing liquid effect
       obj->effect_info->type_flags &= ~EF_LIQUID;
       if (obj == Viewer_object)
-        Render_FOV = D3_DEFAULT_FOV;
+        Render_FOV = Render_FOV_setting;
     } else {
       if (obj == Viewer_object) {
         int inttime = Gametime;
@@ -2502,7 +2502,7 @@ void ObjDoEffects(object *obj) {
         if (obj->effect_info->liquid_time_left < 1)
           scalar *= (obj->effect_info->liquid_time_left);
 
-        Render_FOV = D3_DEFAULT_FOV + scalar;
+        Render_FOV = Render_FOV_setting + scalar;
       }
     }
   }

--- a/Descent3/pilot_class.cpp
+++ b/Descent3/pilot_class.cpp
@@ -205,8 +205,8 @@ void pilot::initialize(void) {
   hud_mode = (uint8_t)HUD_COCKPIT;
   hud_stat = 0;
   hud_graphical_stat = STAT_STANDARD;
-  game_window_w = Video_res_list[Game_video_resolution].width;
-  game_window_h = Video_res_list[Game_video_resolution].height;
+  game_window_w = Video_res_list[Current_video_resolution_id].width;
+  game_window_h = Video_res_list[Current_video_resolution_id].height;
   num_missions_flown = 0;
   mission_data = NULL;
   mouselook_control = false;

--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -353,8 +353,8 @@ void opengl_SetDefaults() {
 extern renderer_preferred_state Render_preferred_state;
 
 int opengl_Setup(oeApplication *app, const int *width, const int *height) {
-  int winw = Video_res_list[Game_video_resolution].width;
-  int winh = Video_res_list[Game_video_resolution].height;
+  int winw = Video_res_list[Current_video_resolution_id].width;
+  int winh = Video_res_list[Current_video_resolution_id].height;
 
   SDL_ClearError();
   if (!SDL_WasInit(SDL_INIT_VIDEO)) {
@@ -424,27 +424,9 @@ int opengl_Setup(oeApplication *app, const int *width, const int *height) {
     int display_arg = FindArg("-display");
     int display_count = 0;
 
-    SDL_DisplayID* displays = SDL_GetDisplays(&display_count);
-
-    if (display_arg != 0) {
-      if (const char * arg_index_str = GetArg (display_arg + 1); arg_index_str == nullptr) {
-        LOG_WARNING << "No parameter for -display given";
-      } else {
-        int arg_index = atoi(arg_index_str);
-        if ((arg_index < 0) || (arg_index >= display_count)) {
-          LOG_WARNING.printf( "Parameter for -display must be in the range 0..%i", display_count-1 );
-        } else {
-          display_num = arg_index;
-        }
-      }
-    }
-
-    int display_id = displays[display_num];
-    SDL_free(displays);
-
     //High-DPI support
     {
-      float scale = SDL_GetDisplayContentScale(display_id);
+      float scale = SDL_GetDisplayContentScale(Display_id);
       LOG_WARNING.printf("Using content scale %f", scale);
       winw = std::floor(static_cast<float>(winw)*scale);
       winh = std::floor(static_cast<float>(winh)*scale);  
@@ -453,8 +435,8 @@ int opengl_Setup(oeApplication *app, const int *width, const int *height) {
 
     SDL_PropertiesID props = SDL_CreateProperties();
     SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, "Descent 3");
-    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER,  SDL_WINDOWPOS_UNDEFINED_DISPLAY(display_id));
-    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, SDL_WINDOWPOS_UNDEFINED_DISPLAY(display_id));
+    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER,  SDL_WINDOWPOS_UNDEFINED_DISPLAY(Display_id));
+    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, SDL_WINDOWPOS_UNDEFINED_DISPLAY(Display_id));
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, winw);
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, winh);
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, SDL_WINDOW_OPENGL);

--- a/renderer/HardwareSetup.cpp
+++ b/renderer/HardwareSetup.cpp
@@ -1,5 +1,5 @@
 /*
-* Descent 3 
+* Descent 3
 * Copyright (C) 2024 Parallax Software
 *
 * This program is free software: you can redistribute it and/or modify
@@ -54,13 +54,8 @@ void g3_GetProjectionMatrix(float zoom, float *projMat) {
   int viewportWidth, viewportHeight;
   rend_GetProjectionParameters(&viewportWidth, &viewportHeight);
 
-  // compute aspect ratio for this ViewPort
-  float screenAspect = rend_GetAspectRatio();
-  if (sAspect != 0.0f) {
-    // check for user override
-    screenAspect = screenAspect * 4.0f / 3.0f / sAspect;
-  }
-  float s = screenAspect * ((float)viewportWidth) / ((float)viewportHeight);
+  float s = ((float)viewportWidth) / ((float)viewportHeight);
+  float vertical_fov = zoom * 3.0f / 4.0f;
 
   // setup the matrix
   memset(projMat, 0, sizeof(float) * 16);
@@ -69,8 +64,19 @@ void g3_GetProjectionMatrix(float zoom, float *projMat) {
   float oOT = 1.0f / zoom;
 
   // fill in the matrix
-  projMat[0] = oOT;
-  projMat[5] = oOT * s;
+  // Go read https://www.songho.ca/opengl/gl_projectionmatrix.html
+  // if you feel like doing the math again :)
+	if (s <= 1.0f)
+	{
+		projMat[0] = oOT;
+		projMat[5] = oOT * s;
+	}
+	else
+	{
+		projMat[0] = oOT / s;
+		projMat[5] = oOT;
+	}
+
   projMat[10] = 1.0f;
   projMat[11] = 1.0f;
   projMat[14] = -1.0f;
@@ -91,16 +97,11 @@ void g3_StartFrame(vector *view_pos, matrix *view_matrix, float zoom) {
   Window_w2 = ((float)Window_width) * 0.5f;
   Window_h2 = ((float)Window_height) * 0.5f;
 
-  // Compute aspect ratio for this window
-  float screen_aspect = rend_GetAspectRatio();
-  if (sAspect != 0.0f) {
-    // check for user override
-    screen_aspect = screen_aspect * 4.0f / 3.0f / sAspect;
-  }
-  float s = screen_aspect * (float)Window_height / (float)Window_width;
+  // ISB trick: use the window aspect only, screen aspect ratio
+  // is not important because we assume pixels are square
+  float s = (float)Window_height / (float)Window_width;
 
-  if (s <= 0.0f) // JEFF: Should this have been 1.0f?
-  {
+  if (s <= 1.0f) {
     // scale x
     Matrix_scale.x = s;
     Matrix_scale.y = 1.0f;
@@ -109,6 +110,9 @@ void g3_StartFrame(vector *view_pos, matrix *view_matrix, float zoom) {
     Matrix_scale.x = 1.0f;
   }
 
+  //ISB: Convert zoom into vertical FOV for convenience
+  zoom *= 3.f / 4.f;
+
   Matrix_scale.z = 1.0f;
 
   // Set the view variables
@@ -116,16 +120,10 @@ void g3_StartFrame(vector *view_pos, matrix *view_matrix, float zoom) {
   View_zoom = zoom;
   Unscaled_matrix = *view_matrix;
 
-  // Compute matrix scale for zoom and aspect ratio
-  if (View_zoom <= 1.0f) {
-    // zoom in by scaling z
-    Matrix_scale.z = Matrix_scale.z * View_zoom;
-  } else {
-    // zoom out by scaling x and y
-    float oOZ = 1.0f / View_zoom;
-    Matrix_scale.x = Matrix_scale.x * oOZ;
-    Matrix_scale.y = Matrix_scale.y * oOZ;
-  }
+  // Scale x and y to zoom in or out;
+  float oOZ = 1.0f / View_zoom;
+  Matrix_scale.x = Matrix_scale.x * oOZ;
+  Matrix_scale.y = Matrix_scale.y * oOZ;
 
   // Scale the matrix elements
   View_matrix.rvec = Unscaled_matrix.rvec * Matrix_scale.x;

--- a/renderer/HardwareSetup.cpp
+++ b/renderer/HardwareSetup.cpp
@@ -61,7 +61,7 @@ void g3_GetProjectionMatrix(float zoom, float *projMat) {
   memset(projMat, 0, sizeof(float) * 16);
 
   // calculate 1/tan(fov)
-  float oOT = 1.0f / zoom;
+  float oOT = 1.0f / vertical_fov;
 
   // fill in the matrix
   // Go read https://www.songho.ca/opengl/gl_projectionmatrix.html


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [x] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

This adds support for setting higher resolutions, as well as the FOV angle. The projection math has been corrected so the aspect ratio is automatically computed given window dimensions.

Possible improvements (probably not in this PR):
 - scale the HUD text to the resolution
 - scale the reticle
 - scale menu

This work is derived from the [Piccu Engine](https://github.com/InsanityBringer/PiccuEngine) that has done this before.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

Closes #205 

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

Descent 3 running in glorious 2540*1440
![res1](https://github.com/user-attachments/assets/c1a3f190-e041-4f95-a5a7-bd85289cd04c)

New video configuration menu
![res2](https://github.com/user-attachments/assets/e4a814dd-96fb-49b5-b844-2d722a235e4f)


![res3](https://github.com/user-attachments/assets/1f83e549-4d51-4915-8ce9-32c261ba76b1)
