### PR TITLE
Remove redundant casts and string operations

### DIFF
--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -701,12 +701,12 @@ bool mn3_GetInfo(const std::filesystem::path &mn3file, tMissionInfo *msn);
 
 static inline bool IS_MN3_FILE(const std::filesystem::path &fname) {
   std::filesystem::path ext = fname.extension();
-  return (stricmp((const char*)ext.u8string().c_str(), ".mn3") == 0);
+  return (stricmp(ext.u8string().c_str(), ".mn3") == 0);
 }
 
 static inline std::filesystem::path MN3_TO_MSN_NAME(const std::filesystem::path &mn3name) {
   std::filesystem::path fname = std::filesystem::path(mn3name).stem();
-  if (stricmp((const char*)fname.u8string().c_str(), "d3_2") == 0) {
+  if (stricmp(fname.u8string().c_str(), "d3_2") == 0) {
     fname = "d3";
   }
   fname.replace_extension(".msn");
@@ -1166,9 +1166,9 @@ bool LoadMission(const char *mssn) {
   //	set up current mission (movies are already set above)
   msn->cur_level = 1;
   msn->num_levels = numlevels;
-  msn->filename = mem_strdup((const char*)mission.u8string().c_str());
+  msn->filename = mem_strdup(mission.u8string().c_str());
   msn->game_state_flags = 0;
-  strcpy(Net_msn_URLs.msnname, (const char*)mission.u8string().c_str());
+  strcpy(Net_msn_URLs.msnname, mission.u8string().c_str());
   res = true; // everything is ok.
 
   // if error, print it out, else end.
@@ -1238,7 +1238,7 @@ void LoadLevelText(const std::filesystem::path &level_filename) {
   pathname.replace_extension(".str");
 
   char **goal_strings;
-  if (CreateStringTable((const char*)pathname.u8string().c_str(), &goal_strings, &n_strings)) {
+  if (CreateStringTable(pathname.u8string().c_str(), &goal_strings, &n_strings)) {
     int n_goals = Level_goals.GetNumGoals();
     ASSERT(n_strings == (n_goals * 3));
     for (int i = 0; i < n_goals; i++) {
@@ -1791,17 +1791,17 @@ bool mn3_Open(const std::filesystem::path &mn3file) {
   std::filesystem::path filename = mn3file.stem();
 
   std::filesystem::path voice_hog;
-  if ((stricmp((const char*)filename.u8string().c_str(), "d3") == 0) || (stricmp((const char*)filename.u8string().c_str(), "training") == 0)) {
+  if ((stricmp(filename.u8string().c_str(), "d3") == 0) || (stricmp(filename.u8string().c_str(), "training") == 0)) {
     // Open audio hog file
     voice_hog = std::filesystem::path("missions") / "d3voice1.hog"; // Audio for levels 1-4
     Mission_voice_hog_handle = cf_OpenLibrary(voice_hog);
-  } else if (stricmp((const char*)filename.u8string().c_str(), "d3_2") == 0) {
+  } else if (stricmp(filename.u8string().c_str(), "d3_2") == 0) {
     // Open audio hog file
     voice_hog = std::filesystem::path("missions") / "d3voice2.hog"; // Audio for levels 5-17
     Mission_voice_hog_handle = cf_OpenLibrary(voice_hog);
   }
   filename.replace_extension(".gam");
-  mng_SetAddonTable((const char*)filename.u8string().c_str());
+  mng_SetAddonTable(filename.u8string().c_str());
   Current_mission.mn3_handle = mn3_handle;
   return true;
 }

--- a/Descent3/OsirisLoadandBind.cpp
+++ b/Descent3/OsirisLoadandBind.cpp
@@ -778,7 +778,7 @@ int Osiris_FindLoadedModule(const std::filesystem::path &module_name) {
   for (int i = 0; i < MAX_LOADED_MODULES; i++) {
     if (OSIRIS_loaded_modules[i].flags & OSIMF_INUSE) {
       if (OSIRIS_loaded_modules[i].module_name &&
-          (stricmp(OSIRIS_loaded_modules[i].module_name, (const char*)real_name.u8string().c_str()) == 0)) {
+          (stricmp(OSIRIS_loaded_modules[i].module_name, real_name.u8string().c_str()) == 0)) {
         // we found a match
         return i;
       }
@@ -890,7 +890,7 @@ int get_full_path_to_module(const std::filesystem::path &module_name, std::files
   adjusted_fname = module_name.filename();
 
   // make sure filename/ext is all lowercase, requirement for Linux, doesn't hurt Windows
-  std::string p = (const char*)adjusted_fname.u8string().c_str();
+  std::string p = adjusted_fname.u8string();
   std::transform(p.begin(), p.end(), p.begin(), [](unsigned char c) { return std::tolower(c); });
   adjusted_fname = p;
 
@@ -1034,7 +1034,7 @@ int Osiris_LoadLevelModule(const std::filesystem::path &module_name) {
   osm->SaveRestoreState = (SaveRestoreState_fp)mod_GetSymbol(mod, "SaveRestoreState", 8);
 
   osm->flags |= OSIMF_INUSE | OSIMF_LEVEL;
-  osm->module_name = mem_strdup((const char*)basename.u8string().c_str());
+  osm->module_name = mem_strdup(basename.u8string().c_str());
   osm->reference_count = 1;
 
 #ifdef OSIRISDEBUG
@@ -1047,7 +1047,7 @@ int Osiris_LoadLevelModule(const std::filesystem::path &module_name) {
       !osm->GetCOScriptList || !osm->CreateInstance || !osm->DestroyInstance || !osm->SaveRestoreState ||
       !osm->CallInstanceEvent) {
     // there was an error importing a function
-    LOG_ERROR.printf("OSIRIS: Osiris_LoadLevelModule(%s) couldn't import function.", (const char*)module_name.u8string().c_str());
+    LOG_ERROR.printf("OSIRIS: Osiris_LoadLevelModule(%s) couldn't import function.", module_name.u8string().c_str());
     Int3();
     osm->flags = 0;
     if (osm->module_name)
@@ -1059,7 +1059,7 @@ int Osiris_LoadLevelModule(const std::filesystem::path &module_name) {
 
   // check to see if there is a corresponding string table to load
   char stringtablename[_MAX_PATH];
-  strcpy(stringtablename, (const char*)basename.u8string().c_str());
+  strcpy(stringtablename, basename.u8string().c_str());
   strcat(stringtablename, ".str");
 
   if (cfexist(stringtablename)) {
@@ -1227,7 +1227,7 @@ int Osiris_LoadGameModule(const std::filesystem::path &module_name) {
   osm->SaveRestoreState = (SaveRestoreState_fp)mod_GetSymbol(mod, "SaveRestoreState", 8);
 
   osm->flags |= OSIMF_INUSE;
-  osm->module_name = mem_strdup((const char*)basename.u8string().c_str());
+  osm->module_name = mem_strdup(basename.u8string().c_str());
   osm->reference_count = 1;
 
 #ifdef OSIRISDEBUG
@@ -1251,7 +1251,7 @@ int Osiris_LoadGameModule(const std::filesystem::path &module_name) {
 
   // check to see if there is a corresponding string table to load
   char stringtablename[_MAX_PATH];
-  strcpy(stringtablename, (const char*)basename.u8string().c_str());
+  strcpy(stringtablename, basename.u8string().c_str());
   strcat(stringtablename, ".str");
 
   if (cfexist(stringtablename)) {
@@ -1259,7 +1259,7 @@ int Osiris_LoadGameModule(const std::filesystem::path &module_name) {
     bool ret = CreateStringTable(stringtablename, &osm->string_table, &osm->strings_loaded);
     if (!ret) {
       LOG_FATAL.printf("OSIRIS: Unable to load string table (%s) for (%s)", stringtablename,
-                       (const char*)basename.u8string().c_str());
+                       basename.u8string().c_str());
       Int3();
       osm->string_table = nullptr;
       osm->strings_loaded = 0;
@@ -1277,7 +1277,7 @@ int Osiris_LoadGameModule(const std::filesystem::path &module_name) {
   // when we get to this point we nearly have a loaded module, we just need to initialize it
   if (!osm->InitializeDLL(&Osiris_module_init)) {
     // there was an error initializing the module
-    LOG_ERROR.printf("OSIRIS: Osiris_LoadGameModule(%s) error initializing module.", (const char*)basename.u8string().c_str());
+    LOG_ERROR.printf("OSIRIS: Osiris_LoadGameModule(%s) error initializing module.", basename.u8string().c_str());
     if (osm->string_table) {
       DestroyStringTable(osm->string_table, osm->strings_loaded);
     }
@@ -3120,7 +3120,7 @@ int Osiris_ExtractScriptsFromHog(int library_handle, bool is_mission_hog) {
         if (temp_filename.empty()) {
           Int3();
         } else {
-          std::string temp_realname = (const char*)std::filesystem::path(filename).stem().u8string().c_str();
+          std::string temp_realname = std::filesystem::path(filename).stem().u8string();
           // Lowercase for optimized search
           std::transform(temp_realname.begin(), temp_realname.end(), temp_realname.begin(),
                          [](unsigned char c) { return std::tolower(c); });

--- a/Descent3/ambient.cpp
+++ b/Descent3/ambient.cpp
@@ -294,7 +294,7 @@ void WriteAmbientData() {
   CFILE *ofile;
 
 #ifndef NEWEDITOR
-  ddio_MakePath(filename, (const char*)cf_GetWritableBaseDirectory().u8string().c_str(), "data", "misc", AMBIENT_FILE_NAME, NULL);
+  ddio_MakePath(filename, cf_GetWritableBaseDirectory().u8string().c_str(), "data", "misc", AMBIENT_FILE_NAME, NULL);
 #else
   ddio_MakePath(filename, D3HogDir, "data", "misc", AMBIENT_FILE_NAME, NULL);
 #endif

--- a/Descent3/audiotaunts.cpp
+++ b/Descent3/audiotaunts.cpp
@@ -354,7 +354,7 @@ bool taunt_ImportWave(const char *wave_filename, const char *outputfilename) {
     goto error;
   }
 
-  if (!aenc_Compress((const char*)temp_filename.u8string().c_str(), (const char*)osftemp_filename.u8string().c_str(), NULL, &samples, &rate, &chan, NULL, NULL)) {
+  if (!aenc_Compress(temp_filename.u8string().c_str(), osftemp_filename.u8string().c_str(), NULL, &samples, &rate, &chan, NULL, NULL)) {
     // unable to compress
     LOG_WARNING << "Unable to compress";
     ret = false;

--- a/Descent3/cinematics.cpp
+++ b/Descent3/cinematics.cpp
@@ -72,9 +72,9 @@ bool PlayMovie(const std::filesystem::path &moviename) {
   std::filesystem::path filename = moviename;
   // check extension
   std::filesystem::path extension = moviename.extension();
-  if (stricmp((const char*)extension.u8string().c_str(), ".mve") != 0 && stricmp((const char*)extension.u8string().c_str(), ".mv8") != 0) {
+  if (stricmp(extension.u8string().c_str(), ".mve") != 0 && stricmp(extension.u8string().c_str(), ".mv8") != 0) {
     // we need an extension
-    filename.replace_extension(".mve");
+    filename.replace_extension(extension.u8string() + ".mve");
   }
 
   // Initializes the subtitles for a given movie file

--- a/Descent3/d3movie.cpp
+++ b/Descent3/d3movie.cpp
@@ -81,7 +81,7 @@ int mve_PlayMovie(const std::filesystem::path &pMovieName, oeApplication *pApp) 
     return MVELIB_FILE_ERROR;
   }
   // open movie file.
-  FILE *hFile = fopen((const char*)real_name.u8string().c_str(), "rb");
+  FILE *hFile = fopen(real_name.u8string().c_str(), "rb");
   if (hFile == nullptr) {
     LOG_ERROR << "MOVIE: Unable to open " << pMovieName;
     return MVELIB_FILE_ERROR;
@@ -323,10 +323,10 @@ intptr_t mve_SequenceStart(const char *mvename, void *fhandle, oeApplication *ap
 #ifndef NO_MOVIES
   // first, find that movie..
   std::filesystem::path real_name = cf_LocatePath(std::filesystem::path("movies") / mvename);
-  fhandle = fopen((const char*)real_name.u8string().c_str(), "rb");
+  fhandle = fopen(real_name.u8string().c_str(), "rb");
 
   if (fhandle == nullptr) {
-    LOG_WARNING.printf("MOVIE: Unable to open %s", (const char*)real_name.u8string().c_str());
+    LOG_WARNING.printf("MOVIE: Unable to open %s", real_name.u8string().c_str());
     return 0;
   }
 

--- a/Descent3/demofile.cpp
+++ b/Descent3/demofile.cpp
@@ -401,7 +401,7 @@ void DemoWriteHeader() {
   ASSERT(Demo_flags == DF_RECORDING);
 
   // Start off with the signature
-  cf_WriteString(Demo_cfp, (const char *)szsig);
+  cf_WriteString(Demo_cfp, szsig);
   // Next is the version
   cf_WriteShort(Demo_cfp, GAMESAVE_VERSION);
   // Write the mission filename
@@ -774,7 +774,7 @@ int DemoReadHeader() {
   // Now load the mission
   Osiris_DisableCreateEvents();
   IsRestoredGame = true;
-  if (LoadMission((const char *)demo_mission)) {
+  if (LoadMission(demo_mission)) {
     mng_LoadAddonPages();
 
     SetCurrentLevel(level_num);

--- a/Descent3/game.cpp
+++ b/Descent3/game.cpp
@@ -969,7 +969,7 @@ void SetScreenMode(int sm, bool force_res_change) {
     } else {
       int t = FindArg("-ForceStateLimited");
       if (t) {
-        StateLimited = (atoi((const char *)GameArgs[t + 1]) != 0);
+        StateLimited = (atoi(GameArgs[t + 1]) != 0);
       }
 
       if (rend_initted == -1) {

--- a/Descent3/game.cpp
+++ b/Descent3/game.cpp
@@ -1273,7 +1273,7 @@ void DoScreenshot() {
   screen_name << "screenshot-" << std::chrono::duration_cast<std::chrono::milliseconds>(now).count() << ".png";
   std::filesystem::path filename = screenshots_path / screen_name.str();
   // Now save it
-  screenshot->saveAsPNG((const char*)filename.u8string().c_str());
+  screenshot->saveAsPNG(filename.u8string().c_str());
 
   if (Demo_flags != DF_PLAYBACK) {
     AddHUDMessage(TXT_SCRNSHT, filename.filename().u8string().c_str());

--- a/Descent3/gamesave.cpp
+++ b/Descent3/gamesave.cpp
@@ -345,8 +345,7 @@ void QuickSaveGame() {
     filename << "saveg" << std::setw(3) << std::setfill('0') << Quicksave_game_slot;
     std::filesystem::path pathname = cf_GetWritableBaseDirectory() / "savegame" / filename.str();
 
-    FILE *fp = fopen((const char*)pathname.u8string().c_str(), "rb");
-
+    FILE *fp = fopen(pathname.u8string().c_str(), "rb");
     if (fp) {
       // slot valid, save here.
       fclose(fp);
@@ -419,8 +418,7 @@ void SaveGameDialog() {
 
     occupied_slot[i] = false;
 
-    fp = fopen((const char*)pathname.u8string().c_str(), "rb");
-
+    fp = fopen(pathname.u8string().c_str(), "rb");
     if (fp) {
       fclose(fp);
 
@@ -542,7 +540,7 @@ void __cdecl LoadGameDialogCB(newuiTiledWindow *wnd, void *data)
 
     LOG_DEBUG.printf("savegame slot=%d", id - SAVE_HOTSPOT_ID);
 
-    ddio_MakePath(savegame_dir, (const char*)cf_GetWritableBaseDirectory().u8string().c_str(), "savegame", NULL);
+    ddio_MakePath(savegame_dir, cf_GetWritableBaseDirectory().u8string().c_str(), "savegame", NULL);
     snprintf(filename, sizeof(filename), "saveg00%d", (id - SAVE_HOTSPOT_ID));
     ddio_MakePath(pathname, savegame_dir, filename, NULL);
 
@@ -615,8 +613,7 @@ bool LoadGameDialog() {
 
     occupied_slot[i] = false;
 
-    fp = fopen((const char*)pathname.u8string().c_str(), "rb");
-
+    fp = fopen(pathname.u8string().c_str(), "rb");
     if (fp) {
       int bm_handle = -1;
       int *pbm_handle;

--- a/Descent3/gamesequence.cpp
+++ b/Descent3/gamesequence.cpp
@@ -1330,7 +1330,7 @@ bool SimpleStartLevel(const std::filesystem::path& level_name) {
   Current_mission.num_levels = 1;
 
   Current_level = nullptr;
-  Current_mission.levels[0].filename = mem_strdup((const char*)level_name.u8string().c_str());
+  Current_mission.levels[0].filename = mem_strdup(level_name.u8string().c_str());
   InitMissionScript();
 
   return true;

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1202,8 +1202,8 @@ void SaveGameSettings() {
   else
     Database->write("Default_pilot", " ", 2);
 
-  Database->write("GAME_base_directory", (const char*)config_base_directory.u8string().c_str(),
-                  strlen((const char*)config_base_directory.u8string().c_str()) + 1);
+  Database->write("GAME_base_directory", config_base_directory.u8string().c_str(),
+                  strlen(config_base_directory.u8string().c_str()) + 1);
 }
 
 /*
@@ -2060,15 +2060,15 @@ void SetupTempDirectory(void) {
     exit(1);
   }
   // restore working dir
-  ddio_SetWorkingDir((const char*)cf_GetWritableBaseDirectory().u8string().c_str());
+  ddio_SetWorkingDir(cf_GetWritableBaseDirectory().u8string().c_str());
 }
 
 void DeleteTempFiles() {
   ddio_DoForeachFile(Descent3_temp_directory, std::regex("d3[smocti].+\\.tmp"), [](const std::filesystem::path &path) {
     std::error_code ec;
     std::filesystem::remove(path, ec);
-    LOG_WARNING_IF(ec).printf("Unable to remove temporary file %s: %s\n", (const char*)path.u8string().c_str(),
-                              (const char*)ec.message().c_str());
+    LOG_WARNING_IF(ec).printf("Unable to remove temporary file %s: %s\n", path.u8string().c_str(),
+                              ec.message().c_str());
   });
 }
 

--- a/Descent3/menu.cpp
+++ b/Descent3/menu.cpp
@@ -1054,11 +1054,11 @@ static inline int count_missions(const std::vector<std::filesystem::path> &missi
 
   for (const auto &missions_directory : missions_directories) {
     ddio_DoForeachFile(missions_directory, std::regex(".*\\.mn3"), [&c](const std::filesystem::path &path) {
-      if (stricmp((const char*)path.filename().u8string().c_str(), "d3_2.mn3") == 0)
+      if (stricmp(path.filename().u8string().c_str(), "d3_2.mn3") == 0)
         return;
-      LOG_DEBUG.printf("Mission path: %s", (const char*)path.u8string().c_str());
+      LOG_DEBUG.printf("Mission path: %s", path.u8string().c_str());
       tMissionInfo msninfo{};
-      GetMissionInfo((const char*)path.filename().u8string().c_str(), &msninfo);
+      GetMissionInfo(path.filename().u8string().c_str(), &msninfo);
 
       if (msninfo.name[0] && msninfo.single) {
         LOG_DEBUG.printf("Name: %s", msninfo.name);
@@ -1081,7 +1081,7 @@ static inline int generate_mission_listbox(newuiListBox *lb, std::vector<std::fi
     ddio_DoForeachFile(
         missions_directory, std::regex(".*\\.mn3"), [&c, &lb, &filelist](const std::filesystem::path &path) {
           tMissionInfo msninfo{};
-          if (stricmp((const char*)path.filename().u8string().c_str(), "d3_2.mn3") == 0)
+          if (stricmp(path.filename().u8string().c_str(), "d3_2.mn3") == 0)
           return;
         if (GetMissionInfo(path.filename(), &msninfo) && msninfo.name[0] && msninfo.single) {
           filelist.push_back(path.filename());
@@ -1174,7 +1174,7 @@ bool MenuNewGame() {
     return false;
   }
   for (auto const &mission : filelist) {
-    if (stricmp((const char*)mission.u8string().c_str(), "d3.mn3") == 0) {
+    if (stricmp(mission.u8string().c_str(), "d3.mn3") == 0) {
       found = true;
       break;
     }
@@ -1245,7 +1245,7 @@ redo_newgame_menu:
     if (index >= 0 && index < filelist.size()) {
       nameptr = filelist[index];
     }
-    if (nameptr.empty() || !LoadMission((const char*)nameptr.u8string().c_str())) {
+    if (nameptr.empty() || !LoadMission(nameptr.u8string().c_str())) {
       DoMessageBox(TXT_ERROR, TXT_ERRLOADMSN, MSGBOX_OK);
       retval = false;
     } else {

--- a/Descent3/mission_download.cpp
+++ b/Descent3/mission_download.cpp
@@ -317,12 +317,12 @@ bool msn_DownloadWithStatus(const char *url, const std::filesystem::path &filena
   bool file_is_zip = false;
 
   std::vector<std::string> url_parts = StringSplit(url, "/");
-  if (!(stricmp("http:", (const char*)url_parts.front().c_str()) == 0 || stricmp("https:", (const char*)url_parts.front().c_str()) == 0)) {
-    LOG_WARNING.printf("'%s' scheme is not supported, no download!", (const char*)url_parts.front().c_str());
+  if (!(stricmp("http:", url_parts.front().c_str()) == 0 || stricmp("https:", url_parts.front().c_str()) == 0)) {
+    LOG_WARNING.printf("'%s' scheme is not supported, no download!", url_parts.front().c_str());
     return false;
   }
   std::filesystem::path download_file = std::filesystem::path(url_parts.back());
-  if (stricmp((const char*)download_file.extension().u8string().c_str(), ".zip") == 0) {
+  if (stricmp(download_file.extension().u8string().c_str(), ".zip") == 0) {
     LOG_DEBUG << "We're downloading a zip file!!!";
     file_is_zip = true;
   }
@@ -703,7 +703,7 @@ int msn_ExtractZipFile(const std::filesystem::path &zipfilename, const std::file
   ZIP zfile;
   zipentry *ze;
 
-  if (!zfile.OpenZip((const char*)zipfilename.u8string().c_str())) {
+  if (!zfile.OpenZip(zipfilename.u8string().c_str())) {
     LOG_WARNING << "Unable to open zip file";
     return 0;
   }
@@ -785,7 +785,7 @@ int msn_ExtractZipFile(const std::filesystem::path &zipfilename, const std::file
             console.puts(GR_GREEN, "CRC OK");
 
             // check to see if we extracted our mn3
-            if (CompareZipFileName(ze->name, (const char*)mn3name.u8string().c_str())) {
+            if (CompareZipFileName(ze->name, mn3name.u8string().c_str())) {
               found_mn3 = true;
             }
           } else {

--- a/Descent3/multi.cpp
+++ b/Descent3/multi.cpp
@@ -7998,23 +7998,23 @@ char *GetFileNameFromPlayerAndID(int16_t playernum, int16_t id) {
     break;
   case NETFILE_ID_SHIP_TEX:
     if (NetPlayers[playernum].ship_logo[0])
-      ddio_MakePath(rval, (const char*)cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "graphics", NetPlayers[playernum].ship_logo, NULL);
+      ddio_MakePath(rval, cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "graphics", NetPlayers[playernum].ship_logo, NULL);
     break;
   case NETFILE_ID_VOICE_TAUNT1:
     if (NetPlayers[playernum].voice_taunt1[0])
-      ddio_MakePath(rval, (const char*)cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "sounds", NetPlayers[playernum].voice_taunt1, NULL);
+      ddio_MakePath(rval, cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "sounds", NetPlayers[playernum].voice_taunt1, NULL);
     break;
   case NETFILE_ID_VOICE_TAUNT2:
     if (NetPlayers[playernum].voice_taunt2[0])
-      ddio_MakePath(rval, (const char*)cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "sounds", NetPlayers[playernum].voice_taunt2, NULL);
+      ddio_MakePath(rval, cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "sounds", NetPlayers[playernum].voice_taunt2, NULL);
     break;
   case NETFILE_ID_VOICE_TAUNT3:
     if (NetPlayers[playernum].voice_taunt3[0])
-      ddio_MakePath(rval, (const char*)cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "sounds", NetPlayers[playernum].voice_taunt3, NULL);
+      ddio_MakePath(rval, cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "sounds", NetPlayers[playernum].voice_taunt3, NULL);
     break;
   case NETFILE_ID_VOICE_TAUNT4:
     if (NetPlayers[playernum].voice_taunt4[0])
-      ddio_MakePath(rval, (const char*)cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "sounds", NetPlayers[playernum].voice_taunt4, NULL);
+      ddio_MakePath(rval, cf_GetWritableBaseDirectory().u8string().c_str(), "custom", "sounds", NetPlayers[playernum].voice_taunt4, NULL);
     break;
   default:
     LOG_FATAL.printf("Unknown id (%d) passed to GetFileNameFromPlayerAndID()", id);

--- a/Descent3/newui_filedlg.cpp
+++ b/Descent3/newui_filedlg.cpp
@@ -219,7 +219,7 @@ bool DoPathFileDialog(bool save_dialog, std::filesystem::path &path, const char 
   sheet->NewGroup(nullptr, 0, 0);
   rootpathlistbox = sheet->AddListBox(60, 124, ID_ROOTPATH);
   for (auto const &root : ddio_GetSysRoots()) {
-    rootpathlistbox->AddItem((const char*)root.u8string().c_str());
+    rootpathlistbox->AddItem(root.u8string().c_str());
   }
 
   sheet->NewGroup(nullptr, 80, 0);
@@ -237,7 +237,7 @@ bool DoPathFileDialog(bool save_dialog, std::filesystem::path &path, const char 
   working_path = std::filesystem::canonical(path);
   UpdateFileList(listbox, working_path, wildcards);
 
-  strncpy(edits_filepath, (const char*)working_path.u8string().c_str(), _MAX_PATH - 1);
+  strncpy(edits_filepath, working_path.u8string().c_str(), _MAX_PATH - 1);
   edits_filepath[_MAX_PATH - 1] = '\0';
 
   std::string wildc1 = StringJoin(wildcards, ";");
@@ -275,7 +275,7 @@ bool DoPathFileDialog(bool save_dialog, std::filesystem::path &path, const char 
                 working_path = std::filesystem::canonical(working_path);
                 UpdateFileList(listbox, working_path, wildcards);
 
-                strncpy(edits_filepath, (const char*)working_path.u8string().c_str(), _MAX_PATH - 1);
+                strncpy(edits_filepath, working_path.u8string().c_str(), _MAX_PATH - 1);
                 edits_filepath[_MAX_PATH - 1] = '\0';
               } else {
                 // File is chosen
@@ -335,7 +335,7 @@ bool DoPathFileDialog(bool save_dialog, std::filesystem::path &path, const char 
 
             UpdateFileList(listbox, working_path, wildcards);
 
-            strncpy(edits_filepath, (const char*)working_path.u8string().c_str(), _MAX_PATH - 1);
+            strncpy(edits_filepath, working_path.u8string().c_str(), _MAX_PATH - 1);
             edits_filepath[_MAX_PATH - 1] = '\0';
           } else {
             // double-click on a file
@@ -362,7 +362,7 @@ bool DoPathFileDialog(bool save_dialog, std::filesystem::path &path, const char 
       working_path = working_path.parent_path();
 
       UpdateFileList(listbox, working_path, wildcards);
-      strncpy(edits_filepath, (const char*)working_path.u8string().c_str(), _MAX_PATH - 1);
+      strncpy(edits_filepath, working_path.u8string().c_str(), _MAX_PATH - 1);
       edits_filepath[_MAX_PATH - 1] = '\0';
     } break;
     case ID_WILDCARD: {
@@ -433,8 +433,8 @@ void UpdateFileList(newuiListBox *lb, const std::filesystem::path &path, const s
       }
       if (std::filesystem::is_regular_file(dir_entry)) {
         for (const auto &wildcard : wildcards) {
-          if (stricmp((const char*)dir_entry.path().extension().u8string().c_str(),
-                      (const char*)std::filesystem::path(wildcard).extension().u8string().c_str()) == 0) {
+          if (stricmp(dir_entry.path().extension().u8string().c_str(),
+                      std::filesystem::path(wildcard).extension().u8string().c_str()) == 0) {
             files.push_back(dir_entry.path().filename());
           }
         }
@@ -442,7 +442,7 @@ void UpdateFileList(newuiListBox *lb, const std::filesystem::path &path, const s
     }
   } catch (std::exception &e) {
     DoMessageBox(TXT_ERROR, TXT_ERRPATHNOTVALID, MSGBOX_OK);
-    LOG_ERROR.printf("Error iterating directory %s: %s", (const char*)path.u8string().c_str(), e.what());
+    LOG_ERROR.printf("Error iterating directory %s: %s", path.u8string().c_str(), e.what());
   }
 
   if (dirs.size() + files.size() == 0) {
@@ -453,11 +453,11 @@ void UpdateFileList(newuiListBox *lb, const std::filesystem::path &path, const s
   char tempbuffer[_MAX_PATH + 1];
 
   for (auto const &dir : dirs) {
-    snprintf(tempbuffer, sizeof(tempbuffer), " [%s]", (const char*)dir.u8string().c_str());
+    snprintf(tempbuffer, sizeof(tempbuffer), " [%s]", dir.u8string().c_str());
     lb->AddItem(tempbuffer);
   }
   for (auto const &file : files) {
-    lb->AddItem((const char*)file.u8string().c_str());
+    lb->AddItem(file.u8string().c_str());
   }
 
   FDlg_EnableWaitMessage(false);

--- a/Descent3/pilot.cpp
+++ b/Descent3/pilot.cpp
@@ -1035,7 +1035,7 @@ void PilotSelect() {
         PilotListSelectChangeCallback(index);
 
         if (found_old) {
-          Current_pilot.set_filename((const char*)old_file.u8string().c_str());
+          Current_pilot.set_filename(old_file.u8string());
           PltReadFile(&Current_pilot, true, true);
 
           char pname[PILOT_STRING_SIZE];
@@ -1700,7 +1700,7 @@ std::vector<std::string> PltGetPilots(std::string ignore_filename, int display_d
     }
 
     ddio_DoForeachFile(cf_GetWritableBaseDirectory(), wildcard, [&ignore_filename, &result](const std::filesystem::path &path) {
-      std::string pilot = (const char*)path.filename().u8string().c_str();
+      std::string pilot = path.filename().u8string();
       if (!ignore_filename.empty() && stricmp(ignore_filename.c_str(), pilot.c_str()) == 0) {
         LOG_INFO.printf("Getting Pilots... found %s, but ignoring", pilot.c_str());
       } else {
@@ -1871,7 +1871,7 @@ tShipListInfo *lp_ship_info = nullptr;
 std::filesystem::path StripCRCFileName(const std::filesystem::path &src) {
   ASSERT(!src.empty());
 
-  std::vector<std::string> parts = StringSplit((const char*)src.u8string().c_str(), "_");
+  std::vector<std::string> parts = StringSplit(src.u8string(), "_");
   if (parts.size() < 2 || parts.back().size() != 8) {
     // this filename doesn't have a trailing CRC
     return src;
@@ -1912,7 +1912,7 @@ bool CreateCRCFileName(const std::filesystem::path &src, std::filesystem::path &
 
   // now create the full filename
 
-  dest = src.parent_path() / ((const char*)(StripCRCFileName(src).stem().concat(hex_string).u8string().c_str()));
+  dest = src.parent_path() / (StripCRCFileName(src).stem().u8string() + hex_string);
   dest.replace_extension(src.extension());
 
   return true;
@@ -2001,7 +2001,7 @@ bool ImportGraphic(const char *pathname, char *newfile) {
 
   // p contains the real filename
   // tempfilename contains old filename
-  bm_handle = bm_AllocLoadFileBitmap(IGNORE_TABLE((const char*)tempfilename.u8string().c_str()), 0);
+  bm_handle = bm_AllocLoadFileBitmap(IGNORE_TABLE(tempfilename.u8string().c_str()), 0);
   if (bm_handle <= BAD_BITMAP_HANDLE) {
     LOG_WARNING << "Error reloading bitmap for rename";
     std::filesystem::remove(tempfilename, ec);
@@ -2018,7 +2018,7 @@ bool ImportGraphic(const char *pathname, char *newfile) {
   bm_FreeBitmap(bm_handle);
   std::filesystem::remove(tempfilename, ec);
 
-  strcpy(newfile, (const char*)p.u8string().c_str());
+  strcpy(newfile, p.u8string().c_str());
   return true;
 }
 
@@ -2042,8 +2042,8 @@ bool UpdateGraphicsListbox(newuiListBox *lb, const std::filesystem::path &select
 
   int i = 1; // With "None"
   for (auto const &image : Custom_images) {
-    lb->AddItem((const char*)StripCRCFileName(image).u8string().c_str());
-    if (stricmp((const char*)image.u8string().c_str(), (const char*)selected_name.filename().u8string().c_str()) == 0) {
+    lb->AddItem(StripCRCFileName(image).u8string().c_str());
+    if (stricmp(image.u8string().c_str(), selected_name.filename().u8string().c_str()) == 0) {
       lb->SetCurrentIndex(i);
       CustomCallBack(i);
     }
@@ -2091,24 +2091,24 @@ void UpdateAudioTauntBoxes(newuiComboBox *audio1_list, newuiComboBox *audio2_lis
   int i = 0;
   for (const auto &taunt : Audio_taunts) {
     std::filesystem::path tfn = StripCRCFileName(taunt);
-    audio1_list->AddItem((const char*)tfn.u8string().c_str());
-    audio2_list->AddItem((const char*)tfn.u8string().c_str());
-    audio3_list->AddItem((const char*)tfn.u8string().c_str());
-    audio4_list->AddItem((const char*)tfn.u8string().c_str());
+    audio1_list->AddItem(tfn.u8string().c_str());
+    audio2_list->AddItem(tfn.u8string().c_str());
+    audio3_list->AddItem(tfn.u8string().c_str());
+    audio4_list->AddItem(tfn.u8string().c_str());
 
-    if (!stricmp(paudio1, (const char*)taunt.u8string().c_str())) {
+    if (!stricmp(paudio1, taunt.u8string().c_str())) {
       // set this as selected index for audio #1
       audio1_list->SetCurrentIndex(i + 1);
     }
-    if (!stricmp(paudio2, (const char*)taunt.u8string().c_str())) {
+    if (!stricmp(paudio2, taunt.u8string().c_str())) {
       // set this as selected index for audio #2
       audio2_list->SetCurrentIndex(i + 1);
     }
-    if (!stricmp(paudio3, (const char*)taunt.u8string().c_str())) {
+    if (!stricmp(paudio3, taunt.u8string().c_str())) {
       // set this as selected index for audio #1
       audio3_list->SetCurrentIndex(i + 1);
     }
-    if (!stricmp(paudio4, (const char*)taunt.u8string().c_str())) {
+    if (!stricmp(paudio4, taunt.u8string().c_str())) {
       // set this as selected index for audio #2
       audio4_list->SetCurrentIndex(i + 1);
     }
@@ -2125,7 +2125,7 @@ void audio1changecallback(int index) {
   } else {
     index--;
     if (index < (int)Audio_taunts.size()) {
-      AudioTauntPilot->set_multiplayer_data(nullptr, (const char*)Audio_taunts[index].u8string().c_str());
+      AudioTauntPilot->set_multiplayer_data(nullptr, Audio_taunts[index].u8string().c_str());
     }
   }
 }
@@ -2137,7 +2137,7 @@ void audio2changecallback(int index) {
   } else {
     index--;
     if (index < (int)Audio_taunts.size()) {
-      AudioTauntPilot->set_multiplayer_data(nullptr, nullptr, (const char*)Audio_taunts[index].u8string().c_str());
+      AudioTauntPilot->set_multiplayer_data(nullptr, nullptr, Audio_taunts[index].u8string().c_str());
     }
   }
 }
@@ -2149,7 +2149,7 @@ void audio3changecallback(int index) {
   } else {
     index--;
     if (index < (int)Audio_taunts.size()) {
-      AudioTauntPilot->set_multiplayer_data(nullptr, nullptr, nullptr, nullptr, (const char*)Audio_taunts[index].u8string().c_str());
+      AudioTauntPilot->set_multiplayer_data(nullptr, nullptr, nullptr, nullptr, Audio_taunts[index].u8string().c_str());
     }
   }
 }
@@ -2162,7 +2162,7 @@ void audio4changecallback(int index) {
     index--;
     if (index < (int)Audio_taunts.size()) {
       AudioTauntPilot->set_multiplayer_data(nullptr, nullptr, nullptr, nullptr, nullptr,
-                                            (const char*)Audio_taunts[index].u8string().c_str());
+                                            Audio_taunts[index].u8string().c_str());
     }
   }
 }
@@ -2465,21 +2465,21 @@ bool PltSelectShip(pilot *Pilot) {
       int index;
       index = taunts_lists.taunt_a->GetCurrentIndex();
       if (index > 0 && !Audio_taunts.empty()) {
-        Pilot->set_multiplayer_data(nullptr, (const char*)Audio_taunts[index - 1].u8string().c_str());
+        Pilot->set_multiplayer_data(nullptr, Audio_taunts[index - 1].u8string().c_str());
       }
       index = taunts_lists.taunt_b->GetCurrentIndex();
       if (index > 0 && !Audio_taunts.empty()) {
-        Pilot->set_multiplayer_data(nullptr, nullptr, (const char*)Audio_taunts[index - 1].u8string().c_str());
+        Pilot->set_multiplayer_data(nullptr, nullptr, Audio_taunts[index - 1].u8string().c_str());
       }
 
       index = taunts_lists.taunt_c->GetCurrentIndex();
       if (index > 0 && !Audio_taunts.empty()) {
-        Pilot->set_multiplayer_data(nullptr, nullptr, nullptr, nullptr, (const char*)Audio_taunts[index - 1].u8string().c_str());
+        Pilot->set_multiplayer_data(nullptr, nullptr, nullptr, nullptr, Audio_taunts[index - 1].u8string().c_str());
       }
 
       index = taunts_lists.taunt_d->GetCurrentIndex();
       if (index > 0 && !Audio_taunts.empty()) {
-        Pilot->set_multiplayer_data(nullptr, nullptr, nullptr, nullptr, nullptr, (const char*)Audio_taunts[index - 1].u8string().c_str());
+        Pilot->set_multiplayer_data(nullptr, nullptr, nullptr, nullptr, nullptr, Audio_taunts[index - 1].u8string().c_str());
       }
 
       char audio1[PAGENAME_LEN], audio2[PAGENAME_LEN], audio3[PAGENAME_LEN], audio4[PAGENAME_LEN];
@@ -2504,7 +2504,7 @@ bool PltSelectShip(pilot *Pilot) {
       std::filesystem::path path;
       char newf[_MAX_FNAME];
       if (DoPathFileDialog(false, path, TXT_CHOOSE, {"*.ogf", "*.tga", "*.pcx", "*.iff"}, PFDF_FILEMUSTEXIST)) {
-        if (ImportGraphic((const char*)path.u8string().c_str(), newf)) {
+        if (ImportGraphic(path.u8string().c_str(), newf)) {
           // update the listbox
           if (!UpdateGraphicsListbox(custom_list, newf))
             goto ship_id_err;
@@ -2516,7 +2516,7 @@ bool PltSelectShip(pilot *Pilot) {
     case ID_GETANIM: {
       std::filesystem::path path;
       if (DoPathFileDialog(false, path, TXT_CHOOSE, {"*.ifl"}, PFDF_FILEMUSTEXIST)) {
-        int handle = AllocLoadIFLVClip(IGNORE_TABLE((const char*)path.u8string().c_str()), SMALL_TEXTURE, 1);
+        int handle = AllocLoadIFLVClip(IGNORE_TABLE(path.u8string().c_str()), SMALL_TEXTURE, 1);
 
         if (handle != -1) {
           // change the file extension
@@ -2561,10 +2561,10 @@ bool PltSelectShip(pilot *Pilot) {
       int index = taunts_lists.taunt_a->GetCurrentIndex();
       if (index > 0 && !Audio_taunts.empty()) {
         std::filesystem::path path = LocalCustomSoundsDir / Audio_taunts[index - 1];
-        LOG_INFO.printf("Playing: %s", (const char*)path.u8string().c_str());
+        LOG_INFO.printf("Playing: %s", path.u8string().c_str());
         bool cenable = taunt_AreEnabled();
         taunt_Enable(true);
-        taunt_PlayTauntFile((const char*)path.u8string().c_str());
+        taunt_PlayTauntFile(path.u8string().c_str());
         taunt_Enable(cenable);
       }
     } break;
@@ -2583,8 +2583,8 @@ bool PltSelectShip(pilot *Pilot) {
         std::filesystem::path tempfile = LocalCustomSoundsDir / filename;
 
         // import the sound
-        LOG_INFO.printf("Importing: '%s'->'%s'", (const char*)path.u8string().c_str(), (const char*)tempfile.u8string().c_str());
-        if (taunt_ImportWave((const char*)path.u8string().c_str(), (const char*)tempfile.u8string().c_str())) {
+        LOG_INFO.printf("Importing: '%s'->'%s'", path.u8string().c_str(), tempfile.u8string().c_str());
+        if (taunt_ImportWave(path.u8string().c_str(), tempfile.u8string().c_str())) {
           // success
 
           // check file size...make sure it isn't too big
@@ -2708,7 +2708,7 @@ void CustomCallBack(int c) {
     select_bitmap = Custom_images[c - 1];
   }
 
-  if (!strcmp(custom_texture, (const char*)select_bitmap.u8string().c_str()))
+  if (!strcmp(custom_texture, select_bitmap.u8string().c_str()))
     return;
 
   if (ship_pos.bm_handle > BAD_BITMAP_HANDLE) {
@@ -2732,7 +2732,7 @@ void CustomCallBack(int c) {
   } else {
     if ((c - 1) < (int)Custom_images.size()) {
       select_bitmap = Custom_images[c - 1];
-      strcpy(custom_texture, (const char*)select_bitmap.u8string().c_str());
+      strcpy(custom_texture, select_bitmap.u8string().c_str());
     } else {
       custom_texture[0] = '\0';
     }

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -137,7 +137,7 @@ std::filesystem::path cf_LocatePathCaseInsensitiveHelper(const std::filesystem::
   auto const &it = std::filesystem::directory_iterator(search_path);
 
   auto found = std::find_if(it, end(it), [&search_file, &search_path, &result](const auto& dir_entry) {
-    return stricmp((const char*)dir_entry.path().filename().u8string().c_str(), (const char*)search_file.u8string().c_str()) == 0;
+    return stricmp(dir_entry.path().filename().u8string().c_str(), search_file.u8string().c_str()) == 0;
   });
 
   if (found != end(it)) {
@@ -244,7 +244,7 @@ int cf_OpenLibrary(const std::filesystem::path &libname) {
   // allocation library structure
   std::shared_ptr<library> lib = std::make_shared<library>();
   lib->name = cf_LocatePath(libname);
-  fp = fopen((const char*)lib->name.u8string().c_str(), "rb");
+  fp = fopen(lib->name.u8string().c_str(), "rb");
   if (fp == nullptr) {
     return 0; // CF_NO_FILE;
   }
@@ -378,7 +378,7 @@ CFILE *cf_OpenFileInLibrary(const std::filesystem::path &filename, int libhandle
 
   do {
     i = (first + last) / 2;
-    c = stricmp((const char*)filename.u8string().c_str(), (const char*)lib->entries[i]->name); // compare to current
+    c = stricmp(filename.u8string().c_str(), lib->entries[i]->name); // compare to current
     if (c == 0) {
       found = true;
       break;
@@ -402,10 +402,10 @@ CFILE *cf_OpenFileInLibrary(const std::filesystem::path &filename, int libhandle
     fp = lib->file;
     lib->file = nullptr;
   } else {
-    fp = fopen((const char*)lib->name.u8string().c_str(), "rb");
+    fp = fopen(lib->name.u8string().c_str(), "rb");
     if (!fp) {
-      LOG_ERROR.printf("Error opening library <%s> when opening file <%s>; errno=%d.", (const char*)lib->name.u8string().c_str(),
-                       (const char*)filename.u8string().c_str(), errno);
+      LOG_ERROR.printf("Error opening library <%s> when opening file <%s>; errno=%d.", lib->name.u8string().c_str(),
+                       filename.u8string().c_str(), errno);
       Int3();
       return nullptr;
     }
@@ -455,9 +455,9 @@ CFILE *open_file_in_lib(const char *filename) {
         fp = lib->file;
         lib->file = nullptr;
       } else {
-        fp = fopen((const char*)lib->name.u8string().c_str(), "rb");
+        fp = fopen(lib->name.u8string().c_str(), "rb");
         if (!fp) {
-          LOG_ERROR.printf("Error opening library <%s> when opening file <%s>; errno=%d.", (const char*)lib->name.u8string().c_str(),
+          LOG_ERROR.printf("Error opening library <%s> when opening file <%s>; errno=%d.", lib->name.u8string().c_str(),
                            filename, errno);
           Int3();
           return nullptr;
@@ -509,7 +509,7 @@ CFILE *open_file_in_directory(const std::filesystem::path &filename, const char 
   // if mode is "w", then open in text or binary as requested.  If "r", always open in "rb"
   tmode[1] = (mode[0] == 'w') ? mode[1] : 'b';
   // try to open file
-  fp = fopen((const char*)using_filename.u8string().c_str(), tmode);
+  fp = fopen(using_filename.u8string().c_str(), tmode);
 
   if (!fp) {
     // File not found
@@ -522,10 +522,10 @@ CFILE *open_file_in_directory(const std::filesystem::path &filename, const char 
   cfile = mem_rmalloc<CFILE>();
   if (!cfile)
     Error("Out of memory in open_file_in_directory()");
-  cfile->name = mem_rmalloc<char>((strlen((const char*)using_filename.u8string().c_str()) + 1));
+  cfile->name = mem_rmalloc<char>((strlen(using_filename.u8string().c_str()) + 1));
   if (!cfile->name)
     Error("Out of memory in open_file_in_directory()");
-  strcpy(cfile->name, (const char*)using_filename.u8string().c_str());
+  strcpy(cfile->name, using_filename.u8string().c_str());
   cfile->file = fp;
   cfile->lib_handle = -1;
   cfile->size = ddio_GetFileLength(fp);
@@ -562,7 +562,7 @@ CFILE *cfopen(const std::filesystem::path &filename, const char *mode) {
 
   // First look in the directories for this file's extension
   for (auto const &entry : extensions) {
-    if (!strnicmp((const char*)entry.first.u8string().c_str(), (const char*)ext.u8string().c_str(), _MAX_EXT)) {
+    if (!strnicmp(entry.first.u8string().c_str(), ext.u8string().c_str(), _MAX_EXT)) {
       // found ext
       cfile = open_file_in_directory(filename, mode, entry.second);
       if (cfile) {
@@ -580,7 +580,7 @@ CFILE *cfopen(const std::filesystem::path &filename, const char *mode) {
     }
   }
   // Lastly, try the hog files
-  cfile = open_file_in_lib((const char*)filename.u8string().c_str());
+  cfile = open_file_in_lib(filename.u8string().c_str());
 got_file:;
   if (cfile) {
     if (mode[0] == 'w')
@@ -893,7 +893,7 @@ void cf_WriteDouble(CFILE *cfp, double d) {
 // Throws an exception of type (cfile_error *) if the OS returns an error on read or write
 bool cf_CopyFile(const std::filesystem::path &dest, const std::filesystem::path &src, int copytime) {
   CFILE *infile, *outfile;
-  if (!stricmp((const char*)dest.u8string().c_str(), (const char*)src.u8string().c_str()))
+  if (!stricmp(dest.u8string().c_str(), src.u8string().c_str()))
     return true; // don't copy files if they are the same
   infile = (CFILE *)cfopen(src, "rb");
   if (!infile)
@@ -1023,7 +1023,7 @@ int cf_DoForeachFileInLibrary(int handle, const std::filesystem::path &ext,
   // Iterate entries on found library
   int result = 0;
   for (const auto &item : search_library->entries) {
-    if (stricmp((const char*)std::filesystem::path(item->name).extension().u8string().c_str(), (const char*)ext.u8string().c_str()) == 0) {
+    if (stricmp(std::filesystem::path(item->name).extension().u8string().c_str(), ext.u8string().c_str()) == 0) {
       func(item->name);
       result++;
     }
@@ -1035,7 +1035,7 @@ bool cf_IsFileInHog(const std::filesystem::path &filename, const std::filesystem
   std::shared_ptr<library> lib = Libraries;
 
   while (lib) {
-    if (stricmp((const char*)lib->name.u8string().c_str(), (const char*)hogname.u8string().c_str()) == 0) {
+    if (stricmp(lib->name.u8string().c_str(), hogname.u8string().c_str()) == 0) {
       // Now look for filename
       CFILE *cf;
       cf = cf_OpenFileInLibrary(filename, lib->handle);

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -522,7 +522,7 @@ CFILE *open_file_in_directory(const std::filesystem::path &filename, const char 
   cfile = mem_rmalloc<CFILE>();
   if (!cfile)
     Error("Out of memory in open_file_in_directory()");
-  cfile->name = mem_rmalloc<char>((strlen(using_filename.u8string().c_str()) + 1));
+  cfile->name = mem_rmalloc<char>(using_filename.u8string().size() + 1);
   if (!cfile->name)
     Error("Out of memory in open_file_in_directory()");
   strcpy(cfile->name, using_filename.u8string().c_str());

--- a/ddio/file.cpp
+++ b/ddio/file.cpp
@@ -170,9 +170,9 @@ std::filesystem::path ddio_GetTmpFileName(const std::filesystem::path &basedir, 
   const int len = 10;
   const char *ext = ".tmp";
   std::filesystem::path result;
-  size_t len_result = strlen((const char*)(basedir / prefix).u8string().c_str());
+  size_t len_result = strlen((basedir / prefix).u8string().c_str());
   char *random_name = (char *)mem_malloc(len_result + len + strlen(ext) + 1);
-  strncpy(random_name, (const char*)(basedir / prefix).u8string().c_str(), len_result);
+  strncpy(random_name, (basedir / prefix).u8string().c_str(), len_result);
 
   srand(D3::ChronoTimer::GetTimeMS());
 

--- a/ddio/file.cpp
+++ b/ddio/file.cpp
@@ -170,7 +170,7 @@ std::filesystem::path ddio_GetTmpFileName(const std::filesystem::path &basedir, 
   const int len = 10;
   const char *ext = ".tmp";
   std::filesystem::path result;
-  size_t len_result = strlen((basedir / prefix).u8string().c_str());
+  size_t len_result = (basedir / prefix).u8string().size();
   char *random_name = (char *)mem_malloc(len_result + len + strlen(ext) + 1);
   strncpy(random_name, (basedir / prefix).u8string().c_str(), len_result);
 

--- a/ddio/lnxfile.cpp
+++ b/ddio/lnxfile.cpp
@@ -91,10 +91,10 @@ bool ddio_SetWorkingDir(const char *path) { return (chdir(path)) ? false : true;
 bool ddio_FileDiff(const std::filesystem::path &path1, const std::filesystem::path &path2) {
   struct stat abuf{}, bbuf{};
 
-  if (stat((const char*)path1.u8string().c_str(), &abuf))
+  if (stat(path1.u8string().c_str(), &abuf))
     Int3(); // error getting stat info
 
-  if (stat((const char*)path2.u8string().c_str(), &bbuf))
+  if (stat(path2.u8string().c_str(), &bbuf))
     Int3(); // error getting stat info
 
   if ((abuf.st_size != bbuf.st_size) || (abuf.st_mtime != bbuf.st_mtime))
@@ -197,14 +197,14 @@ void ddio_SplitPath(const char *srcPath, char *path, char *filename, char *ext) 
 void ddio_CopyFileTime(const std::filesystem::path &dest, const std::filesystem::path &src) {
   struct stat abuf{};
 
-  if (stat((const char*)src.u8string().c_str(), &abuf))
+  if (stat(src.u8string().c_str(), &abuf))
     Int3();
 
   struct utimbuf bbuf{};
   bbuf.actime = abuf.st_atime;
   bbuf.modtime = abuf.st_mtime;
 
-  if (utime((const char*)dest.u8string().c_str(), &bbuf))
+  if (utime(dest.u8string().c_str(), &bbuf))
     Int3();
 }
 

--- a/linux/lnxdata.cpp
+++ b/linux/lnxdata.cpp
@@ -77,7 +77,7 @@ oeLnxAppDatabase::oeLnxAppDatabase() {
   }
   std::filesystem::path fileName = prefPath / REGISTRY_FILENAME;
 
-  database = new CRegistry((const char*)fileName.u8string().c_str());
+  database = new CRegistry(fileName.u8string().c_str());
   database->Import();
   create_record("Version");
 }

--- a/logger/log.cpp
+++ b/logger/log.cpp
@@ -33,7 +33,7 @@
 void InitLog(plog::Severity log_level, bool enable_filelog, bool enable_win_console) {
   std::filesystem::path log_file = "Descent3.log";
   static plog::ColorConsoleAppender<plog::TxtFormatter> consoleAppender;
-  static plog::RollingFileAppender<plog::TxtFormatter> fileAppender((const char*)log_file.u8string().c_str());
+  static plog::RollingFileAppender<plog::TxtFormatter> fileAppender(log_file.u8string().c_str());
 
 #ifdef WIN32
   static plog::DebugOutputAppender<plog::TxtFormatter> debugAppender;

--- a/manage/manage.cpp
+++ b/manage/manage.cpp
@@ -671,9 +671,9 @@ int mng_LoadTableFiles(int show_progress) {
 int mng_InitLocalTables() {
   // Set the local table directory from the base directory.
   auto writable_base_directory_string = cf_GetWritableBaseDirectory().u8string();
-  strncpy(LocalD3Dir, (const char*)writable_base_directory_string.c_str(), sizeof LocalD3Dir);
+  strncpy(LocalD3Dir, writable_base_directory_string.c_str(), sizeof LocalD3Dir);
   LocalD3Dir[sizeof LocalD3Dir - 1] = '\0';
-  if (strlen(LocalD3Dir) != strlen((const char*)writable_base_directory_string.c_str())) {
+  if (strlen(LocalD3Dir) != strlen(writable_base_directory_string.c_str())) {
     LOG_WARNING << "cf_GetWritableBaseDirectory() is too long to fit in LocalD3Dir, so LocalD3Dir was truncated.";
   }
   LOG_INFO << "Local dir: " << LocalD3Dir;
@@ -714,8 +714,8 @@ int mng_InitLocalTables() {
 #endif
 
   if (Network_up) {
-    ddio_MakePath(LocalTableFilename, (const char*)LocalTableDir.u8string().c_str(), LOCAL_TABLE, NULL);
-    ddio_MakePath(LocalTempTableFilename, (const char*)LocalTableDir.u8string().c_str(), TEMP_LOCAL_TABLE, NULL);
+    ddio_MakePath(LocalTableFilename, LocalTableDir.u8string().c_str(), LOCAL_TABLE, NULL);
+    ddio_MakePath(LocalTempTableFilename, LocalTableDir.u8string().c_str(), TEMP_LOCAL_TABLE, NULL);
   } else {
     strcpy(LocalTableFilename, LOCAL_TABLE);
     strcpy(LocalTempTableFilename, TEMP_LOCAL_TABLE);
@@ -747,11 +747,11 @@ int mng_InitNetTables() {
   NetMusicDir = netdir / "data" / "music";
   NetVoiceDir = netdir / "data" / "voice";
   TableLockFilename = NetTableDir / "table.lok";
-  ddio_MakePath(BackupLockFilename, (const char*)NetTableDir.u8string().c_str(), "tablelok.bak", NULL);
-  ddio_MakePath(BackupTableFilename, (const char*)NetTableDir.u8string().c_str(), "table.bak", NULL);
-  ddio_MakePath(TableFilename, (const char*)NetTableDir.u8string().c_str(), NET_TABLE, NULL);
-  ddio_MakePath(TempTableLockFilename, (const char*)NetTableDir.u8string().c_str(), "lock.tmp", NULL);
-  ddio_MakePath(TempTableFilename, (const char*)NetTableDir.u8string().c_str(), TEMP_NET_TABLE, NULL);
+  ddio_MakePath(BackupLockFilename, NetTableDir.u8string().c_str(), "tablelok.bak", NULL);
+  ddio_MakePath(BackupTableFilename, NetTableDir.u8string().c_str(), "table.bak", NULL);
+  ddio_MakePath(TableFilename, NetTableDir.u8string().c_str(), NET_TABLE, NULL);
+  ddio_MakePath(TempTableLockFilename, NetTableDir.u8string().c_str(), "lock.tmp", NULL);
+  ddio_MakePath(TempTableFilename, NetTableDir.u8string().c_str(), TEMP_NET_TABLE, NULL);
   LockerFile = NetTableDir / "locker";
   VersionFile = NetTableDir / "TableVersion";
 
@@ -1573,7 +1573,7 @@ void mng_TransferPages() {
     snprintf(ErrorString, sizeof(ErrorString), "There was a problem deleting the temp file - errno %d", errno);
     goto done;
   }
-  if (rename(TempTableLockFilename, (const char*)TableLockFilename.u8string().c_str())) {
+  if (rename(TempTableLockFilename, TableLockFilename.u8string().c_str())) {
     snprintf(ErrorString, sizeof(ErrorString), "There was a problem renaming the temp file - errno %d", errno);
 
     goto done;
@@ -1860,13 +1860,13 @@ bool InLockList(mngs_Pagelock *pl) {
 int GetPrimType(const std::filesystem::path &name) {
   int primtype;
   std::filesystem::path ext = name.extension();
-  if (!stricmp(".oof", (const char*)ext.u8string().c_str()))
+  if (!stricmp(".oof", ext.u8string().c_str()))
     primtype = PRIMTYPE_OOF;
-  else if (!stricmp(".ogf", (const char*)ext.u8string().c_str()))
+  else if (!stricmp(".ogf", ext.u8string().c_str()))
     primtype = PRIMTYPE_OGF;
-  else if (!stricmp(".oaf", (const char*)ext.u8string().c_str()))
+  else if (!stricmp(".oaf", ext.u8string().c_str()))
     primtype = PRIMTYPE_OAF;
-  else if (!stricmp(".wav", (const char*)ext.u8string().c_str()))
+  else if (!stricmp(".wav", ext.u8string().c_str()))
     primtype = PRIMTYPE_WAV;
   else
     primtype = PRIMTYPE_FILE;

--- a/manage/pagelock.cpp
+++ b/manage/pagelock.cpp
@@ -524,7 +524,7 @@ int mng_ReplacePagelock(char *name, mngs_Pagelock *pl) {
   cfclose(infile);
   cfclose(outfile);
 
-  if (!SwitcherooFiles((const char*)TableLockFilename.u8string().c_str(), TempTableLockFilename)) {
+  if (!SwitcherooFiles(TableLockFilename.u8string().c_str(), TempTableLockFilename)) {
     Int3();
     return 0;
   }
@@ -532,7 +532,7 @@ int mng_ReplacePagelock(char *name, mngs_Pagelock *pl) {
 // Log this change
 #ifndef RELEASE
   std::filesystem::path pathstr = std::filesystem::path(NetD3Dir) / "TableLog";
-  FILE *logfile = fopen((const char*)pathstr.u8string().c_str(), "at");
+  FILE *logfile = fopen(pathstr.u8string().c_str(), "at");
   if (logfile) {
     char str[255 + 32];
     char date[255];
@@ -590,7 +590,7 @@ int mng_DeletePagelock(char *name, int pagetype) {
     snprintf(ErrorString, sizeof(ErrorString), "There was a problem deleting the temp file - errno %d", errno);
     return (0);
   }
-  if (rename(TempTableLockFilename, (const char*)TableLockFilename.u8string().c_str())) {
+  if (rename(TempTableLockFilename, TableLockFilename.u8string().c_str())) {
     snprintf(ErrorString, sizeof(ErrorString), "There was a problem renaming the temp file - errno %d", errno);
 
     return (0);
@@ -644,7 +644,7 @@ int mng_DeletePagelockSeries(char *names[], int num, int pagetype) {
     snprintf(ErrorString, sizeof(ErrorString), "There was a problem deleting the temp file - errno %d", errno);
     return (0);
   }
-  if (rename(TempTableLockFilename, (const char*)TableLockFilename.u8string().c_str())) {
+  if (rename(TempTableLockFilename, TableLockFilename.u8string().c_str())) {
     snprintf(ErrorString, sizeof(ErrorString), "There was a problem renaming the temp file - errno %d", errno);
 
     return (0);
@@ -781,7 +781,7 @@ int mng_UnlockPagelockSeries(const char *names[], int *pagetypes, int num) {
     snprintf(ErrorString, sizeof(ErrorString), "There was a problem deleting the temp file - errno %d", errno);
     return (0);
   }
-  if (rename(TempTableLockFilename, (const char*)TableLockFilename.u8string().c_str())) {
+  if (rename(TempTableLockFilename, TableLockFilename.u8string().c_str())) {
     snprintf(ErrorString, sizeof(ErrorString), "There was a problem renaming the temp file - errno %d", errno);
 
     return (0);

--- a/model/polymodel.cpp
+++ b/model/polymodel.cpp
@@ -2122,12 +2122,12 @@ int LoadPolyModel(const std::filesystem::path &filename, int pageable) {
   }
 
   // if this is an oof instead of a pof, flag it as such
-  if (!stricmp(".oof", (const char*)filename.extension().u8string().c_str())) {
+  if (!stricmp(".oof", filename.extension().u8string().c_str())) {
     Poly_models[polynum].new_style = 1;
   } else
     Poly_models[polynum].new_style = 0;
 
-  strcpy(Poly_models[polynum].name, (const char*)name.u8string().c_str());
+  strcpy(Poly_models[polynum].name, name.u8string().c_str());
 
   int ret = 0;
   if (!pageable)
@@ -2228,7 +2228,7 @@ std::filesystem::path ChangePolyModelName(const std::filesystem::path &src) {
 // or index of polymodel with name
 int FindPolyModelName(const std::filesystem::path &name) {
   for (int i = 0; i < MAX_POLY_MODELS; i++) {
-    if (Poly_models[i].used && !stricmp((const char*)Poly_models[i].name, (const char*)name.u8string().c_str())) {
+    if (Poly_models[i].used && !stricmp(Poly_models[i].name, name.u8string().c_str())) {
       return i;
     }
   }

--- a/module/module.cpp
+++ b/module/module.cpp
@@ -110,7 +110,7 @@ int ModLastError = MODERR_NOERROR;
 
 std::filesystem::path mod_GetRealModuleName(const std::filesystem::path &mod_filename) {
   std::filesystem::path filename = mod_filename;
-  std::string ext = (const char*)mod_filename.extension().u8string().c_str();
+  std::string ext = mod_filename.extension().u8string();
 
   if (ext.empty()) {
     filename.replace_extension(MODULE_EXT);
@@ -180,7 +180,7 @@ bool mod_LoadModule(module *handle, const std::filesystem::path &imodfilename, i
     f |= RTLD_NOW;
   if (flags & MODF_GLOBAL)
     f |= RTLD_GLOBAL;
-  handle->handle = dlopen((const char*)modfilename.u8string().c_str(), f);
+  handle->handle = dlopen(modfilename.u8string().c_str(), f);
   if (!handle->handle) {
     // ok we couldn't find the given name...try other ways
     std::filesystem::path parent_path = modfilename.parent_path().filename();
@@ -196,7 +196,7 @@ bool mod_LoadModule(module *handle, const std::filesystem::path &imodfilename, i
     LOG_DEBUG.printf("MOD: Attempting to open %s instead of %s", new_filename.u8string().c_str(),
                      modfilename.u8string().c_str());
     modfilename = parent_path / new_filename;
-    handle->handle = dlopen((const char*)modfilename.u8string().c_str(), f);
+    handle->handle = dlopen(modfilename.u8string().c_str(), f);
     if (!handle->handle) {
       LOG_ERROR.printf("Module Load Err: %s", dlerror());
       ModLastError = MODERR_MODNOTFOUND;

--- a/netcon/includes/con_dll.h
+++ b/netcon/includes/con_dll.h
@@ -1181,8 +1181,9 @@ int StartMultiplayerGameMenu() {
   for (const auto &netgames_directory : DLLcf_LocateMultiplePaths("netgames")) {
     DLLddio_DoForeachFile(netgames_directory, std::regex(".+\\.d3m"),
                           [&dll_ui_items](const std::filesystem::path& path){
-                            dll_ui_items.insert_or_assign((const char*)path.stem().u8string().c_str(),
-                                DLLCreateNewUITextItem((const char*)path.stem().u8string().c_str(), UICOL_LISTBOX_LO, -1)
+                            dll_ui_items.insert_or_assign(
+                                path.stem().u8string(),
+                                DLLCreateNewUITextItem(path.stem().u8string().c_str(), UICOL_LISTBOX_LO, -1)
                                 );
     } );
   }
@@ -1209,12 +1210,12 @@ int StartMultiplayerGameMenu() {
   for (auto const &i : search_paths) {
     DLLddio_DoForeachFile(i.first, i.second, [&mi, &list_1](const std::filesystem::path &path) {
       std::filesystem::path mission_name = path.filename();
-      if (DLLIsMissionMultiPlayable((const char*)mission_name.u8string().c_str()) &&
-          (stricmp("d3_2.mn3", (const char*)mission_name.u8string().c_str()) != 0)) {
-        DLLmprintf(0, "Found a mission: %s\n", (const char*)mission_name.u8string().c_str());
+      if (DLLIsMissionMultiPlayable(mission_name.u8string().c_str()) &&
+          (stricmp("d3_2.mn3", mission_name.u8string().c_str()) != 0)) {
+        DLLmprintf(0, "Found a mission: %s\n", mission_name.u8string().c_str());
         mi = (msn_list *)DLLmem_malloc(sizeof(msn_list));
-        strcpy(mi->msn_name, DLLGetMissionName((const char*)mission_name.u8string().c_str()));
-        strcpy(mi->msn_file, (const char*)mission_name.u8string().c_str());
+        strcpy(mi->msn_name, DLLGetMissionName(mission_name.u8string().c_str()));
+        strcpy(mi->msn_file, mission_name.u8string().c_str());
         mi->ti = DLLCreateNewUITextItem(mi->msn_name, UICOL_LISTBOX_LO, -1);
         AddMsnItem(mi);
         DLLListAddItem(list_1, mi->ti);

--- a/netcon/mtclient/mtclient.cpp
+++ b/netcon/mtclient/mtclient.cpp
@@ -2126,7 +2126,7 @@ void CheckPXOForAnomalies() {
         // Ok, what we have here is multiple users with the same tracker ID.
         // This is bad. It could be user error, but it could be something worse.
         std::filesystem::path errfilepath = DLLcf_GetWritableBaseDirectory() / "pxo.err";
-        FILE *errfile = fopen((const char*)errfilepath.u8string().c_str(), "at");
+        FILE *errfile = fopen(errfilepath.u8string().c_str(), "at");
         if (errfile) {
           fprintf(errfile, "Dup TID: %s & %s / %s\n", DLLMPlayers[j].callsign, DLLMPlayers[i].callsign,
                   DLLMPlayers[i].tracker_id);


### PR DESCRIPTION
## Pull Request Type

- [x] Build and Dependency changes

### Description

Undo these nonsensical changes added by #686 
    
```diff
-       std::string p = adjusted_fname.u8string();
+       std::string p = (const char*)adjusted_fname.u8string().c_str();
```

### Checklist

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
