### PR TITLE
Revert "Grab keyboard when the game is not launched with -nomousegrab"

### DIFF
--- a/renderer/HardwareOpenGL.cpp
+++ b/renderer/HardwareOpenGL.cpp
@@ -441,7 +441,6 @@ int opengl_Setup(oeApplication *app, const int *width, const int *height) {
 
     bool grabMouse = FindArgChar("-nomousegrab", 'm') == 0;
     SDL_SetWindowRelativeMouseMode(GSDLWindow, grabMouse);
-    SDL_SetWindowKeyboardGrab(GSDLWindow, grabMouse);
 
     rend_SetFullScreen(Game_fullscreen);
   } else if (!Game_fullscreen) {


### PR DESCRIPTION
This reverts commit 1707ee19864d182c503c5be3b9f4abf3054dcefa.

Under X11, grabbing the keyboard has negative side effect of rendering Alt-Tab useless in windowed mode. Multimedia volume keys are rendered useless in windowed or fullscreen mode. When execution of descent3 is suspended (e.g. when running under a debugger), it would be impossible to get out of it even in fullscreen mode, since the SDL handler does not run.
   
Looking at other games, I find that many other engines (chocolate-doom, gzdoom, yquake2, sauerbraten, but also gl-117) do not exercise keyboard grabbing either and only use relative mouse mode (mouse grab).

## Pull Request Type

- [x] Runtime changes
  - [x] Input changes

### Related Issues

#665

### Checklist

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
