### PR TITLE
CI chores

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,12 @@ jobs:
             cc: cc
             cxx: c++
             name: macOS
-          - runner: ubuntu-20.04 # Using an old version on purpose to get wider glibc compatibility
+          - runner: ubuntu-22.04
             preset: linux
             cc: gcc
             cxx: g++
             name: Linux-x64
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             preset: linux-cross-arm64
             cc: gcc
             cxx: g++
@@ -69,14 +69,14 @@ jobs:
         run: brew bundle install
 
       - name: Install Linux dependencies
-        if: ${{ matrix.os.runner == 'ubuntu-20.04' }}
+        if: ${{ matrix.os.runner == 'ubuntu-22.04' }}
         run: |
           sudo apt update
           sudo apt install -y --no-install-recommends \
             ninja-build g++ curl pkg-config autoconf automake libtool libltdl-dev make python3-jinja2 libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libegl1-mesa-dev libibus-1.0-dev libasound2-dev libpulse-dev libaudio-dev libjack-dev libsndio-dev libxcursor-dev libxfixes-dev libxi-dev libxrandr-dev libxss-dev
 
       - name: Setup cmake
-        if: ${{ matrix.os.runner == 'ubuntu-20.04' }}
+        if: ${{ matrix.os.runner == 'ubuntu-22.04' }}
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.30.x'

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "baa52c82b9b0e96f6c2557646a74b1f46b0b3071",
+  "builtin-baseline": "8f90c294883ccf67d2f4953383718aeae981575f",
   "dependencies": [
     "cpp-httplib",
     "glm",
@@ -15,6 +15,11 @@
       "name": "sdl3",
       "version>=": "3.2.6",
       "platform": "!linux"
+    },
+    {
+      "name": "libxcrypt",
+      "version>=": "4.4.38",
+      "platform": "linux"
     },
     "zlib"
   ],


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [x] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [ ] Other changes

## Description

 - VCPKG: Update baseline, lock libxcrypt version to build with GCC 15. libxcrypt is a transitive dependency that we want to be at version 4.4.38 to build with GCC 15
- Update baseline hash to fix Mac CI
- Update Linux runners to Ubuntu 22 because Github is retiring EOL Ubuntu 20.04
