### PR TITLE
Let vector::operator- output same type as input, and implement via std::negate not multiply

### DIFF
--- a/lib/vecmat_external.h
+++ b/lib/vecmat_external.h
@@ -146,7 +146,7 @@ template<enum align A_DST = align::adaptive>
 constexpr inline const vec<T,3,A_DST> bph() const { return vec<T,3,A_DST>{ b(), p(), h() }; }
 
 constexpr inline T sum() const                    { return std::accumulate((*this).cbegin(), (*this).cend(), (T)0); }
-constexpr inline vec<T,3,A> operator-() const     { vec<T,N,A> neg = {}; neg.fill((T)-1); return (*this) * neg; }
+constexpr inline vec<T,N,A> operator-() const     { vec<T,N,A> neg = {}; neg.fill((T)-1); return (*this) * neg; }
 
 /* arithmetic vector */
 template<typename T_OTHER, size_t N_OTHER, enum align A_OTHER = align::adaptive, typename T_DST = decltype((T)1 + (T_OTHER)1)>

--- a/lib/vecmat_external.h
+++ b/lib/vecmat_external.h
@@ -43,10 +43,11 @@
 #pragma once
 
 #include "fix.h"
-#include <array>
-#include <numeric>
 #include <algorithm>
+#include <array>
+#include <functional>
 #include <limits>
+#include <numeric>
 
 static constexpr inline bool VM_ISPOW2(uintmax_t x) { return (x && (!(x & (x-1)))); }
 
@@ -146,7 +147,12 @@ template<enum align A_DST = align::adaptive>
 constexpr inline const vec<T,3,A_DST> bph() const { return vec<T,3,A_DST>{ b(), p(), h() }; }
 
 constexpr inline T sum() const                    { return std::accumulate((*this).cbegin(), (*this).cend(), (T)0); }
-constexpr inline vec<T,N,A> operator-() const     { vec<T,N,A> neg = {}; neg.fill((T)-1); return (*this) * neg; }
+constexpr inline vec<T,N,A> operator-() const
+{
+	vec<T,N,A> dst;
+	std::transform((*this).cbegin(), (*this).cbegin() + N, dst.begin(), std::negate<>{});
+	return dst;
+}
 
 /* arithmetic vector */
 template<typename T_OTHER, size_t N_OTHER, enum align A_OTHER = align::adaptive, typename T_DST = decltype((T)1 + (T_OTHER)1)>


### PR DESCRIPTION
## Pull Request Type

- [x] Build and Dependency changes

### Description

- <T,3,A> looks wrong.
- operator- should be implemented in terms of operator-, not the potentially more costly operator*.

### Related Issues

https://github.com/DescentDevelopers/Descent3/pull/686 cc @jopadan
https://github.com/DescentDevelopers/Descent3/pull/703

### Checklist

- [x] build check
- [x] runtime check (2025-05-21)
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
