### PR TITLE
Resolve 160 instances of -Wchar-subscript

### DIFF
--- a/Descent3/AIGoal.cpp
+++ b/Descent3/AIGoal.cpp
@@ -463,6 +463,7 @@
  * $NoKeywords: $
  */
 
+#include <cstdint>
 #include <cstdlib>
 
 #include "AIGoal.h"
@@ -1096,7 +1097,7 @@ int GoalAddGoal(object *obj, uint32_t goal_type, void *arg_struct, int level, fl
     if ((ai_info->animation_type == AS_ALERT) || (ai_info->animation_type == AS_MELEE1 + 1) ||
         (ai_info->animation_type == AS_MELEE2 + 1)) {
       uint8_t m_num = attack_info->melee_number;
-      char new_anim;
+      int8_t new_anim;
 
       if (m_num)
         new_anim = AS_MELEE1;
@@ -1116,7 +1117,7 @@ int GoalAddGoal(object *obj, uint32_t goal_type, void *arg_struct, int level, fl
     break;
 
   case AIG_SET_ANIM: {
-    char new_anim = *((int *)arg_struct);
+    int8_t new_anim = *static_cast<int *>(arg_struct);
     polyobj_info *p_info = &obj->rtype.pobj_info;
 
     //			mprintf(0, "Anim Goal %d\n", new_anim);

--- a/Descent3/AImain.cpp
+++ b/Descent3/AImain.cpp
@@ -1507,6 +1507,7 @@
  * $NoKeywords: $
  */
 
+#include <cstdint>
 #include <cstdlib>
 
 #include "AIMain.h"
@@ -3346,7 +3347,7 @@ void ai_do_animation(object *obj, float anim_time) {
     }
   } else {
     if (obj->ai_info->animation_type == AS_RANGED_ATTACK) {
-      char wb = obj->ai_info->last_special_wb_firing;
+      int8_t wb = obj->ai_info->last_special_wb_firing;
 
       if (Object_info[obj->id].static_wb[wb].flags & WBF_SPRAY) {
         obj->weapon_fire_flags |= WFF_SPRAY;
@@ -6059,7 +6060,7 @@ void AIDoFrame(object *obj) {
   // Handle On/off and spray weapons
   {
     if ((obj->weapon_fire_flags & WFF_SPRAY) && !(obj->flags & (OF_DESTROYED | OF_DYING))) {
-      char wb_index = ai_info->last_special_wb_firing;
+      int8_t wb_index = ai_info->last_special_wb_firing;
       DoSprayEffect(obj, &Object_info[obj->id].static_wb[wb_index], wb_index);
       if (!((Game_mode & GM_MULTI) && (Netgame.local_role == LR_CLIENT))) {
         if (WBIsBatteryReady(obj, &Object_info[obj->id].static_wb[wb_index], wb_index) &&

--- a/Descent3/LoadLevel.cpp
+++ b/Descent3/LoadLevel.cpp
@@ -3165,7 +3165,7 @@ void ReadRoomAABBChunk(CFILE *fp, int version) {
       Rooms[i].bbf_list = mem_rmalloc<int16_t *>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list_min_xyz = mem_rmalloc<vector>(Rooms[i].num_bbf_regions);
       Rooms[i].bbf_list_max_xyz = mem_rmalloc<vector>(Rooms[i].num_bbf_regions);
-      Rooms[i].bbf_list_sector = mem_rmalloc<uint8_t>(sizeof(char) * Rooms[i].num_bbf_regions);
+      Rooms[i].bbf_list_sector = mem_rmalloc<uint8_t>(Rooms[i].num_bbf_regions);
 
       for (j = 0; j < Rooms[i].num_bbf_regions; j++) {
         Rooms[i].num_bbf[j] = cf_ReadShort(fp);

--- a/Descent3/PilotPicsAPI.cpp
+++ b/Descent3/PilotPicsAPI.cpp
@@ -59,6 +59,7 @@
  */
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstdio>
 
@@ -561,7 +562,7 @@ bool PPic_BuildDatabases(void) {
     Pilot_id_to_offset[count].offset = file_pos;
     Pilot_id_to_offset[count].id = pilot_id;
 
-    char let_pos;
+    int8_t let_pos;
     if (isalpha(name_buffer[0])) {
       let_pos = toupper(name_buffer[0]) - 'A';
     } else {

--- a/Descent3/TelComGoals.cpp
+++ b/Descent3/TelComGoals.cpp
@@ -140,7 +140,7 @@ static int TG_MouseOffset_x = -1, TG_MouseOffset_y = -1;
 bool TG_compare_slots(int left, int right) {
   int left_index, right_index;
   int left_priority, right_priority;
-  char left_list, right_list;
+  int8_t left_list, right_list;
 
   left_index = TG_Lines[left].goal_index;
   right_index = TG_Lines[right].goal_index;

--- a/Descent3/aiambient.cpp
+++ b/Descent3/aiambient.cpp
@@ -16,6 +16,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cstdint>
 #include <stdlib.h>
 #include "aiambient.h"
 #include "string.h"
@@ -30,7 +31,7 @@ ambient_life a_life;
 void ambient_life::DoFrame(void) {}
 
 void ambient_life::InitForLevel(void) {
-  char i;
+  int8_t i;
 
   for (i = 0; i < MAX_AL_TYPES; i++) {
     ComputeNextSize(i);
@@ -41,7 +42,7 @@ void ambient_life::InitForLevel(void) {
   DoFrame();
 }
 
-void ambient_life::GetALValue(char i, char field, void *ptr) {
+void ambient_life::GetALValue(int8_t i, char field, void *ptr) {
   switch (field) {
   case ALI_TYPE:
     *((int *)ptr) = m_type[i];
@@ -61,7 +62,7 @@ void ambient_life::GetALValue(char i, char field, void *ptr) {
   }
 }
 
-void ambient_life::ComputeNextSize(char i) {
+void ambient_life::ComputeNextSize(int8_t i) {
   char diff = m_max[i] - m_min[i];
   if (diff > 0) {
     char offset = ps_rand() % diff;
@@ -71,7 +72,7 @@ void ambient_life::ComputeNextSize(char i) {
   }
 }
 
-void ambient_life::SetALValue(char i, char field, void *ptr) {
+void ambient_life::SetALValue(int8_t i, char field, void *ptr) {
   switch (field) {
   case ALI_TYPE:
     m_type[i] = *((int *)ptr);

--- a/Descent3/aiambient.h
+++ b/Descent3/aiambient.h
@@ -19,6 +19,7 @@
 #ifndef _AIAMBIENT_H_
 #define _AIAMBIENT_H_
 
+#include <cstdint>
 #include "cfile.h"
 
 #define MAX_AL_TYPES 6
@@ -51,13 +52,13 @@ class ambient_life {
   uint8_t m_next_size[MAX_AL_TYPES];
   float m_next_do_time[MAX_AL_TYPES];
 
-  void ComputeNextSize(char index);
+  void ComputeNextSize(int8_t index);
 
 public:
   ambient_life() { ALReset(); }
 
-  void GetALValue(char index, char field, void *ptr);
-  void SetALValue(char index, char field, void *ptr);
+  void GetALValue(int8_t index, char field, void *ptr);
+  void SetALValue(int8_t index, char field, void *ptr);
   void SaveData(CFILE *fptr);
   void LoadData(CFILE *fptr);
 

--- a/Descent3/aistruct.h
+++ b/Descent3/aistruct.h
@@ -392,6 +392,7 @@
 #ifndef AISTRUCT_H_
 #define AISTRUCT_H_
 
+#include <cstdint>
 #include "pstypes.h"
 #include "vecmat.h"
 #include "aistruct_external.h"
@@ -759,10 +760,9 @@ struct ai_frame {
   float last_sound_time[MAX_AI_SOUNDS];
   int16_t last_played_sound_index;
 
-  char movement_type;
-  char movement_subtype;
+  int8_t movement_type, movement_subtype;
 
-  char animation_type;
+  int8_t animation_type;
   char next_animation_type;
 
   char next_movement; // For queueing actions  :)

--- a/Descent3/attach.cpp
+++ b/Descent3/attach.cpp
@@ -16,6 +16,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cstdint>
 #include "attach.h"
 #include "terrain.h"
 #include "log.h"
@@ -142,7 +143,7 @@ PI); rot_angle = acos(dot);
 
 // Finds the position of a attach point on an object
 // The uvec is optional as most attaching objects don't need at complete orientation set (only an fvec)
-static bool AttachPointPos(object *obj, char ap, bool f_compute_pos, vector *attach_pos, bool f_compute_fvec,
+static bool AttachPointPos(object *obj, int8_t ap, bool f_compute_pos, vector *attach_pos, bool f_compute_fvec,
                            vector *attach_fvec, bool *f_computed_uvec = NULL, vector *attach_uvec = NULL) {
   poly_model *pm;
   vector pnt;
@@ -459,7 +460,7 @@ static void ProprogateUltimateAttachParent(object *parent, int ultimate_handle) 
 
 // Attaches 2 objects via attach points on each.  The f_used_aligned allows for an aligned connection.
 // NOTE: The child always moves to the parent
-bool AttachObject(object *parent, char parent_ap, object *child, char child_ap, bool f_use_aligned) {
+bool AttachObject(object *parent, int8_t parent_ap, object *child, char child_ap, bool f_use_aligned) {
   ASSERT(parent);
   ASSERT(child);
 
@@ -510,7 +511,7 @@ bool AttachObject(object *parent, char parent_ap, object *child, char child_ap, 
 
 // Attaches a child object to a parent object by a percent of the radius of the child.
 // NOTE: The child always moves to the parent and not the reverse
-bool AttachObject(object *parent, char parent_ap, object *child, float percent_rad) {
+bool AttachObject(object *parent, int8_t parent_ap, object *child, float percent_rad) {
   ASSERT(parent);
   ASSERT(child);
 
@@ -661,7 +662,7 @@ bool UnattachFromParent(object *child) {
 }
 
 // Unattaches a child from an attach point
-bool UnattachChild(object *parent, char parent_ap) {
+bool UnattachChild(object *parent, int8_t parent_ap) {
   object *child;
 
   if ((child = ObjGet(parent->attach_children[parent_ap])) != NULL) {

--- a/Descent3/attach.h
+++ b/Descent3/attach.h
@@ -19,6 +19,7 @@
 #ifndef _ATTACH_H_
 #define _ATTACH_H_
 
+#include <cstdint>
 #include "object.h"
 
 bool AttachDoPosOrient(object *parent, char parent_ap, object *child, char child_ap, bool f_parent,
@@ -26,10 +27,10 @@ bool AttachDoPosOrient(object *parent, char parent_ap, object *child, char child
 bool AttachDoPosOrientRad(object *parent, char p_ap, object *child, float rad_percent, vector *pos);
 void AttachUpdateSubObjects(object *obj);
 
-bool AttachObject(object *parent, char parent_ap, object *child, char child_ap, bool f_use_aligned = false);
-bool AttachObject(object *parent, char parent_ap, object *child, float percent_rad);
+bool AttachObject(object *parent, int8_t parent_ap, object *child, char child_ap, bool f_use_aligned = false);
+bool AttachObject(object *parent, int8_t parent_ap, object *child, float percent_rad);
 bool UnattachFromParent(object *child);
-bool UnattachChild(object *parent, char parent_ap);
+bool UnattachChild(object *parent, int8_t parent_ap);
 bool UnattachChildren(object *parent);
 
 #endif

--- a/Descent3/levelgoal.cpp
+++ b/Descent3/levelgoal.cpp
@@ -155,6 +155,7 @@
  *
  */
 
+#include <cstdint>
 #include <cstring>
 
 #include "levelgoal.h"
@@ -363,7 +364,7 @@ bool lgoal::Priority(int handle, char operation, int *value) {
   return false;
 }
 
-bool lgoal::GoalList(char operation, char *value) {
+bool lgoal::GoalList(char operation, int8_t *value) {
   if (!value)
     return false;
 
@@ -606,7 +607,7 @@ bool levelgoals::GoalPriority(int index, char operation, int *flags) {
   return m_goal[index].Priority(index, operation, flags);
 }
 
-bool levelgoals::GoalGoalList(int index, char operation, char *value) {
+bool levelgoals::GoalGoalList(int index, char operation, int8_t *value) {
   if (index < 0 || index >= m_num_goals)
     return false;
 
@@ -740,7 +741,7 @@ bool levelgoals::SaveLevelGoalInfo(CFILE *fptr) {
     int num_items;
     int j;
     int priority = 0;
-    char g_list = 0;
+    int8_t g_list = 0;
     int status = 0;
 
     Level_goals.GoalStatus(i, LO_GET_SPECIFIED, &status);
@@ -838,7 +839,7 @@ bool levelgoals::LoadLevelGoalInfo(CFILE *fptr) {
     int num_items;
     int j;
     int priority;
-    char g_list;
+    int8_t g_list;
     int status;
 
     int gi = AddGoal(false);
@@ -958,7 +959,7 @@ int levelgoals::GetNumActivePrimaryGoals() {
   int i;
   int bestp[4];
   int cp;  // Current priority
-  char cl; // Current list
+  int8_t cl; // Current list
   int temp_p[MAX_GOAL_LISTS][MAX_LEVEL_GOALS];
   char temp_g[MAX_GOAL_LISTS][MAX_LEVEL_GOALS];
 
@@ -1013,7 +1014,7 @@ int levelgoals::GetNumActiveSecondaryGoals() {
   int i;
   int bestp[4];
   int cp;  // Current priority
-  char cl; // Current list
+  int8_t cl; // Current list
   int temp_p[MAX_GOAL_LISTS][MAX_LEVEL_GOALS];
   char temp_g[MAX_GOAL_LISTS][MAX_LEVEL_GOALS];
 

--- a/Descent3/levelgoal.h
+++ b/Descent3/levelgoal.h
@@ -19,6 +19,7 @@
 #ifndef _LEVELGOAL_H_
 #define _LEVELGOAL_H_
 
+#include <cstdint>
 #include "object.h"
 #include "cfile.h"
 #include <cstdlib>
@@ -99,7 +100,7 @@ public:
   int GetCompletionMessage(char *message, int buffer_size);
 
   bool Priority(int handle, char operation, int *value);
-  bool GoalList(char operation, char *value);
+  bool GoalList(char operation, int8_t *value);
   bool GetStatus(int handle, char operation, int *value, bool f_save_load = false, bool announce = true);
 
   void SendStateToPlayer(int index, int pnum);
@@ -145,7 +146,7 @@ public:
   int GoalGetCompletionMessage(int goal_index, char *message, int buffer_size);
 
   bool GoalPriority(int goal_index, char operation, int *value);
-  bool GoalGoalList(int goal_index, char operation, char *value);
+  bool GoalGoalList(int goal_index, char operation, int8_t *value);
   bool GoalStatus(int goal_index, char operation, int *value, bool announce = true);
 
   int GoalFindId(const char *goal_name);

--- a/Descent3/matcen.cpp
+++ b/Descent3/matcen.cpp
@@ -145,6 +145,7 @@
 #endif
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 
@@ -706,14 +707,14 @@ bool matcen::SetCreateRoom(int room) {
   return false;
 }
 
-int matcen::GetSpawnPnt(char s_index) {
+int matcen::GetSpawnPnt(int8_t s_index) {
   if (s_index >= 0 && s_index < MAX_SPAWN_PNTS)
     return m_spawn_pnt[s_index];
 
   return MATCEN_ERROR;
 }
 
-bool matcen::SetSpawnPnt(char s_index, int s_value) {
+bool matcen::SetSpawnPnt(int8_t s_index, int s_value) {
   if (s_index >= 0 && s_index < MAX_SPAWN_PNTS) {
     m_spawn_pnt[s_index] = s_value;
     ComputeCreatePnt();
@@ -988,7 +989,7 @@ bool matcen::SetNumProdTypes(char num_prod_types) {
   return false;
 }
 
-bool matcen::GetProdInfo(char index, int *type_id, int *priority, float *time, int *max_prod) {
+bool matcen::GetProdInfo(int8_t index, int *type_id, int *priority, float *time, int *max_prod) {
   if (index >= 0 && index < MAX_PROD_TYPES) {
     if (type_id)
       *type_id = m_prod_type[index];
@@ -1008,7 +1009,7 @@ bool matcen::GetProdInfo(char index, int *type_id, int *priority, float *time, i
   return false;
 }
 
-bool matcen::SetProdInfo(char index, int *type_id, int *priority, float *time, int *max_prod) {
+bool matcen::SetProdInfo(int8_t index, int *type_id, int *priority, float *time, int *max_prod) {
   if (index >= 0 && index < MAX_PROD_TYPES) {
     if (type_id && (*type_id >= -1))
       m_prod_type[index] = *type_id;
@@ -1728,7 +1729,7 @@ void matcen::SetCreationTexture(int16_t texnum) { m_creation_texture = texnum; }
 
 int16_t matcen::GetCreationTexture() { return m_creation_texture; }
 
-int matcen::GetSound(char sound_type) {
+int matcen::GetSound(int8_t sound_type) {
   if (sound_type >= 0 && sound_type < MAX_MATCEN_SOUNDS) {
     return m_sounds[sound_type];
   }
@@ -1736,7 +1737,7 @@ int matcen::GetSound(char sound_type) {
   return MATCEN_ERROR;
 }
 
-bool matcen::SetSound(char sound_type, int sound_index) {
+bool matcen::SetSound(int8_t sound_type, int sound_index) {
   if (sound_type >= 0 && sound_type < MAX_MATCEN_SOUNDS) {
     m_sounds[sound_type] = sound_index;
   }

--- a/Descent3/matcen.h
+++ b/Descent3/matcen.h
@@ -19,6 +19,7 @@
 #ifndef _MATCEN_H_
 #define _MATCEN_H_
 
+#include <cstdint>
 #include "cfile.h"
 #include "vecmat.h"
 #include "matcen_external.h"
@@ -155,8 +156,8 @@ public:
   char GetNumSpawnPnts();
   bool SetNumSpawnPnts(char num_s);
 
-  int GetSpawnPnt(char s_index);
-  bool SetSpawnPnt(char s_index, int s_value);
+  int GetSpawnPnt(int8_t s_index);
+  bool SetSpawnPnt(int8_t s_index, int s_value);
 
   void SaveData(CFILE *fptr);
   void LoadData(CFILE *fptr);
@@ -170,8 +171,8 @@ public:
   char GetNumProdTypes();
   bool SetNumProdTypes(char num_prod_types);
 
-  bool GetProdInfo(char index, int *type_id, int *priority, float *time, int *max_prod);
-  bool SetProdInfo(char index, int *type_id, int *priority, float *time, int *max_prod);
+  bool GetProdInfo(int8_t index, int *type_id, int *priority, float *time, int *max_prod);
+  bool SetProdInfo(int8_t index, int *type_id, int *priority, float *time, int *max_prod);
 
   float GetProdMultiplier();
   bool SetProdMultiplier(float multi);
@@ -194,8 +195,8 @@ public:
   float GetPostProdTime();
   bool SetPostProdTime(float time);
 
-  int GetSound(char sound_type);
-  bool SetSound(char sound_type, int sound_index);
+  int GetSound(int8_t sound_type);
+  bool SetSound(int8_t sound_type, int sound_index);
 
   void Reset();
 };

--- a/Descent3/osiris_predefs.cpp
+++ b/Descent3/osiris_predefs.cpp
@@ -431,6 +431,7 @@
  * $NoKeywords: $
  */
 #include <cstdarg>
+#include <cstdint>
 
 #include "osiris_predefs.h"
 #include "object.h"
@@ -2145,7 +2146,7 @@ int osipf_GetNumAttachSlots(int objhandle) {
 
 int osipf_GetAttachChildHandle(int objhandle, char attachpoint) {
   object *parent = ObjGet(objhandle);
-  char parent_ap = attachpoint;
+  int8_t parent_ap = attachpoint;
 
   if ((parent) && (parent->flags & OF_POLYGON_OBJECT)) {
     poly_model *parent_pm = &Poly_models[parent->rtype.pobj_info.model_num];
@@ -2633,7 +2634,7 @@ float osipf_GameTime(void) { return Gametime; }
 
 float osipf_FrameTime(void) { return Frametime; }
 
-void osipf_ObjWBValue(int obj_handle, char wb_index, char op, char vtype, void *ptr, char g_index) {
+void osipf_ObjWBValue(int obj_handle, int8_t wb_index, char op, char vtype, void *ptr, int8_t g_index) {
   object *objp = ObjGet(obj_handle);
 
   if (!objp) {
@@ -2974,7 +2975,7 @@ bool osipf_AIIsObjEnemy(int obj_handle, int it_handle) {
   return false;
 }
 
-void osipf_AIGoalValue(int obj_handle, char g_index, char op, char vtype, void *ptr, char index) {
+void osipf_AIGoalValue(int obj_handle, int8_t g_index, char op, char vtype, void *ptr, int8_t index) {
   object *obj = ObjGet(obj_handle);
   if (!obj)
     return;
@@ -3558,9 +3559,9 @@ void osipf_LGoalValue(char op, char vtype, void *ptr, int g_index, int i_index) 
   } break;
   case LGSV_C_GOAL_LIST: {
     if (op == VF_GET) {
-      Level_goals.GoalGoalList(g_index, LO_GET_SPECIFIED, (char *)ptr);
+      Level_goals.GoalGoalList(g_index, LO_GET_SPECIFIED, static_cast<int8_t *>(ptr));
     } else if (op == VF_SET) {
-      Level_goals.GoalGoalList(g_index, LO_SET_SPECIFIED, (char *)ptr);
+      Level_goals.GoalGoalList(g_index, LO_SET_SPECIFIED, static_cast<int8_t *>(ptr));
     }
   } break;
   case LGSV_I_STATUS: {

--- a/Descent3/osiris_predefs.h
+++ b/Descent3/osiris_predefs.h
@@ -173,6 +173,7 @@
 #ifndef __OSIRIS_PREDEF_H_
 #define __OSIRIS_PREDEF_H_
 
+#include <cstdint>
 #include "osiris_dll.h"
 #include "cfile.h"
 
@@ -349,7 +350,7 @@ bool osipf_IsObjectVisible(object *obj);
 
 float osipf_GameTime(void);
 float osipf_FrameTime(void);
-void osipf_ObjWBValue(int obj_handle, char wb_index, char op, char vtype, void *ptr, char g_index = 0);
+void osipf_ObjWBValue(int obj_handle, int8_t wb_index, char op, char vtype, void *ptr, int8_t g_index = 0);
 
 void osipf_ObjectValue(int handle, char op, char vtype, void *ptr, int index = 0);
 void osipf_MatcenValue(int handle, char op, char vtype, void *ptr, int index = 0);
@@ -392,7 +393,7 @@ int osipf_SoundFindId(const char *s_name);
 
 bool osipf_AIIsObjFriend(int obj_handle, int it_handle);
 bool osipf_AIIsObjEnemy(int obj_handle, int it_handle);
-void osipf_AIGoalValue(int obj_handle, char g_index, char op, char vtype, void *ptr, char index = 0);
+void osipf_AIGoalValue(int obj_handle, int8_t g_index, char op, char vtype, void *ptr, int8_t index = 0);
 int osipf_AIGetNearbyObjs(vector *pos, int init_roomnum, float rad, int *object_handle_list, int max_elements,
                           bool f_lightmap_only, bool f_only_players_and_ais = true,
                           bool f_include_non_collide_objects = false, bool f_stop_at_closed_doors = true);

--- a/Descent3/robotfire.cpp
+++ b/Descent3/robotfire.cpp
@@ -16,6 +16,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cstdint>
 #include <cstdlib>
 
 #include "robotfire.h"
@@ -51,7 +52,7 @@ void FireOnOffWeapon(object *objp) {
       WBFireBattery(objp, &Ships[ship_index].static_wb[wb_index], 0, wb_index);
     }
   } else if (objp->ai_info) {
-    char wb_index = objp->ai_info->last_special_wb_firing;
+    int8_t wb_index = objp->ai_info->last_special_wb_firing;
     if (wb_index > MAX_WBS_PER_OBJ) { // DAJ
       LOG_WARNING.printf("FireOnOffWeapon wb_index %d > MAX_WBS_PER_OBJ", wb_index);
       return;

--- a/cfile/cfile.cpp
+++ b/cfile/cfile.cpp
@@ -630,7 +630,7 @@ int cfgetc(CFILE *cfp) {
   if (cfp->position >= cfp->size)
     return EOF;
 
-  fread(ch, sizeof(char), 1, cfp->file);
+  fread(ch, 1, 1, cfp->file);
   c = ch[0];
   // c = getc( cfp->file );
   if (cfeof(cfp))
@@ -644,7 +644,7 @@ int cfgetc(CFILE *cfp) {
       if (c == 10) // return LF as newline
         c = '\n';
       else if (c == 13) { // check for CR/LF pair
-        fread(ch, sizeof(char), 1, cfp->file);
+        fread(ch, 1, 1, cfp->file);
         int cc = ch[0]; // getc(cfp->file);
         // if (cc != EOF) {
         if (!cfeof(cfp)) {

--- a/cfile/hogfile.cpp
+++ b/cfile/hogfile.cpp
@@ -123,7 +123,7 @@ bool ReadHogHeader(FILE *fp, tHogHeader *header) {
 }
 
 bool ReadHogEntry(FILE *fp, tHogFileEntry *entry) {
-  if (fread(entry->name, sizeof(char), HOG_FILENAME_LEN, fp) != HOG_FILENAME_LEN)
+  if (fread(entry->name, 1, HOG_FILENAME_LEN, fp) != HOG_FILENAME_LEN)
     return false;
   if (fread(&entry->flags, sizeof(entry->flags), 1, fp) != 1)
     return false;

--- a/editor/levelkeypad.cpp
+++ b/editor/levelkeypad.cpp
@@ -209,7 +209,7 @@ void make_goal_dialog_text(char *big_text_message) {
 
   for (i = 0; i < n; i++) {
     int priority;
-    char list;
+    int8_t list;
     int flags;
 
     Level_goals.GoalPriority(i, LO_GET_SPECIFIED, &priority);
@@ -281,7 +281,7 @@ void levelkeypad::UpdateDialog() {
   int flags;
   int lgflags;
   int priority;
-  char g_list;
+  int8_t g_list;
   char name[256];
   char iname[256];
   char desc[2560];
@@ -1062,7 +1062,7 @@ void levelkeypad::OnSelendokLevelgoaltriggerCombo() {
 void levelkeypad::OnKillfocusLevelGoalListEdit()
 {
         int int_g_list;
-        char g_list;
+        int8_t g_list;
         char str[256];
 
         ((CEdit *) GetDlgItem(IDC_LEVEL_GOAL_LIST_EDIT))->GetWindowText(str,255);
@@ -1077,7 +1077,7 @@ void levelkeypad::OnKillfocusLevelGoalListEdit()
 
 void levelkeypad::OnKillfocusEdit57() {
   int int_g_list;
-  char g_list;
+  int8_t g_list;
   char str[256];
 
   ((CEdit *)GetDlgItem(IDC_EDIT57))->GetWindowText(str, 255);

--- a/legacy/hogedit/HogEditDoc.cpp
+++ b/legacy/hogedit/HogEditDoc.cpp
@@ -239,7 +239,7 @@ int CHogEditDoc::LoadRib(const char *pathname) {
   }
 
   // Read in the hog filename
-  if (!fread(Library.filename, sizeof(char), _MAX_PATH, rib_fp)) {
+  if (!fread(Library.filename, 1, _MAX_PATH, rib_fp)) {
     fclose(rib_fp);
     return false;
   }
@@ -379,7 +379,7 @@ int CHogEditDoc::SaveRib(const char *pathname) {
   }
 
   // write out the hog filename
-  if (!fwrite(Library.filename, sizeof(char), _MAX_PATH, rib_fp)) {
+  if (!fwrite(Library.filename, 1, _MAX_PATH, rib_fp)) {
     fclose(rib_fp);
     return false;
   }
@@ -499,8 +499,8 @@ int CHogEditDoc::UpdatedFileCheck(hog_library_entry *entry) {
 // Loads a Hog library entry structure
 bool CHogEditDoc::ReadHogLibEntry(FILE *fp, hog_library_entry *entry) {
   int res = 0;
-  res = fread(entry->path, sizeof(char), _MAX_PATH, fp);
-  res = fread(entry->name, sizeof(char), PSFILENAME_LEN + 1, fp);
+  res = fread(entry->path, 1, _MAX_PATH, fp);
+  res = fread(entry->name, 1, PSFILENAME_LEN + 1, fp);
   res = fread(&entry->flags, sizeof(entry->flags), 1, fp);
   res = fread(&entry->length, sizeof(entry->length), 1, fp);
   res = fread(&entry->timestamp, sizeof(entry->timestamp), 1, fp);
@@ -516,8 +516,8 @@ bool CHogEditDoc::ReadHogLibEntry(FILE *fp, hog_library_entry *entry) {
 // Saves a Hog library entry structure
 bool CHogEditDoc::WriteHogLibEntry(FILE *fp, hog_library_entry *entry) {
   int res = 0;
-  res = fwrite(entry->path, sizeof(char), _MAX_PATH, fp);
-  res = fwrite(entry->name, sizeof(char), PSFILENAME_LEN + 1, fp);
+  res = fwrite(entry->path, 1, _MAX_PATH, fp);
+  res = fwrite(entry->name, 1, PSFILENAME_LEN + 1, fp);
   res = fwrite(&entry->flags, sizeof(entry->flags), 1, fp);
   res = fwrite(&entry->length, sizeof(entry->length), 1, fp);
   res = fwrite(&entry->timestamp, sizeof(entry->timestamp), 1, fp);

--- a/legacy/powerball/powerball.cpp
+++ b/legacy/powerball/powerball.cpp
@@ -918,12 +918,12 @@ void GetGameStartPacket(uint8_t *data) {
 
   // who has the powerball
   int8_t temp;
-  memcpy(&temp, &data[size], sizeof(char));
-  size += sizeof(char);
+  memcpy(&temp, &data[size], 1);
+  size += 1;
   WhoHasPowerBall = temp;
 
-  memcpy(&temp, &data[size], sizeof(char));
-  size += sizeof(char);
+  memcpy(&temp, &data[size], 1);
+  size += 1;
   NumOfTeams = temp;
 
   // Now based on what we have from the server set up our info
@@ -947,7 +947,7 @@ void GetGameStartPacket(uint8_t *data) {
 }
 
 void SendGameStartPacket(int pnum) {
-  int maxsize = sizeof(int) * DLLMAX_TEAMS + 2 * sizeof(char);
+  int maxsize = sizeof(int) * DLLMAX_TEAMS + 2;
   int size = 0;
 
   uint8_t *data = PBall.StartPacket(maxsize, SPID_NEWPLAYER);
@@ -960,13 +960,13 @@ void SendGameStartPacket(int pnum) {
   int8_t temp;
   // who has the powerball if anyone
   temp = WhoHasPowerBall;
-  memcpy(&data[size], &temp, sizeof(char));
-  size += sizeof(char);
+  memcpy(&data[size], &temp, 1);
+  size += 1;
 
   // number of teams
   temp = NumOfTeams;
-  memcpy(&data[size], &temp, sizeof(char));
-  size += sizeof(char);
+  memcpy(&data[size], &temp, 1);
+  size += 1;
 
   // we're done
   DLLmprintf(0, "Sending Game State to %s\n", PBall.Players[pnum].callsign);

--- a/linux/lnxcon_raw.cpp
+++ b/linux/lnxcon_raw.cpp
@@ -143,14 +143,14 @@ bool con_raw_Create() {
   Con_raw_rows = 24; // one less, since the bottom window takes up one row
 
   // allocate any memory needed for buffers
-  Con_raw_inp_buf = (char *)malloc(sizeof(char) * (Con_raw_cols + 4));
-  Con_raw_read_buf = (char *)malloc(sizeof(char) * (Con_raw_cols + 4));
+  Con_raw_inp_buf = static_cast<char *>(malloc(Con_raw_cols + 4));
+  Con_raw_read_buf = static_cast<char *>(malloc(Con_raw_cols + 4));
   if (!Con_raw_inp_buf || !Con_raw_read_buf) {
     // error allocating memory
     return false;
   }
-  memset(Con_raw_inp_buf, 0, sizeof(char) * (Con_raw_cols + 4));
-  memset(Con_raw_read_buf, 0, sizeof(char) * (Con_raw_cols + 4));
+  memset(Con_raw_inp_buf, 0, Con_raw_cols + 4);
+  memset(Con_raw_read_buf, 0, Con_raw_cols + 4);
   Con_raw_last_command[0] = '\0';
 
   Con_raw_inp_pos = 0;

--- a/linux/lnxcon_raw.cpp
+++ b/linux/lnxcon_raw.cpp
@@ -39,6 +39,7 @@
  * $NoKeywords: $
  */
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
@@ -48,8 +49,8 @@
 #include "ddio_common.h"
 
 static char *Con_raw_read_buf = nullptr; // The next buffer of text from user input
-static char *Con_raw_inp_buf = nullptr,
-            Con_raw_inp_pos = 0;                     // Currently updating input buffer of text (and its position)
+static char *Con_raw_inp_buf = nullptr;
+static int8_t Con_raw_inp_pos = 0; // Currently updating input buffer of text (and its position)
 static char Con_raw_last_command[CON_MAX_STRINGLEN]; // The last command entered by the user
 static int Con_raw_cols = 0, Con_raw_rows = 0;       // The size of the main window (input window is (1 row, Con_cols))
 

--- a/netgames/dmfc/dmfcbase.cpp
+++ b/netgames/dmfc/dmfcbase.cpp
@@ -472,6 +472,7 @@
 #include "dmfcinternal.h"
 #include "dmfcinputcommands.h"
 
+#include <cstdint>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <algorithm>
@@ -3449,7 +3450,8 @@ bool DMFCBase::InputCommandHandle(char *command_string) {
   */
 
   // now extract the command
-  char command[64], index = 0;
+  char command[64];
+  int8_t index = 0;
   char *p = &command_string[1];
 
   // lowercase the command_string

--- a/netgames/entropy/EntropyPackets.cpp
+++ b/netgames/entropy/EntropyPackets.cpp
@@ -160,9 +160,8 @@ void ReceivePickupVirus(uint8_t *data) {
 
 // MTS: only used in this file.
 void SendRoomInfo(int pnum) {
-  char *room_info = NULL;
   int flags, r, i;
-  room_info = (char *)malloc(sizeof(char) * RoomCount);
+  auto room_info = static_cast<char *>(malloc(RoomCount));
   if (!room_info)
     return;
 
@@ -210,8 +209,7 @@ void SendRoomInfo(int pnum) {
 void ReceiveRoomInfo(uint8_t *data) {
   int i, count = 0;
   int flag;
-  char *room_info;
-  room_info = (char *)malloc(sizeof(char) * RoomCount);
+  auto room_info = static_cast<char *>(malloc(RoomCount));
   if (!room_info) {
     FatalError("Out of Memory");
     return;

--- a/scripts/AIGame.cpp
+++ b/scripts/AIGame.cpp
@@ -19,6 +19,7 @@
 // AIGame.cpp
 //
 #include <cfloat>
+#include <cstdint>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -400,7 +401,7 @@ public:
 #define MAX_STOLEN_WEAPONS 25
 
 struct weapon_item {
-  char index;
+  int8_t index;
   int owner;
   char amount;
 };
@@ -2364,7 +2365,7 @@ struct barnswallow_data {
 
   int follower;
 
-  char num_friends;
+  int8_t num_friends;
   int friends[BS_MAX_FRIENDS];
   float next_friend_update_time;
 


### PR DESCRIPTION
## Pull Request Type

- [x] Build and Dependency changes

### Description

`char` is unsigned on some platforms, which breaks the assumption it
can hold value -1. The simple fix is to replace it by int8_t, which
gives compatibility with x86 platforms where Descent3 usually was
delivered on.

```
Descent3/attach.cpp:668:47: warning: array subscript has type "char" [-Wchar-subscripts]
```

### Checklist

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
