### PR TITLE
Fix crashes w.r.t. new display resolution settings

### DIFF
--- a/Descent3/config.cpp
+++ b/Descent3/config.cpp
@@ -782,10 +782,10 @@ struct video_menu {
 
     // video resolution
     sheet->NewGroup(TXT_RESOLUTION, 0, 0);
-    constexpr int RES_BUFFER_SIZE = 15;
-    resolution_string = sheet->AddChangeableText(RES_BUFFER_SIZE);
     std::string res = Video_res_list[Current_video_resolution_id].getName();
-    snprintf(resolution_string, res.size() + 1, res.c_str());
+    auto alloc_size = std::max(res.size() + 1, static_cast<size_t>(15));
+    resolution_string = sheet->AddChangeableText(alloc_size);
+    snprintf(resolution_string, alloc_size, res.c_str());
     sheet->AddLongButton("Change", IDV_CHANGE_RES_WINDOW);
 
     fullscreen = sheet->AddLongCheckBox("Fullscreen", Game_fullscreen);

--- a/Descent3/init.cpp
+++ b/Descent3/init.cpp
@@ -1304,7 +1304,11 @@ void LoadGameSettings() {
   Database->read_int("RoomLeveling", &Default_player_room_leveling);
   Database->read("Specmapping", &Detail_settings.Specular_lighting);
   Database->read("RS_bitdepth", &Render_preferred_bitdepth, sizeof(Render_preferred_bitdepth));
-  Database->read_int("RS_resolution", &Current_video_resolution_id);
+  Database->read_int("RS_resolution", &tempint);
+  if (tempint >= 0 && tempint < std::size(Video_res_list))
+    Current_video_resolution_id = tempint;
+  else
+    LOG_WARNING << "Game settings contain a display resolution index that is out of bounds. Starting with default resolution.";
 
   int tempval = 0;
   Database->read_int("RS_fov", &tempval);

--- a/ui/UIStatic.cpp
+++ b/ui/UIStatic.cpp
@@ -110,7 +110,7 @@ void UIStatic::SetTitle(UIItem *item) {
     delete m_Title;
   m_Title = NULL;
   if (item)
-    m_Title = (UIPrimativeItem *)item->CopyUIItem();
+    m_Title = item->CopyUIItem();
 }
 
 void UIStatic::OnDraw() {


### PR DESCRIPTION
When using a registry file created by commit real-1.5.0-590-g72cca136 with an executable built from commit real-1.5.0-533-gc99e57cf, there is a startup crash due to unsanitized values read from the regsitry.

```
==19328==ERROR: AddressSanitizer: global-buffer-overflow on address 0x0000027dee44 [line numbers as per c99e57cf]
READ of size 2 at 0x0000027dee44 thread T0
    f0 opengl_Setup(oeApplication*, int const*, int const*) renderer/HardwareOpenGL.cpp:356
    f1 opengl_Init(oeApplication*, renderer_preferred_state*) renderer/HardwareOpenGL.cpp:590
    f2 rend_Init(renderer_type, oeApplication*, renderer_preferred_state*) renderer/HardwareOpenGL.cpp:1299
    f3 SetScreenMode(int, bool) Descent3/game.cpp:962
    f4 Descent3() Descent3/descent.cpp:478
    f5 oeD3LnxApp::run() Descent3/sdlmain.cpp:142
    f6 main Descent3/sdlmain.cpp:322

0x0000027dee44 is located 32 bytes after global variable 'Default_detail_level' defined in 'Descent3/config.cpp:316:5' (0x0000027dee20) of size 4 0x0000027dee44 is located 28 bytes before global variable 'Game_toggles' defined in 'Descent3/config.cpp:318:14' (0x0000027dee60) of size 3 SUMMARY: AddressSanitizer: global-buffer-overflow renderer/HardwareOpenGL.cpp:356 in opengl_Setup(oeApplication*, int const*, int const*)
```

## Pull Request Type

- [x] Runtime changes
  - [x] Other changes

### Checklist

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
