### PR TITLE
Fix link failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ endif()
 
 find_package(SDL3 REQUIRED CONFIG REQUIRED COMPONENTS SDL3)
 find_package(glm REQUIRED)
+find_package(httplib QUIET)
 if (TARGET httplib::httplib)
   add_library(httplib ALIAS httplib::httplib)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,9 +186,16 @@ if (TARGET httplib::httplib)
 else()
   # Some Linux distributions do not package httplibConfig.cmake, so find the header manually
   find_file(CPP_HTTPLIB_HEADER httplib.h REQUIRED)
+  find_library(CPP_HTTPLIB_LIB cpp-httplib QUIET)
 
   # The target httplib::httplib cannot be created manually, so rename it
   add_library(httplib INTERFACE ${CPP_HTTPLIB_HEADER})
+
+  # And some Linux distributions build httplib as header-only,
+  # and some as header+library. What a mess!
+  if (NOT ${CPP_HTTPLIB_LIB} STREQUAL "CPP_HTTPLIB_LIB-NOTFOUND")
+    target_link_libraries(httplib INTERFACE ${CPP_HTTPLIB_LIB})
+  endif ()
 endif()
 find_package(ZLIB REQUIRED)
 find_package(plog REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ endif()
 
 find_package(SDL3 REQUIRED CONFIG REQUIRED COMPONENTS SDL3)
 find_package(glm REQUIRED)
-if (TARGET httlib::httplib)
+if (TARGET httplib::httplib)
   add_library(httplib ALIAS httplib::httplib)
 else()
   # Some Linux distributions do not package httplibConfig.cmake, so find the header manually


### PR DESCRIPTION
## Pull Request Type

- [x] Build and Dependency changes

### Description

Fixes

```
    /usr/include/c++/14/bits/unique_ptr.h:1077:(.text+0x7ae9): undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
    /usr/lib64/gcc/x86_64-suse-linux/14/../../../../x86_64-suse-linux/bin/ld: /usr/include/c++/14/bits/unique_ptr.h:93:(.text+0x7b0b): undefined reference to `httplib::Client::~Client()'
```

### Related Issues

#675 

### Checklist

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
