### PR TITLE
Fix handling -mission cmdline arg

### DIFF
--- a/Descent3/Mission.cpp
+++ b/Descent3/Mission.cpp
@@ -879,7 +879,7 @@ bool DemoMission(int mode = 0) {
 }
 #endif
 
-bool LoadMission(const char *mssn) {
+bool LoadMission(const std::filesystem::path& mssn) {
   Times_game_restored = 0;
   LOG_INFO << "In LoadMission()";
 #if (defined(OEM) || defined(DEMO))
@@ -919,7 +919,7 @@ bool LoadMission(const char *mssn) {
   // Open MN3 if filename passed was a mn3 file.
   if (IS_MN3_FILE(mssn)) {
     mission = mssn;
-    pathname = std::filesystem::path("missions") / mission;
+    pathname = "missions" / mission;
   } else {
     mission = mssn;
     pathname = mssn;

--- a/Descent3/Mission.h
+++ b/Descent3/Mission.h
@@ -298,7 +298,7 @@ void InitMission();
 void ResetMission();
 
 //	loads and verifies a mission as the current mission, returns if valid of not.
-bool LoadMission(const char *msn);
+bool LoadMission(const std::filesystem::path& mssn);
 
 //	initializes a level's script.
 void InitLevelScript();

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1545,20 +1545,16 @@ void InitIOSystems(bool editor) {
   // things as the mainmenu movie, or loading screen
   int mission_arg = FindArg("-mission");
   if (mission_arg > 0) {
-    char path_to_mission[_MAX_PATH];
-    char filename[256];
-
     // get the true filename
-    ddio_SplitPath(GameArgs[mission_arg + 1], NULL, filename, NULL);
-    strcat(filename, ".mn3");
+    std::filesystem::path filename = std::filesystem::path(GameArgs[mission_arg + 1]).filename().replace_extension("mn3");
 
-    // make the full path (it is forced to be on the harddrive since it contains
-    // textures and stuff).
-    ddio_MakePath(path_to_mission, LocalD3Dir, "missions", filename, NULL);
+    std::filesystem::path path_to_mission = "missions" / filename;
     if (cfexist(path_to_mission)) {
       cf_OpenLibrary(path_to_mission);
     } else {
-      Int3(); // mission not found
+      // mission not found
+      LOG_WARNING.printf("Mission file '%s' not found! Ignoring -mission command-line arg.",
+                         path_to_mission.u8string().c_str());
     }
   }
 

--- a/Descent3/menu.cpp
+++ b/Descent3/menu.cpp
@@ -813,7 +813,7 @@ int MainMenu() {
       // make only the default ships available (we may need to move this depending on load a saved game)
       PlayerResetShipPermissions(-1, true);
       if (MenuNewGame()) {
-        exit_menu = 1;
+        exit_menu = true;
         MenuScene();
         rend_Flip();
       }
@@ -830,7 +830,7 @@ int MainMenu() {
       if (LoadGameDialog()) {
         SetGameMode(GM_NORMAL);
         SetFunctionMode(RESTORE_GAME_MODE);
-        exit_menu = 1;
+        exit_menu = true;
       }
       break;
     case IDV_OPTIONS:
@@ -1119,7 +1119,20 @@ bool MenuNewGame() {
     return false;
   }
 #else
-  if ((!FindArg("-mission")) && (!FirstGame) && (-1 == Current_pilot.find_mission_data(TRAINING_MISSION_NAME))) {
+  if (int mission_arg = FindArg("-mission")) {
+    std::filesystem::path filename = std::filesystem::path(GameArgs[mission_arg + 1]).filename().replace_extension(".mn3");
+    if (LoadMission(filename.u8string().c_str())) {
+      CurrentPilotUpdateMissionStatus(true);
+      // go into game mode.
+      SetGameMode(GM_NORMAL);
+      SetFunctionMode(GAME_MODE);
+      return true;
+    } else {
+      DoMessageBox(TXT_ERROR, TXT_ERRLOADMSN, MSGBOX_OK);
+      return false;
+    }
+  }
+  if ((!FirstGame) && (-1 == Current_pilot.find_mission_data(TRAINING_MISSION_NAME))) {
 
     FirstGame = true;
 
@@ -1278,7 +1291,7 @@ redo_newgame_menu:
   menu.Destroy();
 
   return retval;
-#endif
+#endif // DEMO
 }
 
 // DisplayLevelWarpDlg

--- a/Descent3/menu.cpp
+++ b/Descent3/menu.cpp
@@ -1107,53 +1107,31 @@ bool MenuNewGame() {
   int n_missions, res;
   bool found = false;
   bool retval = true;
+  std::filesystem::path mission_name;
+
 #ifdef DEMO
-  if (LoadMission("d3demo.mn3")) {
-    CurrentPilotUpdateMissionStatus(true);
-    // go into game mode.
-    SetGameMode(GM_NORMAL);
-    SetFunctionMode(GAME_MODE);
-    return true;
-  } else {
-    DoMessageBox(TXT_ERROR, TXT_ERRLOADMSN, MSGBOX_OK);
-    return false;
-  }
+  mission_name = "d3demo.mn3";
 #else
   if (int mission_arg = FindArg("-mission")) {
-    std::filesystem::path filename = std::filesystem::path(GameArgs[mission_arg + 1]).filename().replace_extension(".mn3");
-    if (LoadMission(filename.u8string().c_str())) {
-      CurrentPilotUpdateMissionStatus(true);
-      // go into game mode.
-      SetGameMode(GM_NORMAL);
-      SetFunctionMode(GAME_MODE);
-      return true;
-    } else {
-      DoMessageBox(TXT_ERROR, TXT_ERRLOADMSN, MSGBOX_OK);
-      return false;
-    }
-  }
-  if ((!FirstGame) && (-1 == Current_pilot.find_mission_data(TRAINING_MISSION_NAME))) {
-
+    // If direct loading via cmdline option
+    mission_name = std::filesystem::path(GameArgs[mission_arg + 1]).filename().replace_extension(".mn3");
+  } else if ((!FirstGame) && (-1 == Current_pilot.find_mission_data(TRAINING_MISSION_NAME))) {
+    // First time?
     FirstGame = true;
-
-    if (LoadMission("training.mn3")) {
-      CurrentPilotUpdateMissionStatus(true);
-      // go into game mode.
-      SetGameMode(GM_NORMAL);
-      SetFunctionMode(GAME_MODE);
-      return true;
-    } else {
-      DoMessageBox(TXT_ERROR, TXT_ERRLOADMSN, MSGBOX_OK);
-      return false;
-    }
+    mission_name = "training.mn3";
   } else if (FirstGame) {
+    // Already trained
     FirstGame = false;
 #ifdef OEM
-    if (LoadMission(OEM_MISSION_FILE))
+    mission_name = OEM_MISSION_FILE;
 #else
-    if (LoadMission("d3.mn3"))
-#endif
-    {
+    mission_name = "d3.mn3";
+#endif // OEM
+  }
+#endif // DEMO
+
+  if (!mission_name.empty()) {
+    if (LoadMission(mission_name)) {
       CurrentPilotUpdateMissionStatus(true);
       // go into game mode.
       SetGameMode(GM_NORMAL);
@@ -1291,7 +1269,6 @@ redo_newgame_menu:
   menu.Destroy();
 
   return retval;
-#endif // DEMO
 }
 
 // DisplayLevelWarpDlg


### PR DESCRIPTION
## Pull Request Type
<!-- Please select which type of change this most aligns with. If more than one type fits, please select multiple. -->

- [ ] GitHub Workflow changes
- [ ] Documentation or Wiki changes
- [ ] Build and Dependency changes
- [x] Runtime changes
  - [ ] Render changes
  - [ ] Audio changes
  - [ ] Input changes
  - [ ] Network changes
  - [x] Other changes

### Description
<!-- Below this comment, add a brief overview of the changes introduced by this pull request. Include any relevant context or background information. -->

Current `-mission` cmdline arg handling is broken. Intended use is direct load specified mission, but currently it fails with Int3().

Now Descent3 loads specified mission after selecting pilot and pressing "New game" in main menu.

Simplified code around direct loading missions.

### Related Issues
<!-- If this pull request will fix an issue, please link it below this comment. Say something like, "Fixes #83" where #83 is the issue number. -->

### Screenshots (if applicable)
<!-- Please add any relevant screenshots or images to show the changes made, if applicable. Remove this section if it does not apply. -->

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.

### Additional Comments
<!-- Add any additional comments, notes, or concerns that you want to communicate to us. -->
