### PR TITLE
Add SDL_SetWindowKeyboardGrab to renderer/HardwareOpenGL.cpp in Release v1.5.0

### DIFF
--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -596,6 +596,7 @@ int opengl_Setup(oeApplication *app, int *width, int *height) {
   }
 
   SDL_SetRelativeMouseMode(ddio_mouseGrabbed ? SDL_TRUE : SDL_FALSE);
+  SDL_SetWindowKeyboardGrab(GSDLWindow, ddio_mouseGrabbed ? SDL_TRUE : SDL_FALSE);
 
   // rcg09182000 gamma fun.
   // rcg01112000 --nogamma fun.


### PR DESCRIPTION
Prevent Fn keys that are in use for desktop environment keyboard shortcuts being passed through.

## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [x] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->
Adds keyboard grab to Release v1.5.0 to enable all Fn keys in game, rather than passing them through for e.g. Xfce keyboard shortcuts.
### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->
Fixes #664
### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
