### PR TITLE
[MacOS] Brewfile: add missing 'pkg-config' dependency

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -2,3 +2,4 @@
 
 brew "cmake"
 brew "ninja"
+brew "pkg-config"


### PR DESCRIPTION


## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

VCPKG will not install dependencies if missing
