### PR TITLE
Improve -nomousegrab mouse input handling

### DIFF
--- a/ddio/lnxmouse.cpp
+++ b/ddio/lnxmouse.cpp
@@ -95,7 +95,8 @@ static bool DDIO_mouse_init = false;
 static struct mses_state {
   int fd;                   // file descriptor of mouse
   int t, l, b, r;           // limit rectangle of absolute mouse coords
-  int x, y, dx, dy, cx, cy; // current x,y,z in absolute mouse coords
+  int x, y, cx, cy;         // current x,y,z in absolute mouse coords
+  float dx, dy;             
   int btn_mask;
 } DDIO_mouse_state;
 
@@ -169,7 +170,7 @@ void ddio_MouseReset() {
 
   DDIO_mouse_state.x = DDIO_mouse_state.cx = Lnx_app_obj->m_W / 2;
   DDIO_mouse_state.y = DDIO_mouse_state.cy = Lnx_app_obj->m_H / 2;
-  DDIO_mouse_state.dy = DDIO_mouse_state.dx = 0;
+  DDIO_mouse_state.dy = DDIO_mouse_state.dx = 0.0f;
 }
 
 //	displays the mouse pointer.  Each Hide call = Show call.
@@ -388,25 +389,16 @@ bool sdlMouseWheelFilter(SDL_Event const *event) {
 
 bool sdlMouseMotionFilter(SDL_Event const *event) {
   if (event->type == SDL_EVENT_JOYSTICK_BALL_MOTION) {
-    DDIO_mouse_state.dx = event->jball.xrel / 100;
-    DDIO_mouse_state.dy = event->jball.yrel / 100;
+    DDIO_mouse_state.dx = event->jball.xrel / 100.0f;
+    DDIO_mouse_state.dy = event->jball.yrel / 100.0f;
     DDIO_mouse_state.x += DDIO_mouse_state.dx;
     DDIO_mouse_state.y += DDIO_mouse_state.dy;
-  } // if
-  else {
-    if (ddio_mouseGrabbed) {
-      DDIO_mouse_state.dx += event->motion.xrel;
-      DDIO_mouse_state.dy += event->motion.yrel;
-      DDIO_mouse_state.x += DDIO_mouse_state.dx;
-      DDIO_mouse_state.y += DDIO_mouse_state.dy;
-    } // if
-    else {
-      DDIO_mouse_state.dx = event->motion.x - DDIO_mouse_state.x;
-      DDIO_mouse_state.dy = event->motion.y - DDIO_mouse_state.y;
-      DDIO_mouse_state.x = event->motion.x;
-      DDIO_mouse_state.y = event->motion.y;
-    } // else
-  }   // else
+  } else {
+    DDIO_mouse_state.dx += event->motion.xrel;
+    DDIO_mouse_state.dy += event->motion.yrel;
+    DDIO_mouse_state.x += DDIO_mouse_state.dx;
+    DDIO_mouse_state.y += DDIO_mouse_state.dy;
+  }
 
   if (DDIO_mouse_state.x < DDIO_mouse_state.l)
     DDIO_mouse_state.x = DDIO_mouse_state.l;
@@ -449,8 +441,8 @@ int ddio_MouseGetState(int *x, int *y, int *dx, int *dy, int *z, int *dz) {
   if (dz)
     *dz = 0;
 
-  DDIO_mouse_state.dx = 0;
-  DDIO_mouse_state.dy = 0;
+  DDIO_mouse_state.dx = 0.0f;
+  DDIO_mouse_state.dy = 0.0f;
 
   // unset the mouse wheel "button" once it's been retrieved.
   DDIO_mouse_state.btn_mask &= ~(MOUSE_B5|MOUSE_B6);


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [ ] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [x] Input changes
  - [ ] Network changes
  - [ ] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Minor fixes to #695 (@tophyr ):
 - `event->motion.[x/y]rel` is float, so store `DDIO_mouse_state.dx` as float to avoid losing precision. This is especially needed when mouse is not grabbed by the window (-nomousegrab option) where xrel/yrel does not only have integer values.
 - Remove broken legacy code supporting `-nomousegrab` mode. Position is still not the same between the actual OS cursor and the in-game cursor, but it is better than it was before.