### PR TITLE
Osiris: only load first-party scripts

### DIFF
--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -670,6 +670,7 @@
 #include "BOA.h"
 #include "terrain.h"
 #include "multi.h"
+#include "module.h"
 #include "hud.h"
 #include "localization.h"
 #include "levelgoal.h"
@@ -1780,7 +1781,11 @@ bool mn3_Open(const std::filesystem::path &mn3file) {
   if (mn3_handle == 0) {
     return false;
   } else {
-    Osiris_ExtractScriptsFromHog(mn3_handle, true);
+    /* Disabled loading scripts from .mn3 files on purpose:
+    all 64-bit first-party level scripts have already been loaded from `PRIMARY_HOG`.
+    Mission files contain only Win32 scripts by default, which cannot not be loaded on 64-bit builds.
+    Reactivate this when we have a proper sandbox system to safely run third-party scripts contained in user-made levels. */ 
+     // Osiris_ExtractScriptsFromHog(mn3_handle, true);
   }
   // do table file stuff.
   std::filesystem::path filename = mn3file.stem();

--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -921,7 +921,10 @@ int get_full_path_to_module(const std::filesystem::path &module_name, std::files
       fullpath = OSIRIS_Extracted_script_dir / OSIRIS_Extracted_scripts[basename].temp_filename;
       return 0;
     }
-    Int3(); // this file was supposed to exist
+
+    // Script was not found in extracted scripts,
+    // we are possibly looking for a script in a 3rd-party level, which we do not want to load 
+    return -2;
   } break;
   default:
     fullpath.clear();


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Disable loading scripts (.dll,.so,.dylib) from .mn3 files, to avoid 3rd-party levels abusing the scripting system. These scripts, compiled for Win32, would not work anyway. The only scripts we want to load are first-party scripts that we compile as part of 'd3-<platform>.hog'.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue 
number. -->
Related to #620 (but not quite loading anything new)