### PR TITLE
Initialize DLLcf_* function pointers in con_dll.h

### DIFF
--- a/netcon/includes/con_dll.h
+++ b/netcon/includes/con_dll.h
@@ -985,6 +985,9 @@ void CommonDLLInit(int *api_func) {
   // API.fp[109]; // Not used
   DLLCheckGetD3M = (CheckGetD3M_fp)API.fp[110];
   DLLddio_DoForeachFile = (ddio_DoForeachFile_fp)API.fp[111];
+  DLLcf_LocatePath = (cf_LocatePath_fp)API.fp[112];
+  DLLcf_LocateMultiplePaths = (cf_LocateMultiplePaths_fp)API.fp[113];
+  DLLcf_GetWritableBaseDirectory = (cf_GetWritableBaseDirectory_fp)API.fp[114];
 
   DLLMPlayers = (player *)API.players;
   DLLNetgame = (netgame_info *)API.netgame;


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [X] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [X] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Starting or joining a multiplayer game crashes the game. It looks like commit f5d2a43 (Add -aditionaldir option) did not add intialization of the new DLLcf_* function pointers to con_dll.h. This causes a crash in StartMultiplayerGameMenu() when it looks for *.d3m files with DLLcf_LocateMultiplePaths (and later when it looks for the settings file folder with DLLcf_GetWritableBaseDirectory).

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [X] I have tested my changes locally and verified that they work as intended.
- [ ] I have documented any new or modified functionality.
- [X] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [X] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
