### PR TITLE
Look for game data in usual Steam/GOG installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,10 +194,10 @@ find_package(plog REQUIRED)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
   message("Building for Linux")
-  add_compile_definitions(POSIX __LINUX__ _USE_OGL_ACTIVE_TEXTURES PRIMARY_HOG=\"d3-linux.hog\")
+  add_compile_definitions(POSIX __LINUX__ PRIMARY_HOG=\"d3-linux.hog\")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   message("Building for macOS")
-  add_compile_definitions(POSIX MACOSX=1 _USE_OGL_ACTIVE_TEXTURES PRIMARY_HOG=\"d3-osx.hog\")
+  add_compile_definitions(POSIX MACOSX=1 PRIMARY_HOG=\"d3-osx.hog\")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   # Windows.h defines to avoid as many issues as possible.
   add_compile_definitions(WIN32_LEAN_AND_MEAN NOMINMAX NODRAWTEXT NOBITMAP NOMCX NOSERVICE PRIMARY_HOG=\"d3-win.hog\"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(D3_PRIMARY_HOG "d3-win.hog")
-  set(D3_STANDARD_PATHS "C:\\Program Files (x86) \\Steam\\Descent 3")
+  set(D3_STANDARD_PATHS
+    "C:\\\\Program Files (x86)\\\\Steam\\\\steamapps\\\\common\\\\Descent 3"
+    "C:\\\\Program Files (x86)\\\\GOG Galaxy\\\\Games\\\\Descent 3"
+  )
 
   # Windows.h defines to avoid as many issues as possible.
   add_compile_definitions(WIN32_LEAN_AND_MEAN NOMINMAX NODRAWTEXT NOBITMAP NOMCX NOSERVICE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,13 +194,25 @@ find_package(plog REQUIRED)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
   message("Building for Linux")
-  add_compile_definitions(POSIX __LINUX__ PRIMARY_HOG=\"d3-linux.hog\")
+  add_compile_definitions(POSIX __LINUX__)
+  set(D3_PRIMARY_HOG "d3-linux.hog")
+  set(D3_STANDARD_PATHS
+    "~/.local/share/Steam/steamapps/common/Descent 3"          # Fedora, arch
+    "~/.steam/debian-installation/steamapps/common/Descent 3"  # Debian & derivatives
+  )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   message("Building for macOS")
-  add_compile_definitions(POSIX MACOSX=1 PRIMARY_HOG=\"d3-osx.hog\")
+  add_compile_definitions(POSIX MACOSX=1)
+  set(D3_PRIMARY_HOG "d3-osx.hog")
+  set(D3_STANDARD_PATHS
+    "~/Library/Application Support/Steam/steamapps/common/Descent 3/Descent 3.app/Contents/Resources"
+  )
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(D3_PRIMARY_HOG "d3-win.hog")
+  set(D3_STANDARD_PATHS "C:\\Program Files (x86) \\Steam\\Descent 3")
+
   # Windows.h defines to avoid as many issues as possible.
-  add_compile_definitions(WIN32_LEAN_AND_MEAN NOMINMAX NODRAWTEXT NOBITMAP NOMCX NOSERVICE PRIMARY_HOG=\"d3-win.hog\"
+  add_compile_definitions(WIN32_LEAN_AND_MEAN NOMINMAX NODRAWTEXT NOBITMAP NOMCX NOSERVICE
           #[[NOGDI]] # We need GDI for now, enable when GDI is actually not needed (or when all windows.h mentions are gone)
   )
 
@@ -237,6 +249,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 
   add_compile_options("/MP")  # so msbuild builds with multiple processes
 endif()
+
+string(REPLACE ";" "\", \"" D3_STANDARD_PATHS_CPP "${D3_STANDARD_PATHS}")
 
 add_compile_definitions($<$<CONFIG:Release>:RELEASE>)
 add_compile_definitions($<$<CONFIG:Debug>:_DEBUG>)

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1444,7 +1444,23 @@ void InitIOSystems(bool editor) {
   // Platform dependent paths
   std::filesystem::path platform_dir = std::filesystem::canonical(D3_DATADIR);
   cf_AddBaseDirectory(platform_dir);
-  // TODO: add Steam/registry locations
+
+  //
+  std::vector<std::filesystem::path> default_platform_dirs = {
+    D3_STANDARD_PATHS
+  };
+
+  for (const auto& platform_dir: default_platform_dirs) {
+    if (platform_dir.u8string().at(0) == '~') {
+      // On Unix, replace "~" in paths by the runtime $HOME directory
+      std::string base_dir_str = platform_dir.u8string();
+      const std::string home_dir = std::getenv("HOME");
+      base_dir_str.replace(0,1,home_dir);
+      cf_AddBaseDirectory(std::filesystem::path(base_dir_str));
+    } else {
+      cf_AddBaseDirectory(platform_dir);
+    }
+  }
 
   // Add path of executable
   std::filesystem::path exec_path = ddio_GetBasePath();
@@ -1534,7 +1550,7 @@ void InitIOSystems(bool editor) {
 
   // last library opened is the first to be searched for dynamic libs, so put
   // this one at the end to find our newly build script libraries first
-  sys_hid = cf_OpenLibrary(PRIMARY_HOG);
+  sys_hid = cf_OpenLibrary(D3_PRIMARY_HOG);
 
   // Check to see if there is a -mission command line option
   // if there is, attempt to open that hog/mn3 so it can override such

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1445,7 +1445,6 @@ void InitIOSystems(bool editor) {
   std::filesystem::path platform_dir = std::filesystem::canonical(D3_DATADIR);
   cf_AddBaseDirectory(platform_dir);
 
-  //
   std::vector<std::filesystem::path> default_platform_dirs = {
     D3_STANDARD_PATHS
   };

--- a/ddio/ddio.h
+++ b/ddio/ddio.h
@@ -318,9 +318,6 @@ void ddio_MouseSetVCoords(int width, int height);
 //	File Operations
 //	---------------------------------------------------------------------------
 
-// Gets the full path of the executable file
-bool ddio_GetBinaryPath(char *exec_path, size_t len);
-
 // deletes a file.  Returns 1 if successful, 0 on failure
 //	This pathname is *RELATIVE* not fully qualified
 int ddio_DeleteFile(const char *name);

--- a/ddio/lnxio.cpp
+++ b/ddio/lnxio.cpp
@@ -106,33 +106,3 @@ void ddio_DebugMessage(unsigned err, char *fmt, ...) {
   LOG_DEBUG << buf;
 }
 
-bool ddio_GetBinaryPath(char *exec_path, size_t len) {
-#ifdef MACOSX
-  if (exec_path == NULL || len == 0) {
-    LOG_ERROR << "Invalid arguments";
-    return false;
-  }
-
-  uint32_t size = (uint32_t)len;
-  if (_NSGetExecutablePath(exec_path, &size) != 0) {
-    LOG_ERROR.printf("Buffer too small; need size %u", size);
-    return false;
-  }
-#elif defined(__LINUX__)
-  if (realpath("/proc/self/exe", exec_path) == NULL) {
-   perror("realpath");
-   return false;
-  }
-#else
-  if (GetModuleFileName(NULL, exec_path, len) == 0) {
-    DWORD error = GetLastError();
-    LOG_ERROR << "GetModuleFileName failed!";
-    return false;
-  }
-  exec_path[len - 1] = '\0';
-  return true;
-
-#endif
-  exec_path[len - 1] = '\0';
-  return true;
-}

--- a/lib/d3_platform_path.h.in
+++ b/lib/d3_platform_path.h.in
@@ -21,6 +21,12 @@
 // Platform-specific compile-time defined location of data files
 #define D3_DATADIR "@D3_DATADIR@"
 
+// Standard Descent 3 installation locations for the platform (Steam, GoG...)
+#define D3_STANDARD_PATHS "@D3_STANDARD_PATHS_CPP@"
+
+// .hog file shipped with the game
+#define D3_PRIMARY_HOG "@D3_PRIMARY_HOG@"
+
 // Part of preference path (organization)
 #define D3_PREF_ORG "Outrage Entertainment"
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Add standard platform paths to look for game data. This makes the game automatically look for not included proprietary game data in classic vendor installation location on all platforms. The objective is not to cover all possible cases, but make the experience seamless for the majority of people.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

Follow up to #628 , also related to #659 

cc @Jayman2000 @winterheart 
